### PR TITLE
Issue#593 solved

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.talawa"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,25 +15,24 @@ import 'controllers/auth_controller.dart';
 import 'controllers/org_controller.dart';
 import 'views/pages/organization/create_organization.dart';
 import 'views/pages/organization/switch_org_page.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 Preferences preferences = Preferences();
 String userID;
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized(); //ensuring weather the app is being initialized or not
   userID = await preferences.getUserId(); //getting user id
-  SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp])  //setting the orientation according to the screen it is running on
-      .then((_) {
-    runApp(MultiProvider(
-      providers: [
-        ChangeNotifierProvider<GraphQLConfiguration>(
-            create: (_) => GraphQLConfiguration()),
-        ChangeNotifierProvider<OrgController>(create: (_) => OrgController()),
-        ChangeNotifierProvider<AuthController>(create: (_) => AuthController()),
-        ChangeNotifierProvider<Preferences>(create: (_) => Preferences()),
-      ],
-      child: MyApp(),
-    ));
-  });
+  await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);//setting the orientation according to the screen it is running on
+  runApp(MultiProvider(
+    providers: [
+      ChangeNotifierProvider<GraphQLConfiguration>(
+          create: (_) => GraphQLConfiguration()),
+      ChangeNotifierProvider<OrgController>(create: (_) => OrgController()),
+      ChangeNotifierProvider<AuthController>(create: (_) => AuthController()),
+      ChangeNotifierProvider<Preferences>(create: (_) => Preferences()),
+    ],
+    child: MyApp(),
+  ));
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/services/preferences.dart
+++ b/lib/services/preferences.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:talawa/model/token.dart';
-
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 class Preferences with ChangeNotifier {
   static const tokenKey = "token";
   static const refreshTokenKey = "refreshTokenKey";
@@ -10,7 +10,7 @@ class Preferences with ChangeNotifier {
   static const currentOrgImgSrc = "currentOrgImgSrc";
   static const currentOrgName = "currentOrgName";
   static const orgUrl = "orgUrl";
-  static const orgImgUrl = "orgUrl";
+  static const orgImgUrl = "orgImgUrl";
   static const userFName = "userFirstName";
   static const userLName = "userLastName";
 
@@ -145,40 +145,48 @@ class Preferences with ChangeNotifier {
 
   //saves the current token
   Future saveToken(Token token) async {
-    SharedPreferences preferences = await SharedPreferences.getInstance();
+    var storage=FlutterSecureStorage();
     token.parseJwt();
-    await preferences.setString(
+    await storage.write(
+        key:
         tokenKey,
+        value:
         (token.tokenString != null && token.tokenString.length > 0)
             ? token.tokenString
             : "");
+    //print("Saved token");
   }
 
 
   //gets the current token
   Future<String> getToken() async {
-    SharedPreferences preferences = await SharedPreferences.getInstance();
-    String userToken = preferences.getString(tokenKey);
+    var storage=FlutterSecureStorage();
+    String userToken = await storage.read(key:tokenKey);
+    //print("getToken");
     return userToken;
   }
 
 
   //saves the refreshed token
   Future saveRefreshToken(Token token) async {
-    SharedPreferences preferences = await SharedPreferences.getInstance();
+    var storage=FlutterSecureStorage();
     token.parseJwt();
-    await preferences.setString(
+    await storage.write(
+        key:
         refreshTokenKey,
+        value:
         (token.tokenString != null && token.tokenString.length > 0)
             ? token.tokenString
             : "");
+    //print("Saved refresh token");
   }
 
 
   //get the refreshed token
   Future<String> getRefreshToken() async {
-    SharedPreferences preferences = await SharedPreferences.getInstance();
-    String refreshToken = preferences.getString(refreshTokenKey);
+    var storage=FlutterSecureStorage();
+    String refreshToken = await storage.read(key:refreshTokenKey);
+    //print("Got refresh token");
     return refreshToken;
   }
 
@@ -186,10 +194,12 @@ class Preferences with ChangeNotifier {
   //get the current user id
   static Future<int> getCurrentUserId() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
+    var storage=FlutterSecureStorage();
     try {
       Token token =
-          new Token(tokenString: preferences.getString(tokenKey) ?? "");
+      new Token(tokenString: await storage.read(key:tokenKey) ?? "");
       Map<String, dynamic> tokenMap = token.parseJwt();
+      //print("Got uid");
       return tokenMap['id'];
     } catch (e) {
       print(e);
@@ -201,10 +211,13 @@ class Preferences with ChangeNotifier {
   //clears the user
   static Future<bool> clearUser() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
+    var storage=FlutterSecureStorage();
     try {
-      preferences.remove(tokenKey);
+      await storage.delete(key: tokenKey);
+      //print("Delete token");
       preferences.remove(currentOrgId);
-      preferences.remove(refreshTokenKey);
+      await storage.delete(key: refreshTokenKey);
+      //print("Refresh token");
       preferences.remove(userId);
       preferences.remove(currentOrgName);
       preferences.remove(currentOrgImgSrc);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,26 +29,26 @@ dependencies:
   datetime_picker_formfield: ^1.0.0
   grouped_buttons: ^1.0.4
   provider: ^4.0.1
-  shared_preferences: ^0.5.6
+  shared_preferences: any
   adhara_socket_io: ^0.4.1
   sqflite: ^1.3.0
   graphql_flutter: ^3.0.1
   email_validator: ^1.0.4
   fluttertoast: ^7.1.8
   persistent_bottom_nav_bar: ^3.2.0
-  file_picker: ^2.1.7
+  file_picker: any
   timeline_list: ^0.0.5
   flutter_sticky_header: ^0.4.5
   filter_list: ^0.0.4
   table_calendar: ^2.2.3
   carousel_slider: ^2.2.1
   get_it: ^4.0.4
-  image_picker: ^0.6.6+5
+  image_picker: any
   flutter_password_strength: ^0.1.6
   intl: ^0.17.0
   flutter_pw_validator: ^1.2.1
   data_connection_checker: ^0.3.4
-
+  flutter_secure_storage: any
 
 
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This issue solved the security vulnerability of storing tokens in plain text. We can now store them AES encryption in android and keystore in IOS.
**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**
No
**Summary**
Storing tokens in plain text makes them vulnerable to be stolen.

**Does this PR introduce a breaking change?**
A moderately important change. As it protects tokens from being stolen from device if they are stored as plain text in shared preferences.
**Other information**
We are storing tokens in AES encryption format in android and keystore in IOS