### PR TITLE
resolved article description clarity issue

### DIFF
--- a/lib/views/pages/newsfeed/newsArticle.dart
+++ b/lib/views/pages/newsfeed/newsArticle.dart
@@ -5,7 +5,6 @@ import 'package:fluttertoast/fluttertoast.dart';
 
 import 'package:flutter/services.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 //the pages are called here

--- a/lib/views/pages/newsfeed/newsArticle.dart
+++ b/lib/views/pages/newsfeed/newsArticle.dart
@@ -5,8 +5,8 @@ import 'package:fluttertoast/fluttertoast.dart';
 
 import 'package:flutter/services.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
-
 
 //the pages are called here
 import 'package:talawa/services/Queries.dart';
@@ -185,19 +185,22 @@ class _NewsArticleState extends State<NewsArticle> {
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Expanded(
-                  flex: 1,
+                Flexible(
+                  flex: 3,
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(20.0, 10, 0, 10),
-                    child: Text(widget.post['text'].toString()),
+                    padding: const EdgeInsets.fromLTRB(20.0, 10, 10, 10),
+                    child: Text(
+                      widget.post['text'].toString(),
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.justify,
+                      maxLines: 10,
+                    ),
                   ),
                 ),
-                Expanded(
+                Flexible(
                   flex: 3,
                   child: ListTile(
-                    leading: userDetails.isEmpty
-                        ? null
-                        : _profileImage(),
+                    leading: userDetails.isEmpty ? null : _profileImage(),
                     title: Container(
                       constraints: BoxConstraints(
                         maxHeight: double.infinity,
@@ -210,12 +213,11 @@ class _NewsArticleState extends State<NewsArticle> {
                           if (value.length > 500) {
                             return "Comment cannot be longer than 500 letters";
                           }
-                          if(value.length == 0)
-                            {
-                              return "Comment cannot be empty";
-                            }
+                          if (value.length == 0) {
+                            return "Comment cannot be empty";
+                          }
                           return null;
-                          },
+                        },
                         inputFormatters: [
                           LengthLimitingTextInputFormatter(500)
                         ],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refer issue #544 . The article description was being overlaped and the text was cut into single line.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**

**Summary**
Now the description is clear and the widgets take space accordingly due to `flexible `widget instead of `expanded`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
![Screenshot_20210328-180723](https://user-images.githubusercontent.com/51524156/112752507-0b099600-8ff1-11eb-8432-326194171f92.png)
