### PR TITLE
Fixed Renderflex Overflow

### DIFF
--- a/lib/views/pages/login_page.dart
+++ b/lib/views/pages/login_page.dart
@@ -463,10 +463,13 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
             ),
           ),
           
-
-          mainScreen(),
-
-                    //has to be scrollable so the screen can adjust when the keyboard is tapped
+          Center(
+            child: SingleChildScrollView(
+              child: mainScreen(),
+            ),
+          ),
+          
+          //has to be scrollable so the screen can adjust when the keyboard is tapped
           Center(
             child: SingleChildScrollView(
                 child:registrationScreenForm()


### PR DESCRIPTION
Fixes #109 .
The widget causing the error was the mainScreen() widget in login_page.dart. Fixed it by wrapping it in a SingleChildScrollView widget further wrapped by a center widget.