### PR TITLE
Back button added to create organization page

### DIFF
--- a/lib/views/pages/organization/create_organization.dart
+++ b/lib/views/pages/organization/create_organization.dart
@@ -148,6 +148,12 @@ class _CreateOrganizationState extends State<CreateOrganization> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
         title: const Text('Create Organization'),
       ),
       body: Container(
@@ -170,89 +176,94 @@ class _CreateOrganizationState extends State<CreateOrganization> {
                       SizedBox(
                         height: 30,
                       ),
-                      AutofillGroup(child:Column(children: <Widget>[
-                        TextFormField(
-                          autofillHints: <String>[AutofillHints.organizationName],
-                          validator: (value) => Validator.validateOrgName(value),
-                          textAlign: TextAlign.left,
-                          textCapitalization: TextCapitalization.words,
-                          style: TextStyle(color: Colors.black),
-                          decoration: InputDecoration(
-                            border: OutlineInputBorder(
-                                borderSide:
-                                BorderSide(color: UIData.secondaryColor),
-                                borderRadius: BorderRadius.circular(20.0)),
-                            prefixIcon: Icon(
-                              Icons.group,
-                              color: UIData.secondaryColor,
+                      AutofillGroup(
+                          child: Column(
+                        children: <Widget>[
+                          TextFormField(
+                            autofillHints: <String>[
+                              AutofillHints.organizationName
+                            ],
+                            validator: (value) =>
+                                Validator.validateOrgName(value),
+                            textAlign: TextAlign.left,
+                            textCapitalization: TextCapitalization.words,
+                            style: TextStyle(color: Colors.black),
+                            decoration: InputDecoration(
+                              border: OutlineInputBorder(
+                                  borderSide:
+                                      BorderSide(color: UIData.secondaryColor),
+                                  borderRadius: BorderRadius.circular(20.0)),
+                              prefixIcon: Icon(
+                                Icons.group,
+                                color: UIData.secondaryColor,
+                              ),
+                              labelText: "Organization Name",
+                              labelStyle: TextStyle(color: Colors.black),
+                              alignLabelWithHint: true,
+                              hintText: 'My Organization',
+                              hintStyle: TextStyle(color: Colors.grey),
                             ),
-                            labelText: "Organization Name",
-                            labelStyle: TextStyle(color: Colors.black),
-                            alignLabelWithHint: true,
-                            hintText: 'My Organization',
-                            hintStyle: TextStyle(color: Colors.grey),
+                            controller: orgNameController,
                           ),
-                          controller: orgNameController,
-                        ),
-                        SizedBox(
-                          height: 20,
-                        ),
-                        TextFormField(
-                          autofillHints: <String>[AutofillHints.impp],
-                          keyboardType: TextInputType.multiline,
-                          maxLines: null,
-                          textCapitalization: TextCapitalization.words,
-                          validator: (value) => Validator.validateOrgDesc(value),
-                          textAlign: TextAlign.left,
-                          style: TextStyle(color: Colors.black),
-                          decoration: InputDecoration(
-                            border: OutlineInputBorder(
-                                borderSide:
-                                BorderSide(color: UIData.secondaryColor),
-                                borderRadius: BorderRadius.circular(20.0)),
-                            prefixIcon:
-                            Icon(Icons.note, color: UIData.secondaryColor),
-                            labelText: "Organization Description",
-                            labelStyle: TextStyle(color: Colors.black),
-                            alignLabelWithHint: true,
-                            hintText: 'My Description',
-                            hintStyle: TextStyle(color: Colors.grey),
+                          SizedBox(
+                            height: 20,
                           ),
-                          controller: orgDescController,
-                        ),
-                        SizedBox(
-                          height: 20,
-                        ),
-                        TextFormField(
-                          autofillHints: <String>[AutofillHints.impp],
-                          keyboardType: TextInputType.multiline,
-                          maxLines: null,
-                          textCapitalization: TextCapitalization.words,
-                          validator: (value) =>
-                              Validator.validateOrgAttendeesDesc(value),
-                          textAlign: TextAlign.left,
-                          style: TextStyle(color: Colors.black),
-                          decoration: new InputDecoration(
-                            border: new OutlineInputBorder(
-                                borderRadius: new BorderRadius.circular(20.0),
-                                borderSide:
-                                new BorderSide(color: UIData.secondaryColor)),
-                            prefixIcon:
-                            Icon(Icons.note, color: UIData.secondaryColor),
-                            labelText: "Member Description",
-                            labelStyle: TextStyle(color: Colors.black),
-                            alignLabelWithHint: true,
-                            hintText: 'Member Description',
-                            hintStyle: TextStyle(color: Colors.grey),
+                          TextFormField(
+                            autofillHints: <String>[AutofillHints.impp],
+                            keyboardType: TextInputType.multiline,
+                            maxLines: null,
+                            textCapitalization: TextCapitalization.words,
+                            validator: (value) =>
+                                Validator.validateOrgDesc(value),
+                            textAlign: TextAlign.left,
+                            style: TextStyle(color: Colors.black),
+                            decoration: InputDecoration(
+                              border: OutlineInputBorder(
+                                  borderSide:
+                                      BorderSide(color: UIData.secondaryColor),
+                                  borderRadius: BorderRadius.circular(20.0)),
+                              prefixIcon: Icon(Icons.note,
+                                  color: UIData.secondaryColor),
+                              labelText: "Organization Description",
+                              labelStyle: TextStyle(color: Colors.black),
+                              alignLabelWithHint: true,
+                              hintText: 'My Description',
+                              hintStyle: TextStyle(color: Colors.grey),
+                            ),
+                            controller: orgDescController,
                           ),
-                          controller: orgMemberDescController,
-                        ),
-                        SizedBox(
-                          height: 20,
-                        ),
-                      ],
-                      )
-                      ),
+                          SizedBox(
+                            height: 20,
+                          ),
+                          TextFormField(
+                            autofillHints: <String>[AutofillHints.impp],
+                            keyboardType: TextInputType.multiline,
+                            maxLines: null,
+                            textCapitalization: TextCapitalization.words,
+                            validator: (value) =>
+                                Validator.validateOrgAttendeesDesc(value),
+                            textAlign: TextAlign.left,
+                            style: TextStyle(color: Colors.black),
+                            decoration: new InputDecoration(
+                              border: new OutlineInputBorder(
+                                  borderRadius: new BorderRadius.circular(20.0),
+                                  borderSide: new BorderSide(
+                                      color: UIData.secondaryColor)),
+                              prefixIcon: Icon(Icons.note,
+                                  color: UIData.secondaryColor),
+                              labelText: "Member Description",
+                              labelStyle: TextStyle(color: Colors.black),
+                              alignLabelWithHint: true,
+                              hintText: 'Member Description',
+                              hintStyle: TextStyle(color: Colors.grey),
+                            ),
+                            controller: orgMemberDescController,
+                          ),
+                          SizedBox(
+                            height: 20,
+                          ),
+                        ],
+                      )),
                       Text('Do you want your organization to be public?',
                           style: TextStyle(fontSize: 16, color: Colors.black)),
                       RadioListTile(
@@ -336,9 +347,9 @@ class _CreateOrganizationState extends State<CreateOrganization> {
                                         backgroundColor: Colors.black,
                                       )))
                               : Text(
-                            "CREATE ORGANIZATION",
-                            style: TextStyle(color: Colors.white),
-                          ),
+                                  "CREATE ORGANIZATION",
+                                  style: TextStyle(color: Colors.white),
+                                ),
                           color: UIData.secondaryColor,
                           onPressed: () async {
                             if (_formKey.currentState.validate() &&
@@ -386,19 +397,19 @@ class _CreateOrganizationState extends State<CreateOrganization> {
               backgroundColor: UIData.secondaryColor,
               child: _image != null
                   ? CircleAvatar(
-                radius: 52,
-                backgroundImage: FileImage(
-                  _image,
-                ),
-              )
+                      radius: 52,
+                      backgroundImage: FileImage(
+                        _image,
+                      ),
+                    )
                   : CircleAvatar(
-                radius: 52,
-                backgroundColor: Colors.lightBlue[50],
-                child: Icon(
-                  Icons.camera_alt,
-                  color: Colors.grey[800],
-                ),
-              ),
+                      radius: 52,
+                      backgroundColor: Colors.lightBlue[50],
+                      child: Icon(
+                        Icons.camera_alt,
+                        color: Colors.grey[800],
+                      ),
+                    ),
             ),
           ),
         )

--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -393,7 +393,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
         foregroundColor: Colors.white,
         elevation: 5.0,
         onPressed: () {
-          Navigator.of(context).pushReplacement(MaterialPageRoute(
+          Navigator.of(context).push(MaterialPageRoute(
               builder: (context) => new CreateOrganization()));
         },
       ),


### PR DESCRIPTION
Fixes #281 
The create organization page just after signing up does not have a back button. Due to this we cannot go back to the select organization page.
Fixes added -

- back-arrow icon added to appbar of Create organization page

- Navigation.pushReplacement has been changed to Navigation.push which was preventing Navigation.pop from going back to select organization page

Before
<img src="https://user-images.githubusercontent.com/58037946/111074886-4002ec80-850b-11eb-9152-c655f9b2e503.jpg" width="200" height="400">

After
<img src="https://user-images.githubusercontent.com/58037946/111075350-aab52780-850d-11eb-9148-d74e5c655dea.jpg" width="200" height="400">