### PR TITLE
Remove colors from FlutterLogo

### DIFF
--- a/lib/views/widgets/about_tile.dart
+++ b/lib/views/widgets/about_tile.dart
@@ -6,10 +6,8 @@ class MyAboutTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return AboutListTile(
       applicationIcon: FlutterLogo(
-        colors: Colors.yellow,
       ),
       icon: FlutterLogo(
-        colors: Colors.yellow,
       ),
       aboutBoxChildren: <Widget>[
         SizedBox(


### PR DESCRIPTION
The constructor they're using had colors property in it, which is now removed.
This PR fixes #86 