### PR TITLE
Changed the order in which the Login Page contents are being animated

### DIFF
--- a/lib/views/pages/login_signup/login_page.dart
+++ b/lib/views/pages/login_signup/login_page.dart
@@ -417,7 +417,6 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
                     height: 20,
                   ),
                   FadeTransition(
-                    // opacity: createAnimation,
                     opacity: loginAnimation,
                     child: Container(
                       //padding: EdgeInsets.all(100.0),

--- a/lib/views/pages/login_signup/login_page.dart
+++ b/lib/views/pages/login_signup/login_page.dart
@@ -418,6 +418,7 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
                   ),
                   FadeTransition(
                     // opacity: createAnimation,
+                    opacity: loginAnimation,
                     child: Container(
                       //padding: EdgeInsets.all(100.0),
                       child: new Container(

--- a/lib/views/pages/login_signup/login_page.dart
+++ b/lib/views/pages/login_signup/login_page.dart
@@ -417,7 +417,7 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
                     height: 20,
                   ),
                   FadeTransition(
-                    opacity: createAnimation,
+                    // opacity: createAnimation,
                     child: Container(
                       //padding: EdgeInsets.all(100.0),
                       child: new Container(

--- a/lib/views/pages/login_signup/login_page.dart
+++ b/lib/views/pages/login_signup/login_page.dart
@@ -417,6 +417,7 @@ class _LoginScreenState extends State<LoginPage> with TickerProviderStateMixin {
                     height: 20,
                   ),
                   FadeTransition(
+                    //changed opacity animation to match login button animation
                     opacity: loginAnimation,
                     child: Container(
                       //padding: EdgeInsets.all(100.0),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
The "**Org URL**" cluster on the Login page is now Faded-in using animation and then afterward both the `create an account` and `login `button are being simultaneously Faded-in.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
No.

**If relevant, did you update the documentation?**
A documentation update is not needed.

**Summary**
When the "**Org URL**" cluster on the Login page is Faded-in using animation and then afterward both the `create an account` and `login `button are simultaneously Faded-in then this looks more natural than the current animation.
Resolves #406 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

