### PR TITLE
Solved image unselection bug- Issue #577

### DIFF
--- a/lib/views/pages/login_signup/register_form.dart
+++ b/lib/views/pages/login_signup/register_form.dart
@@ -37,8 +37,10 @@ class RegisterFormState extends State<RegisterForm> {
   TextEditingController _firstNameController = new TextEditingController();
   TextEditingController _lastNameController = new TextEditingController();
   TextEditingController _emailController = new TextEditingController();
-  TextEditingController _originalPasswordController = new TextEditingController();
-  TextEditingController _confirmPasswordController = new TextEditingController();
+  TextEditingController _originalPasswordController =
+      new TextEditingController();
+  TextEditingController _confirmPasswordController =
+      new TextEditingController();
   FocusNode confirmPassField = FocusNode();
   RegisterViewModel model = new RegisterViewModel();
   bool _progressBarState = false;
@@ -99,7 +101,12 @@ class RegisterFormState extends State<RegisterForm> {
       final String currentUserId = result.data['signUp']['user']['_id'];
       await _pref.saveUserId(currentUserId);
       //Navigate user to join organization screen
-      Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (context)=>JoinOrganization(fromProfile: false,)), (route) => false);
+      Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
+              builder: (context) => JoinOrganization(
+                    fromProfile: false,
+                  )),
+          (route) => false);
     }
   }
 
@@ -134,7 +141,12 @@ class RegisterFormState extends State<RegisterForm> {
       final String currentUserId = result.data['signUp']['user']['_id'];
       await _pref.saveUserId(currentUserId);
 
-      Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (context)=>JoinOrganization(fromProfile: false,)), (route) => false);
+      Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
+              builder: (context) => JoinOrganization(
+                    fromProfile: false,
+                  )),
+          (route) => false);
     }
   }
 
@@ -167,8 +179,21 @@ class RegisterFormState extends State<RegisterForm> {
                 addImage(),
                 Padding(
                   padding: const EdgeInsets.all(8.0),
-                  child: Text('Add Profile Image',
-                      style: TextStyle(fontSize: 16, color: Colors.white)),
+                  child: _image == null
+                      ? Text('Add Profile Image',
+                          style: TextStyle(fontSize: 16, color: Colors.white))
+                      : TextButton(
+                          child: Icon(
+                            Icons.delete,
+                            color: Colors.red,
+                            size: 25,
+                          ),
+                          onPressed: () {
+                            setState(() {
+                              _image = null;
+                            });
+                          },
+                        ),
                 ),
                 SizedBox(
                   height: 25,

--- a/lib/views/pages/organization/update_profile_page.dart
+++ b/lib/views/pages/organization/update_profile_page.dart
@@ -17,6 +17,7 @@ import 'package:talawa/views/pages/organization/profile_page.dart';
 
 class UpdateProfilePage extends StatefulWidget {
   final List userDetails;
+
   const UpdateProfilePage({Key key, @required this.userDetails})
       : super(key: key);
 
@@ -243,6 +244,28 @@ class _UpdateProfilePageState extends State<UpdateProfilePage> {
                   ),
                 ),
                 addImage(),
+                _image == null
+                    ? Container()
+                    : Container(
+                      child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            IconButton(
+                              icon: Icon(
+                                Icons.delete,
+                                size: 30,
+                                color: Colors.red,
+                              ),
+                              onPressed: (){
+                                setState(() {
+                                  _image=null;
+                                });
+                              },
+                            ),
+                          ],
+                        ),
+                    ),
                 SizedBox(
                   height: 30,
                 ),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This PR solves issue #577. When the user selects an image he cannot unselect it unless he back navigates.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**
No
**Summary**
When the user selects an image. A red dustbin icon will come which on being pressed will unselect the image.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
The user can now unselect previously selected image instantly