### PR TITLE
Check added for organization id with toast telling the user if org-id is missing

### DIFF
--- a/lib/views/pages/events/addEventPage.dart
+++ b/lib/views/pages/events/addEventPage.dart
@@ -88,43 +88,51 @@ class _AddEventState extends State<AddEvent> {
 
   //method used to create an event
   Future<void> createEvent() async {
-    DateTime startTime = DateTime(
-        dateRange.start.year,
-        dateRange.start.month,
-        dateRange.start.day,
-        startEndTimes['Start Time'].hour,
-        startEndTimes['Start Time'].minute);
-    DateTime endTime = DateTime(
-        dateRange.end.year,
-        dateRange.end.month,
-        dateRange.end.day,
-        startEndTimes['End Time'].hour,
-        startEndTimes['End Time'].minute);
-
-    if (switchVals['All Day']) {
-      startEndTimes = {
-        'Start Time': DateTime(DateTime.now().year, DateTime.now().month,
-            DateTime.now().day, 12, 0),
-        'End Time': DateTime(DateTime.now().year, DateTime.now().month,
-            DateTime.now().day, 23, 59),
-      };
-    }
     final String currentOrgID = await preferences.getCurrentOrgId();
-    String mutation = Queries().addEvent(
-      organizationId: currentOrgID,
-      title: titleController.text,
-      description: descriptionController.text,
-      location: locationController.text,
-      isPublic: switchVals['Make Public'],
-      isRegisterable: switchVals['Make Registerable'],
-      recurring: switchVals['Recurring'],
-      allDay: switchVals['All Day'],
-      recurrance: recurrance,
-      startTime: startTime.microsecondsSinceEpoch.toString(),
-      endTime: endTime.microsecondsSinceEpoch.toString(),
-    );
-    Map result = await apiFunctions.gqlquery(mutation);
-    print('Result is : $result');
+    if (currentOrgID == null) {
+      Fluttertoast.showToast(
+          msg:
+              'Unable to create an event.\nJoin an organization to create an event.',
+          backgroundColor: Colors.grey[500]);
+    } else {
+      DateTime startTime = DateTime(
+          dateRange.start.year,
+          dateRange.start.month,
+          dateRange.start.day,
+          startEndTimes['Start Time'].hour,
+          startEndTimes['Start Time'].minute);
+      DateTime endTime = DateTime(
+          dateRange.end.year,
+          dateRange.end.month,
+          dateRange.end.day,
+          startEndTimes['End Time'].hour,
+          startEndTimes['End Time'].minute);
+
+      if (switchVals['All Day']) {
+        startEndTimes = {
+          'Start Time': DateTime(DateTime.now().year, DateTime.now().month,
+              DateTime.now().day, 12, 0),
+          'End Time': DateTime(DateTime.now().year, DateTime.now().month,
+              DateTime.now().day, 23, 59),
+        };
+      }
+
+      String mutation = Queries().addEvent(
+        organizationId: currentOrgID,
+        title: titleController.text,
+        description: descriptionController.text,
+        location: locationController.text,
+        isPublic: switchVals['Make Public'],
+        isRegisterable: switchVals['Make Registerable'],
+        recurring: switchVals['Recurring'],
+        allDay: switchVals['All Day'],
+        recurrance: recurrance,
+        startTime: startTime.microsecondsSinceEpoch.toString(),
+        endTime: endTime.microsecondsSinceEpoch.toString(),
+      );
+      Map result = await apiFunctions.gqlquery(mutation);
+      print('Result is : $result');
+    }
   }
 
   //main build starts from here
@@ -205,26 +213,33 @@ class _AddEventState extends State<AddEvent> {
           color: Colors.white,
         ),
         onPressed: () {
-          if(titleController.text.isEmpty || descriptionController.text.isEmpty || locationController.text.isEmpty){
-            if (titleController.text.isEmpty){
+          if (titleController.text.isEmpty ||
+              descriptionController.text.isEmpty ||
+              locationController.text.isEmpty) {
+            if (titleController.text.isEmpty) {
               setState(() {
                 _validateTitle = true;
               });
             }
-            if(descriptionController.text.isEmpty){
+            if (descriptionController.text.isEmpty) {
               setState(() {
                 _validateDescription = true;
               });
             }
-            if(locationController.text.isEmpty){
+            if (locationController.text.isEmpty) {
               setState(() {
                 _validateLocation = true;
               });
             }
-            Fluttertoast.showToast(msg: 'Fill in the empty fields', backgroundColor: Colors.grey[500]);
-          }else {
+            Fluttertoast.showToast(
+                msg: 'Fill in the empty fields',
+                backgroundColor: Colors.grey[500]);
+          } else {
             createEvent();
-            Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context)=>Events()), (route) => false);
+            Navigator.pushAndRemoveUntil(
+                context,
+                MaterialPageRoute(builder: (context) => Events()),
+                (route) => false);
           }
         });
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This PR fixes [issue#561](https://github.com/PalisadoesFoundation/talawa/issues/561).

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
No

**Summary**
I have added a check for the current organization id. If the id is null, then the user will be popped out of the add event screen and a toast will be displayed saying "Unable to create an event.\nJoin an organization to create an event."
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->