### PR TITLE
Event page bug

### DIFF
--- a/lib/views/pages/events/events.dart
+++ b/lib/views/pages/events/events.dart
@@ -154,6 +154,8 @@ class _EventsState extends State<Events> {
       eventList.removeWhere((element) =>
           element['title'] == 'Talawa Congress' ||
           element['title'] == 'test' || element['title'] == 'Talawa Conference Test'); //dont know who keeps adding these
+      // This removes all invalid date formats other than Unix time
+      eventList.removeWhere((element) => int.tryParse(element['startTime']) == null);
       eventList.sort((a, b) {
         return DateTime.fromMicrosecondsSinceEpoch(
           int.parse(a['startTime']))

--- a/lib/views/pages/events/events.dart
+++ b/lib/views/pages/events/events.dart
@@ -167,16 +167,6 @@ class _EventsState extends State<Events> {
         displayedEvents = eventList;
       });
       // print(displayedEvents);
-
-
-    eventList.sort((a, b) => DateTime.fromMicrosecondsSinceEpoch(
-        int.parse(a['startTime']))
-        .compareTo(
-        DateTime.fromMicrosecondsSinceEpoch(int.parse(b['startTime']))));
-    eventsToDates(eventList, DateTime.now());
-    setState(() {
-      displayedEvents = eventList;
-    });
   }
 
 


### PR DESCRIPTION
### What kind of change does this PR introduce?
This PR fixes #482
This exception was caused due to invalid `DateAndTime` formats in the `events` object. (Details below). 
This also solves a minor code duplication in `events.dart`.
### Did you add tests for your changes?
No.

### Summary
When the `user` visits the `eventPage` for the first time the events are fetched from the backend and the `events` are sorted in chronological order. An exception was thrown while the `eventList` was being sorted.
**Code**
```dart
eventList.sort((a, b) {
        // Exception is raised here.
        return DateTime.fromMicrosecondsSinceEpoch(
          int.parse(a['startTime']))
          .compareTo(
          DateTime.fromMicrosecondsSinceEpoch(int.parse(b['startTime'])));
      });
```
**Exception**
```bash
E/flutter ( 6958): [ERROR:flutter/lib/ui/ui_dart_state.cc(186)] Unhandled Exception: FormatException: Invalid radix-10 number (at character 1)
E/flutter ( 6958): 2021-03-22 23:59:00.000
```
**What caused the exception?**
This exception was caused because `int.parse()` couldn't parse `event['startTime']` as few of the entries were in the wrong format or it was not a `numeric string`(**_microsecondsSinceEpoch_**).
**Example**
- Legal entry or Time in microseconds since epoch
    `"startTime" -> "1616696940000000"`
- Wrong Formats
   `"startTime" -> "2021-03-22 23:59:00.000"`
   `"startTime" -> "2021-03-22 01:00 PM"`

**Solution**
Sanitizing the `eventList` before sorting.
### Does this PR introduce a breaking change?
No

### Other information
Dear maintainers kindly have a look into the backend implementation, as these bad entries are being fetched from the backend.

Please review and let me know if it requires any changes.