### PR TITLE
Save login/register forms' state

### DIFF
--- a/lib/views/pages/login_signup/login_page.dart
+++ b/lib/views/pages/login_signup/login_page.dart
@@ -542,13 +542,13 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
                 ),
               ),
 
-              KeepAlivePage(
-                child:Center(
-                  child: SingleChildScrollView(
-                    child: mainScreen(),
-                  ),
+              
+              Center(
+                child: SingleChildScrollView(
+                  child: mainScreen(),
                 ),
               ),
+            
 
               //has to be scrollable so the screen can adjust when the keyboard is tapped
               KeepAlivePage(

--- a/lib/views/pages/login_signup/login_page.dart
+++ b/lib/views/pages/login_signup/login_page.dart
@@ -541,14 +541,12 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
                   ),
                 ),
               ),
-
               
               Center(
                 child: SingleChildScrollView(
                   child: mainScreen(),
                 ),
               ),
-            
 
               //has to be scrollable so the screen can adjust when the keyboard is tapped
               KeepAlivePage(

--- a/lib/views/pages/login_signup/login_page.dart
+++ b/lib/views/pages/login_signup/login_page.dart
@@ -6,6 +6,7 @@ import 'package:talawa/utils/uidata.dart';
 import 'package:talawa/utils/validator.dart';
 import 'package:talawa/views/pages/login_signup/login_form.dart';
 import 'package:talawa/views/pages/login_signup/register_form.dart';
+import 'package:talawa/views/widgets/keep_alive_page.dart';
 
 class LoginPage extends StatefulWidget {
   @override
@@ -533,21 +534,29 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
             physics: saveMsg != "URL SAVED!" ? new NeverScrollableScrollPhysics() : new BouncingScrollPhysics(),
             children: <Widget>[
               //has to be scrollable so the screen can adjust when the keyboard is tapped
-              Center(
-                child: SingleChildScrollView(
-                  child: loginScreenForm(),
+              KeepAlivePage(
+                child:Center(
+                  child: SingleChildScrollView(
+                    child: loginScreenForm(),
+                  ),
                 ),
               ),
 
-              Center(
-                child: SingleChildScrollView(
-                  child: mainScreen(),
+              KeepAlivePage(
+                child:Center(
+                  child: SingleChildScrollView(
+                    child: mainScreen(),
+                  ),
                 ),
               ),
 
               //has to be scrollable so the screen can adjust when the keyboard is tapped
-              Center(
-                child: SingleChildScrollView(child: registrationScreenForm()),
+              KeepAlivePage(
+                child:Center(
+                  child: SingleChildScrollView(
+                    child: registrationScreenForm(),
+                  ),
+                ),
               ),
             ],
           ),

--- a/lib/views/widgets/keep_alive_page.dart
+++ b/lib/views/widgets/keep_alive_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class KeepAlivePage extends StatefulWidget {
+  KeepAlivePage({
+    Key key,
+    @required this.child,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  _KeepAlivePageState createState() => _KeepAlivePageState();
+}
+
+class _KeepAlivePageState extends State<KeepAlivePage>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  Widget build(BuildContext context) {
+    /// Dont't forget this
+    super.build(context);
+
+    return widget.child;
+  }
+
+  @override
+  // TODO: implement wantKeepAlive
+  bool get wantKeepAlive => true;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
**What kind of change does this PR introduce?**
patch/feature to save signup/login form states, so that an accidental swipe on the login page doesn't reset the forms. Fixes #322.
<!-- E.g. a bugfix, feature, refactoring, etc… -->
**Did you add tests for your changes?**
No.
**If relevant, did you update the documentation?**
Not Applicable.
**Summary**
Before this change, if a user had swiped accidentally on the login screen while filling up the login or sign-up form, the forms would have been reset. This PR ensures that this wont happen and the form states are saved.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->