### PR TITLE
Fixes delayed appearance of new events in the events list [Fixes #660]

### DIFF
--- a/lib/views/pages/events/addEventPage.dart
+++ b/lib/views/pages/events/addEventPage.dart
@@ -9,6 +9,7 @@ import 'package:talawa/utils/apiFunctions.dart';
 import 'package:talawa/utils/uidata.dart';
 import 'package:intl/intl.dart';
 import 'package:talawa/views/pages/events/events.dart';
+import 'package:talawa/views/widgets/showProgress.dart';
 
 class AddEvent extends StatefulWidget {
   AddEvent({Key key}) : super(key: key);
@@ -204,7 +205,7 @@ class _AddEventState extends State<AddEvent> {
           Icons.check,
           color: Colors.white,
         ),
-        onPressed: () {
+        onPressed: () async {
           if(titleController.text.isEmpty || descriptionController.text.isEmpty || locationController.text.isEmpty){
             if (titleController.text.isEmpty){
               setState(() {
@@ -223,7 +224,9 @@ class _AddEventState extends State<AddEvent> {
             }
             Fluttertoast.showToast(msg: 'Fill in the empty fields', backgroundColor: Colors.grey[500]);
           }else {
-            createEvent();
+            showProgress(context, 'Creating New Event . . .', false);
+            await createEvent();
+            hideProgress();
             Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context)=>Events()), (route) => false);
           }
         });

--- a/lib/views/pages/events/events.dart
+++ b/lib/views/pages/events/events.dart
@@ -15,6 +15,7 @@ import 'package:talawa/utils/apiFunctions.dart';
 import 'package:talawa/views/pages/events/addTaskDialog.dart';
 import 'package:talawa/views/pages/events/editEventDialog.dart';
 import 'package:talawa/views/widgets/loading.dart';
+import 'package:talawa/views/widgets/showProgress.dart';
 
 //pubspec packages are called here
 import 'package:timeline_list/timeline.dart';
@@ -139,11 +140,11 @@ class _EventsState extends State<Events> {
 
   //function called to delete the event
   Future<void> _deleteEvent(context, eventId) async {
+    showProgress(context, 'Deleting Event . . .', false);
     String mutation = Queries().deleteEvent(eventId);
     Map result = await apiFunctions.gqlquery(mutation);
-    setState(() {
-      getEvents();
-    });
+    await getEvents();
+    hideProgress();
   }
 
   //function to called be called for register


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR implements a minor bug fix by adding a progress bar to the `addEventPage`. This prevents the addEvent screen to pop off before the event is created and now when the event list appears after creating an event, the new event is present in the list(unlike before where it was required to refresh the list to see the new event).

Also added `progressBar` while deleting the event to improve UX.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Summary**
Fixes #660 

**Does this PR introduce a breaking change?**
No