### PR TITLE
[Fix] RenderFlex overflow in Member details Screen

### DIFF
--- a/lib/views/pages/members/member_details.dart
+++ b/lib/views/pages/members/member_details.dart
@@ -1,13 +1,14 @@
 //flutter imported function
 import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
-
 //files are imported here
 import 'package:provider/provider.dart';
 import 'package:talawa/model/orgmemeber.dart';
 import 'package:talawa/utils/gql_client.dart';
 import 'package:talawa/utils/ui_scaling.dart';
+
 import '../../../utils/uidata.dart';
 import 'reg_eventstab.dart';
 import 'user_taskstab.dart';
@@ -79,25 +80,29 @@ class _MemberDetailState extends State<MemberDetail>
                   widget.member.image == null
                       ? defaultUserImg()
                       : userImg(widget.member.image),
-                  Card(
-                      child: Container(
-                    width: MediaQuery.of(context).size.width,
-                    padding: EdgeInsets.only(
-                        left: SizeConfig.safeBlockHorizontal * 5),
-                    alignment: Alignment.centerLeft,
-                    height: SizeConfig.safeBlockVertical * 3.75,
-                    child: Text('User email: ${widget.member.email}'),
-                  )),
-                  Card(
-                    child: Container(
+                  Flexible(
+                    child: Card(
+                        child: Container(
                       width: MediaQuery.of(context).size.width,
                       padding: EdgeInsets.only(
                           left: SizeConfig.safeBlockHorizontal * 5),
                       alignment: Alignment.centerLeft,
                       height: SizeConfig.safeBlockVertical * 3.75,
-                      child: Text(
-                        'User Privileges: ${getPrivilege(widget.member.id)}',
-                        key: const Key('Privilege'),
+                      child: Text('User email: ${widget.member.email}'),
+                    )),
+                  ),
+                  Flexible(
+                    child: Card(
+                      child: Container(
+                        width: MediaQuery.of(context).size.width,
+                        padding: EdgeInsets.only(
+                            left: SizeConfig.safeBlockHorizontal * 5),
+                        alignment: Alignment.centerLeft,
+                        height: SizeConfig.safeBlockVertical * 3.75,
+                        child: Text(
+                          'User Privileges: ${getPrivilege(widget.member.id)}',
+                          key: const Key('Privilege'),
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Fix issue #825 

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No required

**Summary**
Cards are wrapped inside the Flexible widget so, it will not generate an overflow error on any screen size.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Github Externship Application No. : `20-05_Adi500_tfa_262`