### PR TITLE
Updated CircularProgressIndicator on Create an Organization Page and Updated Create an Account Page

### DIFF
--- a/lib/views/pages/login_signup/register_form.dart
+++ b/lib/views/pages/login_signup/register_form.dart
@@ -59,7 +59,6 @@ class RegisterFormState extends State<RegisterForm> {
     final img = await multipartFileFrom(_image);
     print(_image);
     QueryResult result = await _client.mutate(MutationOptions(
-
       documentNode: gql(_signupQuery.registerUser(
           model.firstName, model.lastName, model.email, model.password)),
       variables: {
@@ -134,8 +133,7 @@ class RegisterFormState extends State<RegisterForm> {
   //get image using camera
   _imgFromCamera() async {
     File image = await ImagePicker.pickImage(
-        source: ImageSource.camera, imageQuality: 50
-    );
+        source: ImageSource.camera, imageQuality: 50);
 
     setState(() {
       _image = image;
@@ -144,7 +142,11 @@ class RegisterFormState extends State<RegisterForm> {
 
   //get image using gallery
   _imgFromGallery() async {
-    File image = File((await FilePicker.platform.pickFiles(type: FileType.image)).files.first.path);
+    File image = File(
+        (await FilePicker.platform.pickFiles(type: FileType.image))
+            .files
+            .first
+            .path);
     setState(() {
       _image = image;
     });
@@ -153,192 +155,220 @@ class RegisterFormState extends State<RegisterForm> {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: Form(
-        key: _formKey,
-        autovalidate: _validate,
-        child: Column(
-          children: <Widget>[
-            addImage(),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text('Add Profile Image',
-                  style: TextStyle(fontSize: 16, color: Colors.white)),
-            ),
-            SizedBox(
-              height: 25,
-            ),
-            AutofillGroup(
-              child : Column(
-    children :  <Widget>[
-                TextFormField(
-                  autofillHints: <String>[AutofillHints.name] ,
-                    textCapitalization: TextCapitalization.words,
-                    validator: (value) => Validator.validateFirstName(value),
-                    textAlign: TextAlign.left,
-                    style: TextStyle(color: Colors.white),
-                    decoration: InputDecoration(
-                    border: OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.white),
-                    borderRadius: BorderRadius.circular(20.0)),
-                prefixIcon: Icon(Icons.person),
-                labelText: "First Name",
-                labelStyle: TextStyle(color: Colors.white),
-                alignLabelWithHint: true,
-                hintText: 'Earl',
-                hintStyle: TextStyle(color: Colors.grey),
-              ),
-              onSaved: (value) {
-                model.firstName = value;
-              },
-            ),
-            SizedBox(
-              height: 20,
-            ),
-            TextFormField(
-              autofillHints: <String>[AutofillHints.name] ,
-              textCapitalization: TextCapitalization.words,
-              validator: (value) => Validator.validateLastName(value),
-              textAlign: TextAlign.left,
-              style: TextStyle(color: Colors.white),
-              decoration: InputDecoration(
-                border: OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.white),
-                    borderRadius: BorderRadius.circular(20.0)),
-                prefixIcon: Icon(Icons.person),
-                labelText: "Last Name",
-                labelStyle: TextStyle(color: Colors.white),
-                alignLabelWithHint: true,
-                hintText: 'John',
-                hintStyle: TextStyle(color: Colors.grey),
-              ),
-              onSaved: (value) {
-                model.lastName = value;
-              },
-            ),
-            SizedBox(
-              height: 20,
-            ),
-            TextFormField(
-              autofillHints: <String>[AutofillHints.email] ,
-              keyboardType: TextInputType.emailAddress,
-              validator: (value) => Validator.validateEmail(value),
-              controller: emailController,
-              textAlign: TextAlign.left,
-              style: TextStyle(color: Colors.white),
-              decoration: InputDecoration(
-                border: OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.white),
-                    borderRadius: BorderRadius.circular(20.0)),
-                prefixIcon: Icon(Icons.email),
-                labelText: "Email",
-                labelStyle: TextStyle(color: Colors.white),
-                alignLabelWithHint: true,
-                hintText: 'foo@bar.com',
-                hintStyle: TextStyle(color: Colors.grey),
-              ),
-              onSaved: (value) {
-                model.email = value;
-              },
-            ),
-            SizedBox(
-              height: 20,
-            ),
-            TextFormField(
-              autofillHints: <String>[AutofillHints.password],
-              obscureText: _obscureText,
-              controller: originalPassword,
-              validator: (value) => Validator.validatePassword(value),
-              textAlign: TextAlign.left,
-              style: TextStyle(color: Colors.white),
-              decoration: InputDecoration(
-                border: OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.white),
-                    borderRadius: BorderRadius.circular(20.0)),
-                prefixIcon: Icon(Icons.lock),
-                suffixIcon: FlatButton(
-                  onPressed: _toggle,
-                  child: Icon(_obscureText
-                      ? Icons.visibility_off
-                      : Icons.visibility),
+        child: Form(
+            key: _formKey,
+            autovalidate: _validate,
+            child: Column(
+              children: <Widget>[
+                addImage(),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Add Profile Image',
+                      style: TextStyle(fontSize: 16, color: Colors.white)),
                 ),
-                labelText: "Password",
-                labelStyle: TextStyle(color: Colors.white),
-                focusColor: UIData.primaryColor,
-                alignLabelWithHint: true,
-                hintText: 'password',
-                hintStyle: TextStyle(color: Colors.grey),
-              ),
-              onSaved: (value) {
-                model.password = value;
-              },
-            ),
                 SizedBox(
-                  height: 20,
+                  height: 25,
                 ),
-                FlutterPasswordStrength(
-                password: originalPassword.text,
-                height: 10,
-                radius: 10,
-                strengthCallback: (strength){
-                debugPrint(strength.toString());
-              }
-                ),
-                  SizedBox(
-              height: 20,
-            ),
-            TextFormField(
-              autofillHints: <String>[AutofillHints.password] ,
-              obscureText: true,
-              validator: (value) => Validator.validatePasswordConfirm(
-                  originalPassword.text, value),
-              textAlign: TextAlign.left,
-              style: TextStyle(color: Colors.white),
-              decoration: InputDecoration(
-                border: OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.white),
-                    borderRadius: BorderRadius.circular(20.0)),
-                prefixIcon: Icon(Icons.lock),
-                labelText: "Confirm Password",
-                labelStyle: TextStyle(color: Colors.white),
-                focusColor: UIData.primaryColor,
-              ),
-            ),
-            SizedBox(
-              height: 20,
-            ),
-              ],
-            ),
-            ),
-            Container(
-              padding: EdgeInsets.symmetric(vertical: 20.0, horizontal: 30.0),
-              width: double.infinity,
-              child: RaisedButton(
-                padding: EdgeInsets.all(12.0),
-                shape: StadiumBorder(),
-                child: _progressBarState
-                    ? const CircularProgressIndicator()
-                    : Text(
-                        "SIGN UP",
+                AutofillGroup(
+                  child: Column(
+                    children: <Widget>[
+                      TextFormField(
+                        autofillHints: <String>[AutofillHints.name],
+                        textCapitalization: TextCapitalization.words,
+                        validator: (value) =>
+                            Validator.validateFirstName(value),
+                        textAlign: TextAlign.left,
+                        style: TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.white),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.orange),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          prefixIcon: Icon(Icons.person, color: Colors.white),
+                          labelText: "First Name",
+                          labelStyle: TextStyle(color: Colors.white),
+                          alignLabelWithHint: true,
+                          hintText: 'Earl',
+                          hintStyle: TextStyle(color: Colors.grey),
+                        ),
+                        onSaved: (value) {
+                          model.firstName = value;
+                        },
                       ),
-                color: Colors.white,
-                onPressed: () async {
-                  FocusScope.of(context).unfocus();
-                  _validate = true;
-                  if (_formKey.currentState.validate()) {
-                    _formKey.currentState.save();
-                    _image != null
-                        ? registerUser()
-                        : registerUserWithoutImg();
+                      SizedBox(
+                        height: 20,
+                      ),
+                      TextFormField(
+                        autofillHints: <String>[AutofillHints.name],
+                        textCapitalization: TextCapitalization.words,
+                        validator: (value) => Validator.validateLastName(value),
+                        textAlign: TextAlign.left,
+                        style: TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.white),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.orange),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          prefixIcon: Icon(Icons.person, color: Colors.white),
+                          labelText: "Last Name",
+                          labelStyle: TextStyle(color: Colors.white),
+                          alignLabelWithHint: true,
+                          hintText: 'John',
+                          hintStyle: TextStyle(color: Colors.grey),
+                        ),
+                        onSaved: (value) {
+                          model.lastName = value;
+                        },
+                      ),
+                      SizedBox(
+                        height: 20,
+                      ),
+                      TextFormField(
+                        autofillHints: <String>[AutofillHints.email],
+                        keyboardType: TextInputType.emailAddress,
+                        validator: (value) => Validator.validateEmail(value),
+                        controller: emailController,
+                        textAlign: TextAlign.left,
+                        style: TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.white),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.orange),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          prefixIcon: Icon(Icons.email, color: Colors.white),
+                          labelText: "Email",
+                          labelStyle: TextStyle(color: Colors.white),
+                          alignLabelWithHint: true,
+                          hintText: 'foo@bar.com',
+                          hintStyle: TextStyle(color: Colors.grey),
+                        ),
+                        onSaved: (value) {
+                          model.email = value;
+                        },
+                      ),
+                      SizedBox(
+                        height: 20,
+                      ),
+                      TextFormField(
+                        autofillHints: <String>[AutofillHints.password],
+                        obscureText: true,
+                        controller: originalPassword,
+                        validator: (value) => Validator.validatePassword(value),
+                        textAlign: TextAlign.left,
+                        style: TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.white),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.orange),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          prefixIcon: Icon(Icons.lock, color: Colors.white),
+                          labelText: "Password",
+                          labelStyle: TextStyle(color: Colors.white),
+                          focusColor: UIData.primaryColor,
+                          alignLabelWithHint: true,
+                          hintText: 'Password',
+                          hintStyle: TextStyle(color: Colors.grey),
+                        ),
+                        onSaved: (value) {
+                          model.password = value;
+                        },
+                      ),
+                      SizedBox(
+                        height: 10,
+                      ),
+                      FlutterPasswordStrength(
+                          password: originalPassword.text,
+                          height: 5,
+                          radius: 10,
+                          strengthCallback: (strength) {
+                            debugPrint(strength.toString());
+                          }),
+                      SizedBox(
+                        height: 20,
+                      ),
+                      TextFormField(
+                        autofillHints: <String>[AutofillHints.password],
+                        obscureText: true,
+                        validator: (value) => Validator.validatePasswordConfirm(
+                            originalPassword.text, value),
+                        textAlign: TextAlign.left,
+                        style: TextStyle(color: Colors.white),
+                        decoration: InputDecoration(
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.white),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.orange),
+                            borderRadius: BorderRadius.circular(20.0),
+                          ),
+                          prefixIcon: Icon(Icons.lock, color: Colors.white),
+                          labelText: "Confirm Password",
+                          labelStyle: TextStyle(color: Colors.white),
+                          focusColor: UIData.primaryColor,
+                        ),
+                      ),
+                      SizedBox(
+                        height: 20,
+                      ),
+                    ],
+                  ),
+                ),
+                Container(
+                  padding:
+                      EdgeInsets.symmetric(vertical: 20.0, horizontal: 30.0),
+                  width: double.infinity,
+                  child: RaisedButton(
+                    padding: EdgeInsets.all(12.0),
+                    shape: StadiumBorder(),
+                    child: _progressBarState
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              valueColor:
+                                  AlwaysStoppedAnimation<Color>(Colors.orange),
+                              strokeWidth: 3,
+                              backgroundColor: Colors.black,
+                            ))
+                        : Text(
+                            "SIGN UP",
+                          ),
+                    color: Colors.white,
+                    onPressed: () async {
+                      FocusScope.of(context).unfocus();
+                      _validate = true;
+                      if (_formKey.currentState.validate()) {
+                        _formKey.currentState.save();
+                        _image != null
+                            ? registerUser()
+                            : registerUserWithoutImg();
 
-                    setState(() {
-                      toggleProgressBarState();
-                    });
-                  }
-                },
-              ),
-            ),
-          ],
-        )));
+                        setState(() {
+                          toggleProgressBarState();
+                        });
+                      }
+                    },
+                  ),
+                ),
+              ],
+            )));
   }
 
   Widget addImage() {
@@ -386,7 +416,6 @@ class RegisterFormState extends State<RegisterForm> {
               child: Wrap(
                 children: <Widget>[
                   ListTile(
-
                     leading: Icon(Icons.camera_alt_outlined),
                     title: Text('Camera'),
                     onTap: () {

--- a/lib/views/pages/organization/create_organization.dart
+++ b/lib/views/pages/organization/create_organization.dart
@@ -89,7 +89,11 @@ class _CreateOrganizationState extends State<CreateOrganization> {
 
   //get image using gallery
   _imgFromGallery() async {
-    File image = File((await FilePicker.platform.pickFiles(type: FileType.image)).files.first.path);
+    File image = File(
+        (await FilePicker.platform.pickFiles(type: FileType.image))
+            .files
+            .first
+            .path);
     setState(() {
       _image = image;
     });
@@ -268,7 +272,17 @@ class _CreateOrganizationState extends State<CreateOrganization> {
                           padding: EdgeInsets.all(16.0),
                           shape: StadiumBorder(),
                           child: _progressBarState
-                              ? const CircularProgressIndicator()
+                              ? const Center(
+                                  child: SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        valueColor:
+                                            AlwaysStoppedAnimation<Color>(
+                                                Colors.white),
+                                        strokeWidth: 3,
+                                        backgroundColor: Colors.black,
+                                      )))
                               : Text(
                                   "CREATE ORGANIZATION",
                                   style: TextStyle(color: Colors.white),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring and Improving the UI of the Create an Organization Page as well as Create an Account Page

- The `CircularProgressIndicator` color was changed to make it look better and whenever the loader was loading, the button size also changed which also needed to be fixed

- The borders and icons of Create an Account Page weren't properly visible, so changed the colors of that and along with that the `CircularProgressIndicator`  used to change the size of the `Sign Up` button which as also been fixed 

- The size of the password strength meter was also adjusted to make it more appealing to the user

**Did you add tests for your changes?**
Yes, the change was tested and works well in both iOS & Android systems without breaking anything.

**Summary**

The main motivation for the change is to have a better User Interface design and make the loader color pop to the user and also fix the button size.

This PR is related to Issues #224  ,  #220 and  #228