### PR TITLE
Email and password validator in login_form.dart that was using same validating criteria in registration_form.dart has been removed 

### DIFF
--- a/lib/views/pages/login_signup/login_form.dart
+++ b/lib/views/pages/login_signup/login_form.dart
@@ -131,7 +131,7 @@ class LoginFormState extends State<LoginForm> {
                   keyboardType: TextInputType.emailAddress,
                   textAlign: TextAlign.left,
                   controller: _emailController,
-                  validator: Validator.validateEmail,
+                  validator: (value) => value.isEmpty? 'Field required' : null,
                   style: TextStyle(color: Colors.white),
                   //Changed text input action to next
                   textInputAction: TextInputAction.next,
@@ -166,7 +166,7 @@ class LoginFormState extends State<LoginForm> {
                   obscureText: _obscureText,
                   textAlign: TextAlign.left,
                   controller: _passwordController,
-                  validator: Validator.validatePassword,
+                  validator: (value) => value.isEmpty? 'Field Required' : null,
                   style: TextStyle(color: Colors.white),
                   decoration: InputDecoration(
                     enabledBorder: OutlineInputBorder(


### PR DESCRIPTION
@Sagar2366 issue #600 fixed, you can check it.

What kind of change does this PR introduce?
Fixed a bug where email and password were being validated like how they are supposed to be while registering. Refer to #496 and #600 for more details.
Login validation will now check if the field is empty or not so that unnecessary API calls are avoided as much as possible.

Does this PR introduce a breaking change?
No