### PR TITLE
Fix #529 Create button throw exception while waiting for response

### DIFF
--- a/lib/views/pages/organization/create_organization.dart
+++ b/lib/views/pages/organization/create_organization.dart
@@ -387,7 +387,9 @@ class _CreateOrganizationState extends State<CreateOrganization> { //defining th
                                   "CREATE ORGANIZATION",
                                   style: TextStyle(color: Colors.white),
                                 ),
-                          onPressed: () async {
+                          onPressed: _progressBarState?(){
+                            _exceptionToast('Request in Progress');
+                          }:() async {
                             if (_formKey.currentState.validate() &&
                                 radioValue >= 0 &&
                                 radioValue1 >= 0) {
@@ -523,7 +525,7 @@ class _CreateOrganizationState extends State<CreateOrganization> { //defining th
     fToast.showToast(
       child: toast,
       gravity: ToastGravity.BOTTOM,
-      toastDuration: Duration(seconds: 3),
+      toastDuration: Duration(seconds: 1),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,12 +63,12 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   random_pk:
-  flutter_launcher_icons: "^0.8.0"
+#flutter_launcher_icons: "^0.8.0"
 
-flutter_icons:
-  android: "launcher_icon"
-  ios: true
-  image_path: "assets/images/talawaLogo.png"
+#flutter_icons:
+#  android: "launcher_icon"
+#  ios: true
+#  image_path: "assets/images/talawaLogo.png"
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This PR is raised to resolve the issue #529 .

Demo of changes incorporated:

https://user-images.githubusercontent.com/44184786/112686836-97ef0b00-8e9c-11eb-8804-05c01722a2a7.mp4

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
Will raise a separate PR as no test are there for the ```create_organization.dart``` file. As well as well need to wait for #519 to get merged to write complete tests.

**If relevant, did you update the documentation?**
Not needed.

**Summary**
This PR merge will resolve the issue #529 .
On clicking the button once the request to create organization is made while the button is pressed the next time during the request the user sees a toast responding the request is in progress. i.e the button ignores to create a organization if the request is made and result is waiting.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, this does not bring breaking changes.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Fixed talawa/master #529 