### PR TITLE
[SwitchOrganization] Snackbar optimization

### DIFF
--- a/lib/views/pages/organization/profile_page.dart
+++ b/lib/views/pages/organization/profile_page.dart
@@ -33,6 +33,7 @@ class _ProfilePageState extends State<ProfilePage> {
   AuthController _authController = AuthController();
   List userDetails = [];
   List orgAdmin = [];
+  List org = [];
   bool isCreator;
   OrgController _orgController = OrgController();
 
@@ -56,6 +57,7 @@ class _ProfilePageState extends State<ProfilePage> {
     } else if (!result.hasException) {
       setState(() {
         userDetails = result.data['users'];
+        org = userDetails.first['joinedOrganizations'];
       });
     }
   }
@@ -226,21 +228,23 @@ class _ProfilePageState extends State<ProfilePage> {
                             ),
                             onTap: () {},
                           ),
-                          ListTile(
-                              title: Text(
-                                'Switch Organization',
-                                style: TextStyle(fontSize: 18.0),
-                              ),
-                              leading: Icon(
-                                Icons.compare_arrows,
-                                color: UIData.secondaryColor,
-                              ),
-                              onTap: () {
-                                pushNewScreen(
-                                  context,
-                                  screen: SwitchOrganization(),
-                                );
-                              }),
+                          org.length == 0
+                              ? SizedBox()
+                              : ListTile(
+                                  title: Text(
+                                    'Switch Organization',
+                                    style: TextStyle(fontSize: 18.0),
+                                  ),
+                                  leading: Icon(
+                                    Icons.compare_arrows,
+                                    color: UIData.secondaryColor,
+                                  ),
+                                  onTap: () {
+                                    pushNewScreen(
+                                      context,
+                                      screen: SwitchOrganization(),
+                                    );
+                                  }),
                           ListTile(
                               title: Text(
                                 'Join or Create New Organization',

--- a/lib/views/pages/organization/switch_org_page.dart
+++ b/lib/views/pages/organization/switch_org_page.dart
@@ -72,7 +72,11 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
         MutationOptions(documentNode: gql(_query.fetchOrgById(itemIndex))));
     if (result.hasException) {
       print(result.exception);
-      _exceptionToast(result.exception.toString());
+      if (result.exception.graphqlErrors.isNotEmpty) {
+        _exceptionToast(result.exception.graphqlErrors.first.message);
+      } else {
+        _exceptionToast(result.exception.clientException.message);
+      }
     } else if (!result.hasException) {
       _successToast(
           "Switched to " + result.data['organizations'][0]['name'].toString());
@@ -153,6 +157,8 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
     return Center(
       child: Text(
         msg,
+        maxLines: 4,
+        overflow: TextOverflow.ellipsis,
         style: TextStyle(fontSize: 16),
         textAlign: TextAlign.center,
       ),
@@ -188,11 +194,10 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
         borderRadius: BorderRadius.circular(25.0),
         color: Colors.red,
       ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(msg),
-        ],
+      child: Text(
+        msg,
+        overflow: TextOverflow.ellipsis,
+        maxLines: 4,
       ),
     );
 

--- a/lib/views/pages/organization/switch_org_page.dart
+++ b/lib/views/pages/organization/switch_org_page.dart
@@ -5,8 +5,8 @@ import 'package:provider/provider.dart';
 import 'package:talawa/services/Queries.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/utils/GQLClient.dart';
-import 'package:talawa/utils/globals.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:talawa/utils/globals.dart';
 import 'package:talawa/utils/uidata.dart';
 import 'package:talawa/views/pages/organization/profile_page.dart';
 

--- a/lib/views/pages/organization/switch_org_page.dart
+++ b/lib/views/pages/organization/switch_org_page.dart
@@ -6,7 +6,6 @@ import 'package:talawa/services/Queries.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/utils/GQLClient.dart';
 import 'package:fluttertoast/fluttertoast.dart';
-import 'package:talawa/utils/globals.dart';
 import 'package:talawa/utils/uidata.dart';
 import 'package:talawa/views/pages/organization/profile_page.dart';
 
@@ -72,11 +71,7 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
         MutationOptions(documentNode: gql(_query.fetchOrgById(itemIndex))));
     if (result.hasException) {
       print(result.exception);
-      if (result.exception.graphqlErrors.isNotEmpty) {
-        _exceptionToast(result.exception.graphqlErrors.first.message);
-      } else {
-        _exceptionToast(result.exception.clientException.message);
-      }
+      _exceptionToast(result.exception.toString());
     } else if (!result.hasException) {
       _successToast(
           "Switched to " + result.data['organizations'][0]['name'].toString());
@@ -107,6 +102,7 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
       body: _progressBarState
           ? Center(child: CircularProgressIndicator())
           : ListView.separated(
+              padding: EdgeInsets.only(top: 10.0),
               itemCount: userOrg.length,
               itemBuilder: (context, index) {
                 return RadioListTile(
@@ -157,8 +153,6 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
     return Center(
       child: Text(
         msg,
-        maxLines: 4,
-        overflow: TextOverflow.ellipsis,
         style: TextStyle(fontSize: 16),
         textAlign: TextAlign.center,
       ),
@@ -194,10 +188,11 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
         borderRadius: BorderRadius.circular(25.0),
         color: Colors.red,
       ),
-      child: Text(
-        msg,
-        overflow: TextOverflow.ellipsis,
-        maxLines: 4,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(msg),
+        ],
       ),
     );
 

--- a/lib/views/pages/organization/switch_org_page.dart
+++ b/lib/views/pages/organization/switch_org_page.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:talawa/services/Queries.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/utils/GQLClient.dart';
+import 'package:talawa/utils/globals.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:talawa/utils/uidata.dart';
 import 'package:talawa/views/pages/organization/profile_page.dart';
@@ -102,7 +103,6 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
       body: _progressBarState
           ? Center(child: CircularProgressIndicator())
           : ListView.separated(
-              padding: EdgeInsets.only(top: 10.0),
               itemCount: userOrg.length,
               itemBuilder: (context, index) {
                 return RadioListTile(


### PR DESCRIPTION
Issue: #175 
The aim of this pull is to make sure the error message is displayed in the snackbar without
1. Breaking the widget
2. In a user appealing way

**Current Behaviour:**
![Screenshot 2021-03-15 at 3 46 32 PM](https://user-images.githubusercontent.com/35868598/111138220-afc5b580-85a5-11eb-9307-3102c83aabf9.png)

**Expected Behaviour:**
Save button to be removed or snackbar to be optimized

**Steps to create Issue:**

1. Login/Signup
2. Remove Yourself from all organization
3. Now restart the app and navigate to the Profile Screen
4. In Profile screen navigate to Switch Organization
5. Press Save