### PR TITLE
fixed Renderflex-overflow due to login toast-messages

### DIFF
--- a/lib/views/pages/login_signup/login_form.dart
+++ b/lib/views/pages/login_signup/login_form.dart
@@ -194,7 +194,7 @@ class LoginFormState extends State<LoginForm> {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(msg),
+          Expanded(child:Text(msg)),
         ],
       ),
     );
@@ -216,7 +216,7 @@ class LoginFormState extends State<LoginForm> {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(msg),
+          Expanded(child:Text(msg)),
         ],
       ),
     );


### PR DESCRIPTION
Fixes #157 .
Fixed by wrapping the concerned Text widgets causing the errors in an Expanded widget.