### PR TITLE
Fixes auto updating of all tab pages with change in current org data

### DIFF
--- a/lib/controllers/org_controller.dart
+++ b/lib/controllers/org_controller.dart
@@ -8,10 +8,12 @@ import 'package:talawa/services/preferences.dart';
 class OrgController with ChangeNotifier {
   final Preferences _pref = Preferences();
 
-  Future<void> setNewOrg(
-      BuildContext context, String newOrgId, String newOrgName) async {
+  Future<void> setNewOrg(BuildContext context, String newOrgId,
+      String newOrgName, String newOrgImgSrc) async {
     await Preferences.removeOrg();
     await _pref.saveCurrentOrgId(newOrgId);
     await _pref.saveCurrentOrgName(newOrgName);
+    await _pref.saveCurrentOrgImgSrc(newOrgImgSrc);
+    notifyListeners();
   }
 }

--- a/lib/services/preferences.dart
+++ b/lib/services/preferences.dart
@@ -78,6 +78,7 @@ class Preferences with ChangeNotifier {
   Future saveCurrentOrgName(String currName) async {
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     await preferences.setString(currentOrgName, currName);
+    notifyListeners();
   }
 
   //get the current organization name
@@ -92,6 +93,7 @@ class Preferences with ChangeNotifier {
   Future saveCurrentOrgImgSrc(String currImgSrc) async {
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     await preferences.setString(currentOrgImgSrc, currImgSrc);
+    notifyListeners();
   }
 
   //gets the current organization image source
@@ -106,6 +108,7 @@ class Preferences with ChangeNotifier {
   Future saveCurrentOrgId(String currOrgId) async {
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     await preferences.setString(currentOrgId, currOrgId);
+    notifyListeners();
   }
 
   //get the current organization id

--- a/lib/views/pages/events/events.dart
+++ b/lib/views/pages/events/events.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:provider/provider.dart';
+import 'package:talawa/controllers/org_controller.dart';
 
 //pages are imported here
 import 'package:talawa/services/preferences.dart';
@@ -47,6 +49,13 @@ class _EventsState extends State<Events> {
   Future<void> events;
   Timer timer = Timer();
   String userId;
+
+  @override
+  void didChangeDependencies() {
+    Provider.of<OrgController>(context, listen: true);
+    events = getEvents();
+    super.didChangeDependencies();
+  }
 
   @override
   void initState() {

--- a/lib/views/pages/home_page.dart
+++ b/lib/views/pages/home_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 //importing the pages here
 import 'package:provider/provider.dart';
+import 'package:talawa/controllers/org_controller.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/services/queries_.dart';
 import 'package:talawa/utils/gql_client.dart';
@@ -126,6 +127,9 @@ class _HomePageState extends State<HomePage> {
         ),
         ChangeNotifierProvider<Preferences>(
           create: (_) => Preferences(),
+        ),
+        ChangeNotifierProvider<OrgController>(
+          create: (_) => OrgController(),
         )
       ],
       child: Builder(builder: (BuildContext context) {
@@ -133,23 +137,27 @@ class _HomePageState extends State<HomePage> {
         Provider.of<GraphQLConfiguration>(rootContext, listen: false)
             .getOrgUrl();
         Provider.of<Preferences>(rootContext, listen: false).getCurrentOrgId();
-        return PersistentTabView(rootContext,
-            backgroundColor: UIData.primaryColor,
-            controller: _controller,
-            items: _navBarsItems(),
-            screens: _buildScreens(),
-            confineInSafeArea: true,
-            handleAndroidBackButtonPress: true,
-            navBarStyle: NavBarStyle.style4,
-            itemAnimationProperties: const ItemAnimationProperties(
-              duration: Duration(milliseconds: 200),
-              curve: Curves.ease,
-            ),
-            screenTransitionAnimation: const ScreenTransitionAnimation(
-              animateTabTransition: true,
-              curve: Curves.ease,
-              duration: Duration(milliseconds: 200),
-            ));
+        return Consumer<OrgController>(
+          builder: (BuildContext context, value, Widget child) {
+            return PersistentTabView(rootContext,
+                backgroundColor: UIData.primaryColor,
+                controller: _controller,
+                items: _navBarsItems(),
+                screens: _buildScreens(),
+                confineInSafeArea: true,
+                handleAndroidBackButtonPress: true,
+                navBarStyle: NavBarStyle.style4,
+                itemAnimationProperties: const ItemAnimationProperties(
+                  duration: Duration(milliseconds: 200),
+                  curve: Curves.ease,
+                ),
+                screenTransitionAnimation: const ScreenTransitionAnimation(
+                  animateTabTransition: true,
+                  curve: Curves.ease,
+                  duration: Duration(milliseconds: 200),
+                ));
+          },
+        );
       }),
     );
   }

--- a/lib/views/pages/members/members.dart
+++ b/lib/views/pages/members/members.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 //pages are called here
 import 'package:persistent_bottom_nav_bar/persistent-tab-view.dart';
 import 'package:provider/provider.dart';
+import 'package:talawa/controllers/org_controller.dart';
 import 'package:talawa/services/queries_.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/utils/gql_client.dart';
@@ -30,6 +31,13 @@ class _OrganizationsState extends State<Organizations> {
   List admins = [];
   String creatorId;
   Preferences preferences = Preferences();
+
+  @override
+  void didChangeDependencies() {
+    Provider.of<OrgController>(context, listen: true);
+    getMembers();
+    super.didChangeDependencies();
+  }
 
   //providing initial states to the variables
   @override

--- a/lib/views/pages/newsfeed/newsfeed.dart
+++ b/lib/views/pages/newsfeed/newsfeed.dart
@@ -5,6 +5,7 @@ import 'package:flutter/rendering.dart';
 //pages are imported here
 import 'package:persistent_bottom_nav_bar/persistent-tab-view.dart';
 import 'package:provider/provider.dart';
+import 'package:talawa/controllers/org_controller.dart';
 import 'package:talawa/services/queries_.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/utils/api_functions.dart';
@@ -33,10 +34,21 @@ class _NewsFeedState extends State<NewsFeed> {
   Map<String, bool> likePostMap = <String, bool>{};
   // key = postId and value will be true if user has liked a post.
 
+  @override
+  void didChangeDependencies() {
+    Provider.of<OrgController>(context, listen: true);
+    getData();
+    super.didChangeDependencies();
+  }
+
   //setting initial state to the variables
   @override
   initState() {
     super.initState();
+    getData();
+  }
+
+  getData() {
     getPosts();
     Provider.of<Preferences>(context, listen: false).getCurrentOrgId();
     scrollController.addListener(() {

--- a/lib/views/pages/organization/create_organization.dart
+++ b/lib/views/pages/organization/create_organization.dart
@@ -5,7 +5,9 @@ import 'package:flutter/services.dart';
 
 //pages are imported here
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:provider/provider.dart';
 import 'package:talawa/controllers/auth_controller.dart';
+import 'package:talawa/controllers/org_controller.dart';
 import 'package:talawa/services/queries_.dart';
 import 'package:talawa/utils/gql_client.dart';
 import 'package:talawa/utils/globals.dart';
@@ -13,7 +15,7 @@ import 'package:talawa/utils/uidata.dart';
 import 'package:talawa/utils/validator.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:graphql/utilities.dart' show multipartFileFrom;
-import 'package:file_picker/file_picker.dart';
+//import 'package:file_picker/file_picker.dart';
 import 'package:talawa/views/pages/_pages.dart';
 import 'package:image_picker/image_picker.dart';
 
@@ -98,8 +100,13 @@ class _CreateOrganizationState extends State<CreateOrganization> {
       setState(() {
         _progressBarState = true;
       });
-      _successToast("Sucess!");
-      print(result.data);
+      _successToast("Success!");
+      final currentOrg = result.data['createOrganization'];
+      Provider.of<OrgController>(context, listen: false).setNewOrg(
+          context,
+          currentOrg['_id'].toString(),
+          currentOrg['name'].toString(),
+          currentOrg['image'].toString());
 
       if (widget.isFromProfile) {
         Navigator.pop(context);
@@ -147,8 +154,14 @@ class _CreateOrganizationState extends State<CreateOrganization> {
       setState(() {
         _progressBarState = true;
       });
-      _successToast("Sucess!");
-      print(result.data);
+      _successToast("Success!");
+      print(result);
+      final currentOrg = result.data['createOrganization'];
+      Provider.of<OrgController>(context, listen: false).setNewOrg(
+          context,
+          currentOrg['_id'].toString(),
+          currentOrg['name'].toString(),
+          currentOrg['image'].toString());
       if (widget.isFromProfile) {
         Navigator.pop(context);
         Navigator.pop(context);
@@ -536,7 +549,7 @@ class _CreateOrganizationState extends State<CreateOrganization> {
     fToast.showToast(
       child: toast,
       gravity: ToastGravity.BOTTOM,
-      toastDuration: const Duration(seconds: 1),
+      toastDuration: const Duration(seconds: 20),
     );
   }
 

--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -4,9 +4,9 @@ import 'package:flutter/material.dart';
 
 //Pages are imported here
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:persistent_bottom_nav_bar/persistent-tab-view.dart';
 import 'package:provider/provider.dart';
 import 'package:talawa/controllers/auth_controller.dart';
+import 'package:talawa/controllers/org_controller.dart';
 import 'package:talawa/services/queries_.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/utils/gql_client.dart';
@@ -14,7 +14,6 @@ import 'package:talawa/utils/globals.dart';
 import 'package:talawa/utils/uidata.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:talawa/views/pages/home_page.dart';
-import 'package:talawa/views/pages/organization/profile_page.dart';
 import 'package:talawa/views/widgets/loading.dart';
 
 import 'create_organization.dart';
@@ -192,46 +191,31 @@ class _JoinOrganizationState extends State<JoinOrganization> {
       //set the default organization to the first one in the list
 
       if (joinedOrg.length == 1) {
-        final String currentOrgId = result.data['joinPublicOrganization']
-                ['joinedOrganizations'][0]['_id']
-            .toString();
-        await _pref.saveCurrentOrgId(currentOrgId);
-        final String currentOrgImgSrc = result.data['joinPublicOrganization']
-                ['joinedOrganizations'][0]['image']
-            .toString();
-        await _pref.saveCurrentOrgImgSrc(currentOrgImgSrc);
-        final String currentOrgName = result.data['joinPublicOrganization']
-                ['joinedOrganizations'][0]['name']
-            .toString();
-        await _pref.saveCurrentOrgName(currentOrgName);
+        final currentOrg =
+            result.data['joinPublicOrganization']['joinedOrganizations'][0];
+        Provider.of<OrgController>(context, listen: false).setNewOrg(
+            context,
+            currentOrg['_id'].toString(),
+            currentOrg['name'].toString(),
+            currentOrg['image'].toString());
+        //save new current org in preference
       } else {
         // If there are multiple number of organizations.
         for (int i = 0; i < joinedOrg.length; i++) {
           if (joinedOrg[i]['name'] == orgName) {
-            final String currentOrgId = result.data['joinPublicOrganization']
-                    ['joinedOrganizations'][i]['_id']
-                .toString();
-            await _pref.saveCurrentOrgId(currentOrgId);
-            final String currentOrgImgSrc = result
-                .data['joinPublicOrganization']['joinedOrganizations'][i]
-                    ['image']
-                .toString();
-            await _pref.saveCurrentOrgImgSrc(currentOrgImgSrc);
-            final String currentOrgName = result.data['joinPublicOrganization']
-                    ['joinedOrganizations'][i]['name']
-                .toString();
-            await _pref.saveCurrentOrgName(currentOrgName);
+            Provider.of<OrgController>(context, listen: false).setNewOrg(
+                context,
+                joinedOrg[i]['_id'].toString(),
+                joinedOrg[i]['name'].toString(),
+                joinedOrg[i]['image'].toString());
           }
         }
       }
       _successToast("Success!");
 
-      //Navigate user to newsfeed
+      //Navigate user to newsfeed if user not coming from profile
       if (widget.fromProfile) {
-        pushNewScreen(
-          context,
-          screen: const ProfilePage(),
-        );
+        Navigator.pop(context);
       } else {
         Navigator.of(context).pushReplacement(MaterialPageRoute(
           builder: (context) => const HomePage(

--- a/lib/views/pages/organization/organization_settings.dart
+++ b/lib/views/pages/organization/organization_settings.dart
@@ -14,7 +14,6 @@ import 'package:talawa/utils/gql_client.dart';
 import 'package:talawa/utils/globals.dart';
 import 'package:talawa/utils/uidata.dart';
 import 'package:talawa/views/pages/organization/accept_requests_page.dart';
-import 'package:talawa/views/pages/organization/profile_page.dart';
 import 'package:talawa/views/pages/organization/organization_members.dart';
 import 'package:talawa/views/widgets/alert_dialog_box.dart';
 import 'package:talawa/views/widgets/toast_tile.dart';
@@ -34,7 +33,6 @@ class _OrganizationSettingsState extends State<OrganizationSettings> {
   final Preferences _preferences = Preferences();
   final Queries _query = Queries();
   final AuthController _authController = AuthController();
-  final OrgController _orgController = OrgController();
   GraphQLConfiguration graphQLConfiguration = GraphQLConfiguration();
   FToast fToast;
   bool processing = false;
@@ -53,6 +51,7 @@ class _OrganizationSettingsState extends State<OrganizationSettings> {
     List remaindingOrg = [];
     String newOrgId;
     String newOrgName;
+    String newOrgImgSrc;
     final GraphQLClient _client = graphQLConfiguration.authClient();
     final QueryResult result = await _client.mutate(MutationOptions(
         documentNode:
@@ -82,21 +81,22 @@ class _OrganizationSettingsState extends State<OrganizationSettings> {
             newOrgName = result.data['leaveOrganization']['joinedOrganizations']
                     [0]['name']
                 .toString();
+            newOrgImgSrc = result.data['removeOrganization']
+                    ['joinedOrganizations'][0]['image']
+                .toString();
           });
         }
         processing = false;
       });
 
-      _orgController.setNewOrg(context, newOrgId, newOrgName);
-      Provider.of<Preferences>(context, listen: false)
-          .saveCurrentOrgName(newOrgName);
-      Provider.of<Preferences>(context, listen: false)
-          .saveCurrentOrgId(newOrgId);
+      Provider.of<OrgController>(context, listen: false)
+          .setNewOrg(context, newOrgId, newOrgName, newOrgImgSrc);
       _successToast('You are no longer apart of this organization');
-      pushNewScreen(
+      /*pushNewScreen(
         context,
         screen: const ProfilePage(),
-      );
+      );*/
+      Navigator.pop(context);
     }
   }
 
@@ -109,6 +109,7 @@ class _OrganizationSettingsState extends State<OrganizationSettings> {
     List remaindingOrg = [];
     String newOrgId;
     String newOrgName;
+    String newOrgImgSrc;
     final GraphQLClient _client = graphQLConfiguration.authClient();
 
     final QueryResult result = await _client
@@ -132,6 +133,8 @@ class _OrganizationSettingsState extends State<OrganizationSettings> {
             result.data['removeOrganization']['joinedOrganizations'] as List;
         if (remaindingOrg.isEmpty) {
           newOrgId = null;
+          newOrgName = null;
+          newOrgImgSrc = null;
         } else if (remaindingOrg.isNotEmpty) {
           newOrgId = result.data['removeOrganization']['joinedOrganizations'][0]
                   ['_id']
@@ -139,20 +142,16 @@ class _OrganizationSettingsState extends State<OrganizationSettings> {
           newOrgName = result.data['removeOrganization']['joinedOrganizations']
                   [0]['name']
               .toString();
+          newOrgImgSrc = result.data['removeOrganization']
+                  ['joinedOrganizations'][0]['image']
+              .toString();
         }
         processing = false;
       });
 
-      _orgController.setNewOrg(context, newOrgId, newOrgName);
-      Provider.of<Preferences>(context, listen: false)
-          .saveCurrentOrgName(newOrgName);
-      Provider.of<Preferences>(context, listen: false)
-          .saveCurrentOrgId(newOrgId);
+      Provider.of<OrgController>(context, listen: false)
+          .setNewOrg(context, newOrgId, newOrgName, newOrgImgSrc);
       Navigator.of(context).pop();
-      pushNewScreen(
-        context,
-        screen: const ProfilePage(),
-      );
     }
   }
 

--- a/lib/views/pages/organization/switch_org_page.dart
+++ b/lib/views/pages/organization/switch_org_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:persistent_bottom_nav_bar/persistent-tab-view.dart';
 import 'package:provider/provider.dart';
+import 'package:talawa/controllers/org_controller.dart';
 import 'package:talawa/services/queries_.dart';
 import 'package:talawa/services/preferences.dart';
 import 'package:talawa/utils/gql_client.dart';
@@ -94,26 +95,14 @@ class _SwitchOrganizationState extends State<SwitchOrganization> {
         _exceptionToast(result.exception.toString());
       } else if (!result.hasException) {
         _successToast("Switched to ${result.data['organizations'][0]['name']}");
-
+        final currentOrg = result.data['organizations'][0];
+        Provider.of<OrgController>(context, listen: false).setNewOrg(
+            context,
+            currentOrg['_id'].toString(),
+            currentOrg['name'].toString(),
+            currentOrg['image'].toString());
         //save new current org in preference
-        final String currentOrgId =
-            result.data['organizations'][0]['_id'].toString();
-        await _pref.saveCurrentOrgId(currentOrgId);
-        final String currentOrgImgSrc =
-            result.data['organizations'][0]['image'].toString();
-        await _pref.saveCurrentOrgImgSrc(currentOrgImgSrc);
-        final String currentOrgName =
-            result.data['organizations'][0]['name'].toString();
-        await _pref.saveCurrentOrgName(currentOrgName);
-
-        //Kill all previous stacked screen
-        Navigator.of(context).popUntil(ModalRoute.withName("/"));
-
-        //New Screen with Updated data set
-        pushNewScreen(
-          context,
-          screen: const ProfilePage(),
-        );
+        Navigator.pop(context);
       }
     }
   }

--- a/lib/views/pages/organization/update_profile_page.dart
+++ b/lib/views/pages/organization/update_profile_page.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:file_picker/file_picker.dart';
+//import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This PR fixes the issue for updating the tab bar pages on change in current organization data.
This updates the newsfeed page, members page, profile page, events page and chats page as well
The two pages ```events page```  have the same data provided by the database so they don't seem to update but internally they also do update due to same data as previous the change not noticeable.
and ```chats page``` is a static page as of now.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
Yes, tested the changes.

**If relevant, did you update the documentation?**
Not needed to update the documentation.

**Summary**
This PR fixes the issues of refreshing the pages with any change in the current organization data and displays data relevent to current org also handles the edge case when no organization is present.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no, this PR doesn't bring breaking changes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Closes #514 