### PR TITLE
Fix: #654 Sort the Organization Names in Join_Organization Page

### DIFF
--- a/lib/views/pages/organization/Join-Organization-Widgets/org_body.dart
+++ b/lib/views/pages/organization/Join-Organization-Widgets/org_body.dart
@@ -193,6 +193,8 @@ class _OrganizationBodyState extends State<OrganizationBody> {
 
               final List organizations =
                   result.data['organizationsConnection'] as List;
+              organizations.sort((a, b) => (a['name'].toString().toLowerCase())
+                  .compareTo(b['name'].toString().toLowerCase()));
               print(organizations.length);
 
               if (organizations.isEmpty) {


### PR DESCRIPTION
Fixes #654 

Now the organization's names are in sorted order.