### PR TITLE
Update Switch Organization Page

### DIFF
--- a/lib/views/pages/organization/switch_org_page.dart
+++ b/lib/views/pages/organization/switch_org_page.dart
@@ -103,6 +103,7 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
       body: _progressBarState
           ? Center(child: CircularProgressIndicator())
           : ListView.separated(
+              padding: EdgeInsets.only(top: 10.0),
               itemCount: userOrg.length,
               itemBuilder: (context, index) {
                 return RadioListTile(


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring and Improving the UI of the Switch Organization Page

- The spacing between Header Bar and Organization Image Changed

**Did you add tests for your changes?**
Yes, the change was tested and works well in both iOS & Android systems without breaking anything.

This Commit Fixes #222
