### PR TITLE
Event page's DraggableScrollableSheet's animation fixed & Minor Table Calendar fix

### DIFF
--- a/lib/views/pages/events/events.dart
+++ b/lib/views/pages/events/events.dart
@@ -49,7 +49,7 @@ class _EventsState extends State<Events> {
   Future<void> events;
   Timer timer = Timer();
   String userId;
-  ScrollController listScrollController  = ScrollController();
+  ScrollController listScrollController = ScrollController();
 
   FToast fToast;
 
@@ -316,33 +316,30 @@ class _EventsState extends State<Events> {
                                           return TimelineModel(
                                             Column(
                                               mainAxisAlignment:
-                                              MainAxisAlignment.center,
+                                                  MainAxisAlignment.center,
                                               children: [
                                                 Container(
                                                   padding: EdgeInsets.symmetric(
                                                       vertical: SizeConfig
-                                                          .safeBlockVertical *
+                                                              .safeBlockVertical *
                                                           0.625),
                                                   child: Text(
                                                     '${displayedEvents.length} Events',
                                                     style: const TextStyle(
-                                                        color:
-                                                        Colors.black45),
+                                                        color: Colors.black45),
                                                   ),
                                                 ),
                                                 eventCard(index)
                                               ],
                                             ),
                                             iconBackground:
-                                            UIData.secondaryColor,
+                                                UIData.secondaryColor,
                                           );
                                         }
                                         return TimelineModel(
                                           eventCard(index),
-                                          iconBackground:
-                                          UIData.secondaryColor,
-                                          position:
-                                          TimelineItemPosition.right,
+                                          iconBackground: UIData.secondaryColor,
+                                          position: TimelineItemPosition.right,
                                         );
                                       },
                                     ),
@@ -383,22 +380,6 @@ class _EventsState extends State<Events> {
         headerStyle: const HeaderStyle(
           formatButtonShowsNext: false,
         ),
-        /*onDaySelected: (day, events) {
-          String carouselDay = DateFormat.yMMMd('en_US').format(day);
-          if (timer.isSameDay(day, now)) {
-            carouselDay = 'Today';
-          }
-          carouselController.animateToPage(1);
-          setState(() {
-            _calendarController.setSelectedDay(day);
-            dateSelected = carouselDay;
-          });
-          List currentevents = filterEventsByDay(day, events);
-          setState(() {
-            currentFilterEvents = currentevents;
-            displayedEvents = currentevents;
-          });
-        },*/
         events: thisMonthsEvents as Map<DateTime, List<dynamic>>,
         calendarController: _calendarController,
       ),
@@ -501,11 +482,6 @@ class _EventsState extends State<Events> {
               displayedEvents[index]['isRegistered'] as bool
                   ? menueText('You Are Registered')
                   : menueText('You Are Not Registered'),
-              // menueText('Starts: ' +
-              //     DateFormat.jm('en_US')
-              //         .format(DateTime.fromMicrosecondsSinceEpoch(
-              //             int.parse(displayedEvents[index]['startTime'])))
-              //         .toString()),
               ListTile(
                 trailing: ElevatedButton(
                   style: ButtonStyle(

--- a/lib/views/pages/events/events.dart
+++ b/lib/views/pages/events/events.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:sliding_up_panel/sliding_up_panel.dart';
 
 //pages are imported here
 import 'package:talawa/services/preferences.dart';
@@ -48,6 +49,7 @@ class _EventsState extends State<Events> {
   Future<void> events;
   Timer timer = Timer();
   String userId;
+  ScrollController listScrollController  = ScrollController();
 
   FToast fToast;
 
@@ -293,68 +295,61 @@ class _EventsState extends State<Events> {
                             right: 0,
                             child: calendar(),
                           ),
-                          DraggableScrollableSheet(
-                            initialChildSize: 0.3,
-                            minChildSize: 0.3,
-                            maxChildSize: 1.0,
-                            expand: true,
-                            builder:
-                                (BuildContext context, myscrollController) {
-                              return Container(
-                                color: Colors.white,
-                                child: Column(
-                                  children: [
-                                    ListView(
-                                      controller: myscrollController,
-                                      shrinkWrap: true,
-                                      children: [carouselSliderBar()],
-                                    ),
-                                    Expanded(
-                                      child: Timeline.builder(
-                                        controller: myscrollController,
-                                        lineColor: UIData.primaryColor,
-                                        position: TimelinePosition.Left,
-                                        itemCount: displayedEvents.length,
-                                        itemBuilder: (context, index) {
-                                          if (index == 0) {
-                                            return TimelineModel(
-                                              Column(
-                                                mainAxisAlignment:
-                                                    MainAxisAlignment.center,
-                                                children: [
-                                                  Container(
-                                                    padding: EdgeInsets.symmetric(
-                                                        vertical: SizeConfig
-                                                                .safeBlockVertical *
-                                                            0.625),
-                                                    child: Text(
-                                                      '${displayedEvents.length} Events',
-                                                      style: const TextStyle(
-                                                          color:
-                                                              Colors.black45),
-                                                    ),
-                                                  ),
-                                                  eventCard(index)
-                                                ],
-                                              ),
-                                              iconBackground:
-                                                  UIData.secondaryColor,
-                                            );
-                                          }
+                          SlidingUpPanel(
+                            backdropEnabled: true,
+                            panel: Container(
+                              color: Colors.white,
+                              child: Column(
+                                children: [
+                                  ListView(
+                                    controller: listScrollController,
+                                    shrinkWrap: true,
+                                    children: [carouselSliderBar()],
+                                  ),
+                                  Expanded(
+                                    child: Timeline.builder(
+                                      lineColor: UIData.primaryColor,
+                                      position: TimelinePosition.Left,
+                                      itemCount: displayedEvents.length,
+                                      itemBuilder: (context, index) {
+                                        if (index == 0) {
                                           return TimelineModel(
-                                            eventCard(index),
+                                            Column(
+                                              mainAxisAlignment:
+                                              MainAxisAlignment.center,
+                                              children: [
+                                                Container(
+                                                  padding: EdgeInsets.symmetric(
+                                                      vertical: SizeConfig
+                                                          .safeBlockVertical *
+                                                          0.625),
+                                                  child: Text(
+                                                    '${displayedEvents.length} Events',
+                                                    style: const TextStyle(
+                                                        color:
+                                                        Colors.black45),
+                                                  ),
+                                                ),
+                                                eventCard(index)
+                                              ],
+                                            ),
                                             iconBackground:
-                                                UIData.secondaryColor,
-                                            position:
-                                                TimelineItemPosition.right,
+                                            UIData.secondaryColor,
                                           );
-                                        },
-                                      ),
+                                        }
+                                        return TimelineModel(
+                                          eventCard(index),
+                                          iconBackground:
+                                          UIData.secondaryColor,
+                                          position:
+                                          TimelineItemPosition.right,
+                                        );
+                                      },
                                     ),
-                                  ],
-                                ),
-                              );
-                            },
+                                  ),
+                                ],
+                              ),
+                            ),
                           ),
                         ],
                       ),
@@ -385,6 +380,9 @@ class _EventsState extends State<Events> {
           });
         },
         calendarStyle: const CalendarStyle(markersColor: Colors.black45),
+        headerStyle: const HeaderStyle(
+          formatButtonShowsNext: false,
+        ),
         /*onDaySelected: (day, events) {
           String carouselDay = DateFormat.yMMMd('en_US').format(day);
           if (timer.isSameDay(day, now)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   sqflite: ^1.3.0
   table_calendar: ^2.2.3
   timeline_list: ^0.0.5
+  sliding_up_panel: ^1.0.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
What kind of change does this PR introduce?
Enhancement:

DraggableScrollableSheet is replaced by SlidingUpPanel for smoother animations and better UX in events.dart
Table Calendar's button that is on the top right corner shows exactly what it indicates.
i.e Calendar will show a full month while indicating a month, like in this photo.
![WhatsApp Image 2021-04-22 at 6 15 38 PM](https://user-images.githubusercontent.com/32870564/116044785-f6232f80-a68e-11eb-94eb-85f70ff4f377.jpeg)


![WhatsApp Image 2021-04-22 at 6 15 38 PM (1)](https://user-images.githubusercontent.com/32870564/116044803-f9b6b680-a68e-11eb-930c-4e54e36dfee3.jpeg)


Summary

The DraggableScrollableSheet was making the app lag when dragging the sheet up and down. SlidingUpPanel package makes it not only smoother but also better looking due to the shadow effect it gives when the sheet is dragged up. To know about the issue in more detail, check #682

The calendar button on the top right shows the format which is not true to what it shows.
Eg: 2 weeks is showing Calander of a month and the Week shows the calendar content of 2 weeks, etc.
It had to be changed because a new user can get confused as the button doesn't do what it indicates it will. For more details, check #689

Does this PR introduce a breaking change?
No


