### PR TITLE
[Fix]- Validation in events page before for submission and error handling.

### DIFF
--- a/lib/views/pages/newsfeed/addPost.dart
+++ b/lib/views/pages/newsfeed/addPost.dart
@@ -1,7 +1,5 @@
-
 //flutter imported packages
 import 'package:flutter/material.dart';
-
 //pages are called here
 import 'package:talawa/services/Queries.dart';
 import 'package:talawa/services/preferences.dart';
@@ -18,8 +16,10 @@ class AddPost extends StatefulWidget {
 class _AddPostState extends State<AddPost> {
   final titleController = TextEditingController();
   final textController = TextEditingController();
+  AutovalidateMode validate = AutovalidateMode.disabled;
   String id;
-  String oranizationId;
+  String organizationId;
+  Map result;
   Preferences preferences = Preferences();
 
   //giving every variable its initial state
@@ -32,17 +32,19 @@ class _AddPostState extends State<AddPost> {
   getCurrentOrgId() async {
     final orgId = await preferences.getCurrentOrgId();
     setState(() {
-      oranizationId = orgId;
+      organizationId = orgId;
     });
-    print(oranizationId);
+    print(organizationId);
   }
 
   //creating post
   createPost() async {
+    textController.text = textController.text.trim().replaceAll('\n', ' ');
+    titleController.text = titleController.text.trim().replaceAll('\n', ' ');
     String mutation = Queries()
-        .addPost(textController.text, oranizationId, titleController.text);
+        .addPost(textController.text, organizationId, titleController.text);
     ApiFunctions apiFunctions = ApiFunctions();
-    Map result = await apiFunctions.gqlmutation(mutation);
+    result = await apiFunctions.gqlmutation(mutation);
   }
 
   void dispose() {
@@ -52,7 +54,7 @@ class _AddPostState extends State<AddPost> {
   }
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  
+
   //main build starts from here
   @override
   Widget build(BuildContext context) {
@@ -65,13 +67,14 @@ class _AddPostState extends State<AddPost> {
       ),
       body: Container(
           child: Form(
-        autovalidateMode: AutovalidateMode.onUserInteraction,
+        autovalidateMode: validate,
         key: _formKey,
         child: Column(
           children: <Widget>[
             Padding(
               padding: const EdgeInsets.all(9.0),
               child: TextFormField(
+                textInputAction: TextInputAction.next,
                 validator: (String value) {
                   if (value.isEmpty) {
                     return "This field is Required";
@@ -97,6 +100,8 @@ class _AddPostState extends State<AddPost> {
               padding: const EdgeInsets.all(9.0),
               child: TextFormField(
                 controller: textController,
+                keyboardType: TextInputType.multiline,
+                maxLines: null,
                 validator: (String value) {
                   if (value.isEmpty) {
                     return "This field is Required";

--- a/lib/views/pages/newsfeed/addPost.dart
+++ b/lib/views/pages/newsfeed/addPost.dart
@@ -90,6 +90,7 @@ class _AddPostState extends State<AddPost> {
             Padding(
               padding: const EdgeInsets.all(9.0),
               child: TextFormField(
+                key: Key('Title'),
                 textInputAction: TextInputAction.next,
                 validator: (String value) {
                   if (value.isEmpty) {
@@ -115,6 +116,7 @@ class _AddPostState extends State<AddPost> {
             Padding(
               padding: const EdgeInsets.all(9.0),
               child: TextFormField(
+                key: Key('Description'),
                 controller: textController,
                 keyboardType: TextInputType.multiline,
                 maxLines: null,
@@ -148,6 +150,7 @@ class _AddPostState extends State<AddPost> {
   //this method adds the post
   Widget addPostFab() {
     return FloatingActionButton(
+      key: Key('submit'),
         backgroundColor: UIData.secondaryColor,
         child: Icon(
           Icons.check,

--- a/test/widget_tests/addPost_test.dart
+++ b/test/widget_tests/addPost_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+// Local files imports.
+import 'package:talawa/controllers/auth_controller.dart';
+import 'package:talawa/controllers/org_controller.dart';
+import 'package:talawa/services/preferences.dart';
+import 'package:talawa/utils/GQLClient.dart';
+
+import '../../lib/views/pages/newsfeed/addPost.dart';
+
+Widget createMemberPageScreen() => MultiProvider(
+      providers: [
+        ChangeNotifierProvider<GraphQLConfiguration>(
+          create: (_) => GraphQLConfiguration(),
+        ),
+        ChangeNotifierProvider<OrgController>(
+          create: (_) => OrgController(),
+        ),
+        ChangeNotifierProvider<AuthController>(
+          create: (_) => AuthController(),
+        ),
+        ChangeNotifierProvider<Preferences>(
+          create: (_) => Preferences(),
+        ),
+      ],
+      child: MaterialApp(
+        home: AddPost(),
+      ),
+    );
+
+void main() {
+  group("member Page Tests", () {
+    testWidgets(
+        "Testing if addPost page shows up validations on empty submission",
+        (tester) async {
+      await tester.pumpWidget(createMemberPageScreen());
+      Finder formWidgetFinder = find.byType(Form);
+      Form formWidget = tester.widget(formWidgetFinder) as Form;
+      GlobalKey<FormState> formKey = formWidget.key as GlobalKey<FormState>;
+      expect(formKey.currentState.validate(), isFalse);
+    });
+    testWidgets(
+        "Testing if addPost page shows up validations on empty submission of description field",
+        (tester) async {
+      await tester.pumpWidget(createMemberPageScreen());
+      Finder title = find.byKey(Key('Title'));
+      await tester.enterText(title, "Something post title");
+      await tester.pump();
+      Finder formWidgetFinder = find.byType(Form);
+      Form formWidget = tester.widget(formWidgetFinder) as Form;
+      GlobalKey<FormState> formKey = formWidget.key as GlobalKey<FormState>;
+      expect(formKey.currentState.validate(), isFalse);
+    });
+    testWidgets(
+        "Testing if addPost page shows up validations on empty submission of title field",
+        (tester) async {
+      await tester.pumpWidget(createMemberPageScreen());
+      Finder description = find.byKey(Key('Description'));
+      await tester.enterText(description, "Description for the post");
+      await tester.pump();
+      Finder formWidgetFinder = find.byType(Form);
+      Form formWidget = tester.widget(formWidgetFinder) as Form;
+      GlobalKey<FormState> formKey = formWidget.key as GlobalKey<FormState>;
+      expect(formKey.currentState.validate(), isFalse);
+    });
+    testWidgets(
+        "Testing if addPost page shows up validations on submission on fields with data",
+        (tester) async {
+      await tester.pumpWidget(createMemberPageScreen());
+      Finder title = find.byKey(Key('Title'));
+      await tester.enterText(title, "Something post title");
+      Finder description = find.byKey(Key('Description'));
+      await tester.enterText(description, "Description for the post");
+      await tester.pump();
+      Finder formWidgetFinder = find.byType(Form);
+      Form formWidget = tester.widget(formWidgetFinder) as Form;
+      GlobalKey<FormState> formKey = formWidget.key as GlobalKey<FormState>;
+      expect(formKey.currentState.validate(), isTrue);
+    });
+    testWidgets(
+        "Testing if addPost page shows up error toast on submission on fields with multiline description",
+        (tester) async {
+      await tester.pumpWidget(createMemberPageScreen());
+      Finder title = find.byKey(Key('Title'));
+      await tester.enterText(title, 'Something post\n title');
+      await tester.pump();
+      Finder description = find.byKey(Key('Description'));
+      await tester.enterText(description, 'Description for\n the post');
+      await tester.pump();
+      Finder formWidgetFinder = find.byType(Form);
+      Form formWidget = tester.widget(formWidgetFinder) as Form;
+      GlobalKey<FormState> formKey = formWidget.key as GlobalKey<FormState>;
+      expect(formKey.currentState.validate(), isTrue);
+    });
+  });
+}

--- a/test/widget_tests/addPost_test.dart
+++ b/test/widget_tests/addPost_test.dart
@@ -30,7 +30,7 @@ Widget createMemberPageScreen() => MultiProvider(
     );
 
 void main() {
-  group("member Page Tests", () {
+  group("Member Page Tests", () {
     testWidgets(
         "Testing if addPost page shows up validations on empty submission",
         (tester) async {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
After the merge of this PR, one won't see the validation stating ```This field is required``` in the inactive field. The validation will only be shown when the form is submitted. Also if for some reason the API call is unsuccessful the error message will be displayed respectively.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
Yes, added test to the changes made.

**If relevant, did you update the documentation?**
Not needed, to update the documentation.

**Summary**
 | [**Earlier**](https://user-images.githubusercontent.com/44184786/112301767-48ec7e80-8cc0-11eb-8d2b-419d4ae76297.gif)      | [**Now**](https://user-images.githubusercontent.com/44184786/112301703-3a9e6280-8cc0-11eb-81fd-95aeb1d30495.gif)     | 
|------------|-------------| 
|  <img src="https://user-images.githubusercontent.com/44184786/112301767-48ec7e80-8cc0-11eb-8d2b-419d4ae76297.gif" width="250"> |  <img src="https://user-images.githubusercontent.com/44184786/112301703-3a9e6280-8cc0-11eb-81fd-95aeb1d30495.gif" width="250"> |
 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, this PR does not bring breaking changes.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
#487 