### PR TITLE
Hiding FAB on reaching end of list

### DIFF
--- a/lib/utils/validator.dart
+++ b/lib/utils/validator.dart
@@ -14,7 +14,7 @@ class Validator {
     if (value.isEmpty) {
       return 'Firstname must not be left blank.';
     }
-    if(!regex.hasMatch(value)){
+    if (!regex.hasMatch(value)) {
       return "Invalid Firstname";
     }
     return null;
@@ -26,7 +26,7 @@ class Validator {
     if (value.isEmpty) {
       return 'Lastname must not be left blank.';
     }
-    if(!regex.hasMatch(value)){
+    if (!regex.hasMatch(value)) {
       return "Invalid Lastname";
     }
     return null;
@@ -75,7 +75,7 @@ class Validator {
     if (!regExp.hasMatch(password)) {
       return "Invalid Password";
     }
-    if(!noSpaceRegex.hasMatch(password)){
+    if (!noSpaceRegex.hasMatch(password)) {
       return "Password must not contain spaces";
     }
 

--- a/lib/view_models/page_view_model/join_organization_view_model.dart
+++ b/lib/view_models/page_view_model/join_organization_view_model.dart
@@ -40,7 +40,6 @@ class JoinOrgnizationViewModel extends BaseModel {
   List get filteredOrgInfo => _filteredOrgInfo;
   String get isPublic => _isPublic;
   String get itemIndex => _itemIndex;
-
   void initialise(BuildContext context, OrganisationFilter filter) {
     fToast = FToast();
     fToast.init(context);

--- a/lib/views/pages/login_signup/register_form.dart
+++ b/lib/views/pages/login_signup/register_form.dart
@@ -39,7 +39,8 @@ class RegisterFormState extends State<RegisterForm> {
   final TextEditingController _firstNameController = TextEditingController();
   final TextEditingController _lastNameController = TextEditingController();
   final TextEditingController _emailController = TextEditingController();
-  final TextEditingController _originalPasswordController = TextEditingController();
+  final TextEditingController _originalPasswordController =
+      TextEditingController();
   FocusNode confirmPassField = FocusNode();
   RegisterViewModel model = RegisterViewModel();
   bool _progressBarState = false;

--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -26,6 +26,42 @@ class _JoinOrganizationState extends State<JoinOrganization> {
   OrganisationFilter filter = OrganisationFilter.showAll;
   bool isFilterLoading = false;
 
+  //variable to store whether floatingActionButton is visible or not
+  bool _isVisible = true;
+  //scroll controller for the list view
+  var _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    //creating the initial state for all the variables
+    super.initState();
+    hideFloatingActionButton();
+  }
+
+  //Function for making the floating action button hide when someone scrolls to end of the list
+  void hideFloatingActionButton() {
+    _scrollController.addListener(() {
+      if (_scrollController.position.atEdge) // if the list is at one end
+          {
+        if (_scrollController.position.pixels > 0) // if the list is at the bottom end
+            {
+          if (_isVisible == true) {
+            setState(() {
+              _isVisible = false;
+            });
+          }
+        }
+      }
+      else{ // make the floating action button visible when user scrolls back up
+        if(_isVisible == false){
+          setState(() {
+            _isVisible = true;
+          });
+        }
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return BaseView<JoinOrgnizationViewModel>(
@@ -82,20 +118,23 @@ class _JoinOrganizationState extends State<JoinOrganization> {
                   ],
                 ),
               ),
-        floatingActionButton: FloatingActionButton(
-          backgroundColor: UIData.secondaryColor,
-          foregroundColor: Colors.white,
-          elevation: 5.0,
-          onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => CreateOrganization(
-                  isFromProfile: widget.fromProfile,
+        floatingActionButton: Visibility(
+          visible: _isVisible,
+          child: FloatingActionButton(
+            backgroundColor: UIData.secondaryColor,
+            foregroundColor: Colors.white,
+            elevation: 5.0,
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => CreateOrganization(
+                    isFromProfile: widget.fromProfile,
+                  ),
                 ),
-              ),
-            );
-          },
-          child: const Icon(Icons.add),
+              );
+            },
+            child: const Icon(Icons.add),
+          ),
         ),
         floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       ),
@@ -105,6 +144,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
   ListView buildJoinOrgListView(
       List<dynamic> orgList, JoinOrgnizationViewModel model) {
     return ListView.builder(
+      controller: _scrollController,
       itemCount: orgList.length,
       itemBuilder: (context, index) {
         final organization = orgList[index];

--- a/lib/views/pages/organization/join_organization.dart
+++ b/lib/views/pages/organization/join_organization.dart
@@ -35,6 +35,7 @@ class _JoinOrganizationState extends State<JoinOrganization> {
   void initState() {
     //creating the initial state for all the variables
     super.initState();
+
     hideFloatingActionButton();
   }
 
@@ -42,18 +43,19 @@ class _JoinOrganizationState extends State<JoinOrganization> {
   void hideFloatingActionButton() {
     _scrollController.addListener(() {
       if (_scrollController.position.atEdge) // if the list is at one end
-          {
-        if (_scrollController.position.pixels > 0) // if the list is at the bottom end
-            {
+      {
+        if (_scrollController.position.pixels >
+            0) // if the list is at the bottom end
+        {
           if (_isVisible == true) {
             setState(() {
               _isVisible = false;
             });
           }
         }
-      }
-      else{ // make the floating action button visible when user scrolls back up
-        if(_isVisible == false){
+      } else {
+        // make the floating action button visible when user scrolls back up
+        if (_isVisible == false) {
           setState(() {
             _isVisible = true;
           });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This PR fixes Issue #771 . The FAB on the join organisation page is hidden when the user reaches the end of the list of organisations and is made visible again when user scrolls up.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
No, I have not added tests.

**If relevant, did you update the documentation?**
No, updating the documentation was not required.

**Summary**
The Join button for last organisation was getting partly hidden by the FAB.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, it does not introduce a breaking change.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

