### PR TITLE
User log out bug

### DIFF
--- a/lib/views/pages/home_page.dart
+++ b/lib/views/pages/home_page.dart
@@ -46,6 +46,10 @@ class _HomePageState extends State<HomePage> {
     Provider.of<Preferences>(context, listen: false).getCurrentOrgId();
   }
 
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   Future<void> getUserInfo() async {
     final String userID = await preferences.getUserId(); //getting the current user id from the server

--- a/lib/views/pages/home_page.dart
+++ b/lib/views/pages/home_page.dart
@@ -46,10 +46,6 @@ class _HomePageState extends State<HomePage> {
     Provider.of<Preferences>(context, listen: false).getCurrentOrgId();
   }
 
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   Future<void> getUserInfo() async {
     final String userID = await preferences.getUserId(); //getting the current user id from the server

--- a/lib/views/pages/login_signup/set_url_page.dart
+++ b/lib/views/pages/login_signup/set_url_page.dart
@@ -18,7 +18,32 @@ void changeFirst() {
   first = false;
 }
 
-class _UrlPageState extends State<UrlPage> with TickerProviderStateMixin {
+class _UrlPageState extends State<UrlPage> with TickerProviderStateMixin<UrlPage> {
+
+  final GlobalKey<ScaffoldState> _scaffoldkey = new GlobalKey<ScaffoldState>();
+
+  var _media;
+  final _formKey = GlobalKey<FormState>();
+  final urlController = TextEditingController();
+  String dropdownValue = 'HTTP';
+  Preferences _pref = Preferences();
+  String orgUrl, orgImgUrl;
+  String saveMsg = "Set URL";
+  String urlInput;
+  FToast fToast;
+  bool isUrlCalled = false;
+  //animation Controllers
+  AnimationController controller;
+  AnimationController loginController;
+  AnimationController helloController;
+  AnimationController createController;
+  // animation
+  Animation loginAnimation;
+  Animation createAnimation;
+  Animation animation;
+  Animation helloAnimation;
+
+
   listenToUrl() {
     if (saveMsg == "URL SAVED!" && urlController.text != urlInput) {
       setState(() {
@@ -92,67 +117,10 @@ class _UrlPageState extends State<UrlPage> with TickerProviderStateMixin {
     );
   }
 
-  final GlobalKey<ScaffoldState> _scaffoldkey = new GlobalKey<ScaffoldState>();
 
-  var _media;
-  final _formKey = GlobalKey<FormState>();
-  final urlController = TextEditingController();
-  String dropdownValue = 'HTTP';
-  Preferences _pref = Preferences();
-  String orgUrl, orgImgUrl;
-  String saveMsg = "Set URL";
-  String urlInput;
-  FToast fToast;
-  bool isUrlCalled = false;
-  //this animation length has to be larger becasuse it includes startup time
-  AnimationController controller;
 
-  @override
-  void initState() {
-    super.initState();
-    fToast = FToast();
-    fToast.init(context);
-    urlController.addListener(listenToUrl);
-    controller = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: 2000),
-    );
-  }
-
-  @override
-  dispose() {
-    controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    var loginController = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: 500),
-    );
-    var loginAnimation = Tween(begin: 0.0, end: 1.0).animate(loginController);
-    var createController = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: 500),
-    );
-    //AnimationController controller;
-    var createAnimation = Tween(begin: 0.0, end: 1.0).animate(createController);
-    var helloController = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: 500),
-    );
-    var animation = Tween(begin: 0.0, end: 1.0).animate(controller);
-    var helloAnimation = Tween(begin: 0.0, end: 1.0).animate(helloController);
-    Future<void> load() async {
-      await controller.forward();
-      await helloController.forward();
-      await createController.forward();
-      await loginController.forward();
-      changeFirst();
-    }
-
-    if (first != true) {
+    void assignAnimation(bool firstTime) {
+    if (!firstTime) {
       animation = Tween(begin: 1.0, end: 1.0).animate(controller);
 
       helloAnimation = Tween(begin: 1.0, end: 1.0).animate(helloController);
@@ -160,7 +128,55 @@ class _UrlPageState extends State<UrlPage> with TickerProviderStateMixin {
       createAnimation = Tween(begin: 1.0, end: 1.0).animate(createController);
 
       loginAnimation = Tween(begin: 1.0, end: 1.0).animate(loginController);
+    } else {
+      loginAnimation = Tween(begin: 0.0, end: 1.0).animate(loginController);
+
+      createAnimation = Tween(begin: 0.0, end: 1.0).animate(createController);
+
+      animation = Tween(begin: 0.0, end: 1.0).animate(controller);
+
+      helloAnimation = Tween(begin: 0.0, end: 1.0).animate(helloController);
     }
+  }
+  Future<void> load() async {
+      await controller?.forward();
+      await helloController?.forward();
+      await createController?.forward();
+      await loginController?.forward();
+      changeFirst();
+  }
+  @override
+  void initState() {
+    super.initState();
+    fToast = FToast();
+    fToast.init(context);
+    urlController.addListener(listenToUrl);
+    // Initializing all the animationControllers
+    controller = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 2000),
+    );
+    loginController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 500),
+    );
+
+    helloController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 500),
+    );
+
+    createController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 500),
+    );
+  }
+
+
+
+  @override
+  Widget build(BuildContext context) {
+    assignAnimation(first);
     load();
     Widget mainScreen() {
       return new Column(
@@ -507,5 +523,14 @@ class _UrlPageState extends State<UrlPage> with TickerProviderStateMixin {
         ),
       ),
     );
+  }
+
+  @override
+  dispose() {
+    controller.dispose();
+    helloController.dispose();
+    createController.dispose();
+    loginController.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?
This PR fixes second exception of #520 
<!-- E.g. a bugfix, feature, refactoring, etc… -->

### Did you add tests for your changes?
No.

### Summary
There are two exceptions in the app which are occurring when a user tries to logout.


**What caused the first exception?**
Because `PersistentTabController` is used after being disposed.
It is an issue in the `PersistentBottomNavBar` API which is fixed in the latest version. (check it out [here](https://github.com/BilalShahid13/PersistentBottomNavBar/issues/44))


**What caused the second exception?**
In the stateful widget `UrlPage`, its state `_UrlPageState` is with `TickerProviderStateMixin`; hence the animation controllers called or used inside this class get a `Ticker`, these `Tickers` needs to be disposed of. If not, these tickers will leak.
There are four animation controllers used in `UrlPage`. Still, three of them are inside the `build()` method, which is the root cause of this exception because the three animation controllers are **local** to the `build` method and are impossible to `dispose()`, and each time the `build()` method is called three new tickers are assigned to the three animation controllers, hence leading to a memory leak.
```dart
 @override
  Widget build(BuildContext context) {
  //These are the three controllers which are local to Build
    var loginController = AnimationController(
      vsync: this,
      duration: Duration(milliseconds: 500),
    );
    var createController = AnimationController(
      vsync: this,
      duration: Duration(milliseconds: 500),
    );
    var helloController = AnimationController(
      vsync: this,
      duration: Duration(milliseconds: 500),
    );
      ...
   }
```
**Solution**
declaring the controllers as class members and initializing them in `init()` and disposing all the controllers.
```dart
class _UrlPageState extends State<UrlPage> with TickerProviderStateMixin<UrlPage> {

   ...
  //animation Controllers
  AnimationController controller;
  AnimationController loginController;
  AnimationController helloController;
  AnimationController createController;
  // animation
  Animation loginAnimation;
  Animation createAnimation;
  Animation animation;
  Animation helloAnimation;
  ...
    @override
  void initState() {
    super.initState();
    // Initializing all the animationControllers
    controller = AnimationController(
      vsync: this,
      duration: Duration(milliseconds: 2000),
    );
    loginController = AnimationController(
      vsync: this,
      duration: Duration(milliseconds: 500),
    );

    helloController = AnimationController(
      vsync: this,
      duration: Duration(milliseconds: 500),
    );

    createController = AnimationController(
      vsync: this,
      duration: Duration(milliseconds: 500),
    );
  }
  @override
  Widget build(BuildContext context) {
  ...
  }
    @override
  dispose() {
    controller.dispose();
    helloController.dispose();
    createController.dispose();
    loginController.dispose();
    super.dispose();
  }
}

```
**Does this PR introduce a breaking change?**
No, it doesn't.