### PR TITLE
Fixed Bug #433 Memory Leak

### DIFF
--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -20,7 +20,7 @@ import 'package:talawa/views/pages/organization/profile_page.dart';
 import 'create_organization.dart';
 
 class JoinOrganization extends StatefulWidget {
-  JoinOrganization({Key key, this.msg,this.fromProfile=false});
+  JoinOrganization({Key key, this.msg, this.fromProfile = false});
   final bool fromProfile;
   final String msg;
   @override
@@ -40,6 +40,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
   AuthController _authController = AuthController();
   String isPublic;
   TextEditingController searchController = TextEditingController();
+  bool disposed = false;
 
   @override
   void initState() {
@@ -48,6 +49,12 @@ class _JoinOrganizationState extends State<JoinOrganization> {
     fToast = FToast();
     fToast.init(context);
     fetchOrg();
+  }
+
+  @override
+  void dispose() {
+    disposed = true;
+    super.dispose();
   }
 
   void searchOrgName(String orgName) {
@@ -78,7 +85,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
     if (result.hasException) {
       print(result.exception);
       showError(result.exception.toString());
-    } else if (!result.hasException) {
+    } else if (!result.hasException && !disposed) {
       setState(() {
         organizationInfo = result.data['organizations'];
       });
@@ -103,11 +110,14 @@ class _JoinOrganizationState extends State<JoinOrganization> {
       print(result.data);
       _successToast("Request Sent to Organization Admin");
 
-      if(widget.fromProfile){
+      if (widget.fromProfile) {
         Navigator.pop(context);
-      }else{
-        Navigator.of(
-            context).pushReplacement(MaterialPageRoute(builder: (context)=>HomePage(openPageIndex: 4,),));
+      } else {
+        Navigator.of(context).pushReplacement(MaterialPageRoute(
+          builder: (context) => HomePage(
+            openPageIndex: 4,
+          ),
+        ));
       }
     }
   }
@@ -147,11 +157,14 @@ class _JoinOrganizationState extends State<JoinOrganization> {
       _successToast("Sucess!");
 
       //Navigate user to newsfeed
-      if(widget.fromProfile){
+      if (widget.fromProfile) {
         Navigator.pop(context);
-      }else{
-        Navigator.of(
-            context).pushReplacement(MaterialPageRoute(builder: (context)=>HomePage(openPageIndex: 4,),));
+      } else {
+        Navigator.of(context).pushReplacement(MaterialPageRoute(
+          builder: (context) => HomePage(
+            openPageIndex: 4,
+          ),
+        ));
       }
     }
   }
@@ -432,7 +445,9 @@ class _JoinOrganizationState extends State<JoinOrganization> {
         elevation: 5.0,
         onPressed: () {
           Navigator.of(context).push(MaterialPageRoute(
-              builder: (context) => new CreateOrganization(isFromProfile: widget.fromProfile,)));
+              builder: (context) => new CreateOrganization(
+                    isFromProfile: widget.fromProfile,
+                  )));
         },
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,


### PR DESCRIPTION
**What kind of change does this PR introduce:**
This fixes the bug #433 memory leak after leaving the join organization page.
**Issue Number:**
#433 
**Did you add tests for your code?**
Yes. I have tested it.
**Snapshots/Videos:**
**Video when the user closes the join organization page after the data is fetched :** 


https://user-images.githubusercontent.com/56271252/111908446-549d3280-8a7f-11eb-9fdd-8778925f23c3.mp4


as it is visible from the logs that everything is working fine like before.

**Video when the user closes the join organization page and the data fetching process was not completed :** 


https://user-images.githubusercontent.com/56271252/111908486-7bf3ff80-8a7f-11eb-9bfb-7cc1cb0ce678.mp4


And in this case, the code is throwing no error as it was throwing error before. In this case, no setState call is being made after the disposal of the widget but previously the call was being made to setState even after the disposal of the widget.

**Does this PR introduce a breaking change?**
No
**Other information:**
I added the print statements in the code just for demonstration purpose. In this pull request no print statement has been added as it has nothing to do with the bugfix.