### PR TITLE
Fixed keyboard dismissal error(2020-Q4 branch)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,54 +66,62 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GraphQLProvider(
       client: graphQLConfiguration.client,
-      child: MaterialApp(
-        title: UIData.appName,
-        theme: ThemeData(
-            primaryColor: UIData.primaryColor,
-            fontFamily: UIData.quickFont,
-            primarySwatch: UIData.primaryColor),
-        debugShowCheckedModeBanner: false,
-        showPerformanceOverlay: false,
-        onGenerateRoute: (RouteSettings settings) {
-          print('build route for ${settings.name}');
-          var routes = <String, WidgetBuilder>{
-            UIData.homeRoute: (BuildContext context) => HomePage(),
-            UIData.addActivityPage: (BuildContext context) => AddActivityPage(),
-            UIData.addResponsibilityPage: (BuildContext context) =>
-                AddResponsibilityPage(settings.arguments),
-            UIData.activityDetails: (BuildContext context) =>
-                ActivityDetails(settings.arguments),
-            UIData.notFoundRoute: (BuildContext context) => NotFoundPage(),
-            UIData.responsibilityPage: (BuildContext context) => NotFoundPage(),
-            UIData.contactPage: (BuildContext context) =>
-                ContactPage(settings.arguments),
-            UIData.loginPageRoute: (BuildContext context) => LoginPage(),
-            UIData.createOrgPage: (BuildContext context) => CreateOrganization(),
-            UIData.joinOrganizationPage: (BuildContext context) => JoinOrganization(),
-            UIData.switchOrgPage: (BuildContext context) => SwitchOrganization(),
-            UIData.profilePage: (BuildContext context) => ProfilePage(),
-
-          };
-          WidgetBuilder builder = routes[settings.name];
-          return MaterialPageRoute(builder: (ctx) => builder(ctx));
+      child: GestureDetector(
+        onTap:(){
+          FocusScopeNode currentFocus = FocusScope.of(context);
+          if (!currentFocus.hasPrimaryFocus && currentFocus.focusedChild != null) {
+            FocusManager.instance.primaryFocus.unfocus();
+          }
         },
-        home: FutureBuilder(
-            future: Provider.of<AuthController>(context).getUser(),
-            builder: (context, AsyncSnapshot snapshot) {
-              if (snapshot.connectionState == ConnectionState.done) {
-                return snapshot.data ? HomePage() : LoginPage();
-              } else {
-                return Container(color: Colors.white);
-              }
-            }),
-        onUnknownRoute: (RouteSettings rs) => new MaterialPageRoute(
-            builder: (context) => new NotFoundPage(
-                  appTitle: UIData.coming_soon,
-                  icon: FontAwesomeIcons.solidSmile,
-                  title: UIData.coming_soon,
-                  message: "Under Development",
-                  iconColor: Colors.green,
-                )),
+        child:MaterialApp(
+          title: UIData.appName,
+          theme: ThemeData(
+              primaryColor: UIData.primaryColor,
+              fontFamily: UIData.quickFont,
+              primarySwatch: UIData.primaryColor),
+          debugShowCheckedModeBanner: false,
+          showPerformanceOverlay: false,
+          onGenerateRoute: (RouteSettings settings) {
+            print('build route for ${settings.name}');
+            var routes = <String, WidgetBuilder>{
+              UIData.homeRoute: (BuildContext context) => HomePage(),
+              UIData.addActivityPage: (BuildContext context) => AddActivityPage(),
+              UIData.addResponsibilityPage: (BuildContext context) =>
+                  AddResponsibilityPage(settings.arguments),
+              UIData.activityDetails: (BuildContext context) =>
+                  ActivityDetails(settings.arguments),
+              UIData.notFoundRoute: (BuildContext context) => NotFoundPage(),
+              UIData.responsibilityPage: (BuildContext context) => NotFoundPage(),
+              UIData.contactPage: (BuildContext context) =>
+                  ContactPage(settings.arguments),
+              UIData.loginPageRoute: (BuildContext context) => LoginPage(),
+              UIData.createOrgPage: (BuildContext context) => CreateOrganization(),
+              UIData.joinOrganizationPage: (BuildContext context) => JoinOrganization(),
+              UIData.switchOrgPage: (BuildContext context) => SwitchOrganization(),
+              UIData.profilePage: (BuildContext context) => ProfilePage(),
+
+            };
+            WidgetBuilder builder = routes[settings.name];
+            return MaterialPageRoute(builder: (ctx) => builder(ctx));
+          },
+          home: FutureBuilder(
+              future: Provider.of<AuthController>(context).getUser(),
+              builder: (context, AsyncSnapshot snapshot) {
+                if (snapshot.connectionState == ConnectionState.done) {
+                  return snapshot.data ? HomePage() : LoginPage();
+                } else {
+                  return Container(color: Colors.white);
+                }
+              }),
+          onUnknownRoute: (RouteSettings rs) => new MaterialPageRoute(
+              builder: (context) => new NotFoundPage(
+                    appTitle: UIData.coming_soon,
+                    icon: FontAwesomeIcons.solidSmile,
+                    title: UIData.coming_soon,
+                    message: "Under Development",
+                    iconColor: Colors.green,
+                  )),
+        ),
       ),
     );
   }

--- a/lib/views/pages/login_page.dart
+++ b/lib/views/pages/login_page.dart
@@ -450,8 +450,13 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
     ),
 
 
-        child: new PageView(
+        
+        child:new PageView(
           controller: _pageController,
+          onPageChanged: (index ){
+            FocusScopeNode currentFocus = FocusScope.of(context);
+            FocusManager.instance.primaryFocus.unfocus();
+          },
           physics: new BouncingScrollPhysics(),
           children: <Widget>[
           //has to be scrollable so the screen can adjust when the keyboard is tapped
@@ -479,7 +484,7 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
             
           ],
         ),
-      )
-      );
+      ),
+    );
 }
 }

--- a/lib/views/widgets/forms/register_form.dart
+++ b/lib/views/widgets/forms/register_form.dart
@@ -231,6 +231,7 @@ class RegisterFormState extends State<RegisterForm> {
                       ),
                 color: Colors.white,
                 onPressed: () async {
+                  FocusScope.of(context).unfocus();
                   _validate = true;
                   if (_formKey.currentState.validate()) {
                     print("run mutation");


### PR DESCRIPTION
Fixes #112 .
Wrapped the main.dart MaterialApp widget in in a GestureDetector widget to dismiss keyboard when there was a tap outside of a textField. Also used onPageChanged to dismiss the keyboard upon a page change in loin_page.dart.