### PR TITLE
Email and password validator removed from login_form.dart

### DIFF
--- a/lib/views/pages/login_signup/login_form.dart
+++ b/lib/views/pages/login_signup/login_form.dart
@@ -130,7 +130,6 @@ class LoginFormState extends State<LoginForm> {
                 TextFormField(
                   autofillHints: <String>[AutofillHints.email],
                   keyboardType: TextInputType.emailAddress,
-                  validator: (value) => Validator.validateEmail(value),
                   textAlign: TextAlign.left,
                   style: TextStyle(color: Colors.white),
                   //Changed text input action to next
@@ -164,7 +163,6 @@ class LoginFormState extends State<LoginForm> {
                 TextFormField(
                   autofillHints: <String>[AutofillHints.password],
                   obscureText: _obscureText,
-                  validator: (value) => Validator.validatePassword(value),
                   textAlign: TextAlign.left,
                   style: TextStyle(color: Colors.white),
                   decoration: InputDecoration(


### PR DESCRIPTION
@Sagar2366  issue #496 fixed, you can check it.
**What kind of change does this PR introduce?**

 Fixed a bug where email and password were being validated like how they are supposed to be while registering. Refer to #496 for more details.

**Does this PR introduce a breaking change?**
No