### PR TITLE
[BugFix] Update comment count on Newsfeed page after adding comment .

### DIFF
--- a/lib/views/pages/newsfeed/newsArticle.dart
+++ b/lib/views/pages/newsfeed/newsArticle.dart
@@ -147,7 +147,26 @@ class _NewsArticleState extends State<NewsArticle> {
   //main build starts here
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return WillPopScope(
+      onWillPop: () async{ 
+         Navigator.of(context).pop(isCommentAdded);
+         return true;
+       },
+    child: Scaffold(
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0.0,
+        leading: GestureDetector(
+          child: Icon(
+            Icons.arrow_back,
+            color: Colors.black,
+          ),
+          onTap: () {
+            Navigator.of(context).pop(isCommentAdded);
+          },
+        ),
+      ),
       resizeToAvoidBottomInset: false,
       body: Column(
         children: <Widget>[
@@ -256,7 +275,7 @@ class _NewsArticleState extends State<NewsArticle> {
           ),
         ],
       ),
-    );
+    ));
   }
 
   //this loads the comments button

--- a/lib/views/pages/newsfeed/newsfeed.dart
+++ b/lib/views/pages/newsfeed/newsfeed.dart
@@ -255,10 +255,8 @@ class _NewsFeedState extends State<NewsFeed> {
         ),
         IconButton(
             icon: Icon(Icons.comment), color: Colors.grey, onPressed: () async{
-        var refresh = await Navigator.push(context,CupertinoPageRoute(
-                    builder: (context) => NewsArticle(
-                          post: postList[index],
-                        )),
+              pushNewScreenWithRouteSettings(context,
+              screen: NewsArticle( post: postList[index],), settings: RouteSettings(),withNavBar:false
               ).then((value) {
                 if (value != null && value) {
                   getPosts();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This PR fixes #535 


**Did you add tests for your changes?**
No

**Summary**
 
The comment count was not updating on newsfeed page after adding comment. 
In this PR I have added app Bar in `newsArticle.dart` which aids in navigation as well as in refreshing the comment count.


**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

