### PR TITLE
Profile page now updating on joining organization and exception thrown on toast fixed.

### DIFF
--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -548,14 +548,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
         borderRadius: BorderRadius.circular(25.0),
         color: Colors.red,
       ),
-      child: Expanded(
-        child: Column(
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            Text(msg),
-          ],
-        ),
-      ),
+      child: Text(msg),
     );
 
     fToast.showToast(

--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -125,9 +125,11 @@ class _JoinOrganizationState extends State<JoinOrganization> {
     }
   }
 
-  Future joinPublicOrg() async {
+  Future joinPublicOrg(String orgName) async {
     //function which will be called if the person wants to join the organization which is not private
     GraphQLClient _client = graphQLConfiguration.authClient();
+
+    print(orgName);
 
     QueryResult result = await _client
         .mutate(MutationOptions(documentNode: gql(_query.getOrgId(itemIndex))));
@@ -135,7 +137,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
     if (result.hasException &&
         result.exception.toString().substring(16) == accessTokenException) {
       _authController.getNewToken();
-      return joinPublicOrg();
+      _exceptionToast(result.exception.toString().substring(16));
     } else if (result.hasException &&
         result.exception.toString().substring(16) != accessTokenException) {
       _exceptionToast(result.exception.toString().substring(16));
@@ -146,6 +148,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
       });
 
       //set the default organization to the first one in the list
+
       if (joinedOrg.length == 1) {
         final String currentOrgId = result.data['joinPublicOrganization']
             ['joinedOrganizations'][0]['_id'];
@@ -156,12 +159,30 @@ class _JoinOrganizationState extends State<JoinOrganization> {
         final String currentOrgName = result.data['joinPublicOrganization']
             ['joinedOrganizations'][0]['name'];
         await _pref.saveCurrentOrgName(currentOrgName);
+      } else {
+        // If there are multiple number of organizations.
+        for(int i = 0; i < joinedOrg.length; i++) {
+          if(joinedOrg[i]['name'] == orgName) {
+            final String currentOrgId = result.data['joinPublicOrganization']
+            ['joinedOrganizations'][i]['_id'];
+        await _pref.saveCurrentOrgId(currentOrgId);
+        final String currentOrgImgSrc = result.data['joinPublicOrganization']
+            ['joinedOrganizations'][i]['image'];
+        await _pref.saveCurrentOrgImgSrc(currentOrgImgSrc);
+        final String currentOrgName = result.data['joinPublicOrganization']
+            ['joinedOrganizations'][i]['name'];
+        await _pref.saveCurrentOrgName(currentOrgName);
+          }
+        }
       }
       _successToast("Sucess!");
 
       //Navigate user to newsfeed
       if (widget.fromProfile) {
-        Navigator.pop(context);
+        pushNewScreen(
+          context,
+          screen: ProfilePage(),
+        );
       } else {
         Navigator.of(context).pushReplacement(MaterialPageRoute(
           builder: (context) => HomePage(
@@ -320,7 +341,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
                                                   isPublic = 'true';
                                                 });
                                               }
-                                              confirmOrgDialog();
+                                              confirmOrgDialog(organization['name']);
                                             },
                                             color: UIData.primaryColor,
                                             child: _isLoaderActive
@@ -433,7 +454,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
                                                   isPublic = 'true';
                                                 });
                                               }
-                                              confirmOrgDialog();
+                                              confirmOrgDialog(organization['name']);
                                             },
                                             color: UIData.primaryColor,
                                             child: _isLoaderActive
@@ -471,7 +492,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
     );
   }
 
-  void confirmOrgDialog() {
+  void confirmOrgDialog(String orgName) {
     //this is the pop up shown when the confirmation is required
     showDialog(
         context: context,
@@ -494,7 +515,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
                   });
                   Navigator.of(context).pop();
                   if (isPublic == 'true') {
-                    await joinPublicOrg().whenComplete(() => setState(() {
+                    await joinPublicOrg(orgName).whenComplete(() => setState(() {
                           _isLoaderActive = false;
                         }));
                   } else if (isPublic == 'false') {

--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -175,7 +175,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
           }
         }
       }
-      _successToast("Sucess!");
+      _successToast("Success!");
 
       //Navigate user to newsfeed
       if (widget.fromProfile) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fixes: #562 

1. Fixes the below exception :
```

Expanded widgets are placed directly inside Flex widgets.
The offending Expanded is currently placed inside a Padding widget.
The ownership chain for the RenderObject that received the incompatible parent data was:
  Column ← Expanded ← Padding ← DecoratedBox ← Container ← DefaultTextStyle ←
AnimatedDefaultTextStyle ← _InkFeatures-[GlobalKey#7fd9d ink renderer] ←
NotificationListener<LayoutChangedNotification> ← PhysicalModel ← ⋯
```

2. On joining a new organization, the profile page was not updating on joining the new organization.

**Did you add tests for your changes?**

Not applicable.

**Does this PR introduce a breaking change?**

No, all the tests are passing.

https://user-images.githubusercontent.com/43968121/113582662-4554e200-9646-11eb-831d-867ee80af4c1.mp4



**Other information**

I am trying to figure out why the profile page is not updating after joining the organization. 

**Update** : Figured out why it was not updated because we were explicitly passing only the organization at index 0.
