### PR TITLE
fixed unhandled exception by renderflex

### DIFF
--- a/lib/views/widgets/forms/register_form.dart
+++ b/lib/views/widgets/forms/register_form.dart
@@ -262,12 +262,7 @@ class RegisterFormState extends State<RegisterForm> {
         borderRadius: BorderRadius.circular(25.0),
         color: Colors.red,
       ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(msg),
-        ],
-      ),
+      child: Text(msg),
     );
 
     fToast.showToast(


### PR DESCRIPTION
fixes #105 partially. I have fixed the overflowing renderflex error by removing the row widget entirely and just using the text widget in its place. 