### PR TITLE
Toast Message fixes in Login Form and Registration Form

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    ndkVersion "22.0.7026061"
     compileSdkVersion 30
 
     sourceSets {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,6 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    ndkVersion "22.0.7026061"
     compileSdkVersion 30
 
     sourceSets {

--- a/lib/views/pages/login_signup/login_form.dart
+++ b/lib/views/pages/login_signup/login_form.dart
@@ -1,4 +1,5 @@
 //flutter packages are called here
+import 'package:data_connection_checker/data_connection_checker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -56,13 +57,21 @@ class LoginFormState extends State<LoginForm> {
     GraphQLClient _client = graphQLConfiguration.clientToQuery();
     QueryResult result = await _client.mutate(MutationOptions(
         documentNode: gql(_query.loginUser(model.email, model.password))));
-    if (result.hasException) {
+    bool connectionCheck = await DataConnectionChecker().hasConnection;
+    if (!connectionCheck) {
+      print('You are not connected to the internet');
+      setState(() {
+        _progressBarState = false;
+      });
+      _exceptionToast('Connection Error. Make sure your Internet connection is stable');
+    }
+    else if (result.hasException) {
       print(result.exception);
       setState(() {
         _progressBarState = false;
       });
 
-      _exceptionToast(result.exception.toString().substring(16));
+      _exceptionToast(result.exception.toString().substring(16,35));
     } else if (!result.hasException && !result.loading) {
       setState(() {
         _progressBarState = true;

--- a/lib/views/pages/login_signup/login_form.dart
+++ b/lib/views/pages/login_signup/login_form.dart
@@ -164,7 +164,6 @@ class LoginFormState extends State<LoginForm> {
                 TextFormField(
                   autofillHints: <String>[AutofillHints.password],
                   obscureText: _obscureText,
-                  validator: (value) => Validator.validatePassword(value),
                   textAlign: TextAlign.left,
                   style: TextStyle(color: Colors.white),
                   decoration: InputDecoration(

--- a/lib/views/pages/login_signup/login_form.dart
+++ b/lib/views/pages/login_signup/login_form.dart
@@ -265,7 +265,7 @@ class LoginFormState extends State<LoginForm> {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(child: Text(msg)),
+          Expanded(child: Text(msg, textAlign: TextAlign.center,)),
         ],
       ),
     );
@@ -273,7 +273,9 @@ class LoginFormState extends State<LoginForm> {
     fToast.showToast(
       child: toast,
       gravity: ToastGravity.BOTTOM,
+
       toastDuration: Duration(seconds: 5),
+
     );
   }
 

--- a/lib/views/pages/login_signup/login_form.dart
+++ b/lib/views/pages/login_signup/login_form.dart
@@ -164,6 +164,7 @@ class LoginFormState extends State<LoginForm> {
                 TextFormField(
                   autofillHints: <String>[AutofillHints.password],
                   obscureText: _obscureText,
+                  validator: (value) => Validator.validatePassword(value),
                   textAlign: TextAlign.left,
                   style: TextStyle(color: Colors.white),
                   decoration: InputDecoration(

--- a/lib/views/pages/login_signup/register_form.dart
+++ b/lib/views/pages/login_signup/register_form.dart
@@ -76,7 +76,7 @@ class RegisterFormState extends State<RegisterForm> {
       setState(() {
         _progressBarState = false;
       });
-      _exceptionToast('Invalid Organisation URL');
+      _exceptionToast(result.hasException.toString().substring(16,35));
     } else if (!result.hasException && !result.loading) {
       setState(() {
         _progressBarState = true;
@@ -115,7 +115,7 @@ class RegisterFormState extends State<RegisterForm> {
       setState(() {
         _progressBarState = false;
       });
-      _exceptionToast("Invalid Organization URL");
+      _exceptionToast(result.exception.toString().substring(16,35));
     } else if (!result.hasException && !result.loading) {
       setState(() {
         _progressBarState = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   flutter_password_strength: ^0.1.6
   intl: ^0.17.0
   flutter_pw_validator: ^1.0.1+1
+  data_connection_checker: ^0.3.4
 
 
 


### PR DESCRIPTION
@Sagar2366 I have fixed #434 and #441 please check.
What kind of change does this PR introduce?
Bug Fixes:-
1. Toast Message on the login form will now say "Invalid Credentials" instead of "Invalid Credentials: Undefined Location"
2. Toast Message on the registration from will now say "Email Address Taken" instead of "Invalid Organization URL"
3. Added an extra dependency: data_connection_checker to check and show if the app is connected to the internet or not.
Summary
It needed to be fixed as a normal user would have been mislead if the toast messages were giving wrong information.
For more information I would suggest referring to #434 and #441.
Does this PR introduce a breaking change?
No