### PR TITLE
[GSOC] Add functionality to Edit and Delete an Event

### DIFF
--- a/lib/constants/routing_constants.dart
+++ b/lib/constants/routing_constants.dart
@@ -22,4 +22,5 @@ class Routes {
   static const String profilePage = "/profilePage";
   static const String editProfilePage = "/editProfilePage";
   static const String joinOrg = '/joinOrg';
+  static const String editEventPage = "/editEventPage";
 }

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -8,6 +8,7 @@ import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/post_service.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/services/user_config.dart';
+import 'package:talawa/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
 import 'package:talawa/utils/queries.dart';
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/create_event_view_model.dart';
@@ -73,6 +74,7 @@ void setupLocator() {
   locator.registerFactory(() => ProfilePageViewModel());
   locator.registerFactory(() => EditProfilePageViewModel());
   locator.registerFactory(() => CreateEventViewModel());
+  locator.registerFactory(() => EditEventViewModel());
 
   //Widgets viewModels
   locator.registerFactory(() => ProgressDialogViewModel());

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -92,10 +92,14 @@ Route<dynamic> generateRoute(RouteSettings settings) {
       return MaterialPageRoute(
           builder: (context) => const ExploreEvents(key: Key('ExploreEvents')));
     case Routes.eventInfoPage:
-      final Event event = settings.arguments! as Event;
+      final Map<String, dynamic> args =
+          settings.arguments! as Map<String, dynamic>;
+      //  final Event event = settings.arguments! as Event;
       return MaterialPageRoute(
-        builder: (context) =>
-            EventInfoPage(key: const Key('EventInfo'), event: event),
+        builder: (context) => EventInfoPage(
+          key: const Key('EventInfo'),
+          agrs: args,
+        ),
       );
     case Routes.createEventPage:
       return MaterialPageRoute(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -94,7 +94,6 @@ Route<dynamic> generateRoute(RouteSettings settings) {
     case Routes.eventInfoPage:
       final Map<String, dynamic> args =
           settings.arguments! as Map<String, dynamic>;
-      //  final Event event = settings.arguments! as Event;
       return MaterialPageRoute(
         builder: (context) => EventInfoPage(
           key: const Key('EventInfo'),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -7,6 +7,7 @@ import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/models/post/post_model.dart';
 import 'package:talawa/splash_screen.dart';
 import 'package:talawa/views/after_auth_screens/events/create_event_page.dart';
+import 'package:talawa/views/after_auth_screens/events/edit_event_page.dart';
 import 'package:talawa/views/after_auth_screens/events/event_info_page.dart';
 import 'package:talawa/views/after_auth_screens/events/explore_events.dart';
 import 'package:talawa/views/after_auth_screens/feed/individual_post.dart';
@@ -109,6 +110,13 @@ Route<dynamic> generateRoute(RouteSettings settings) {
       return MaterialPageRoute(
           builder: (context) => const JoinOrganisationAfterAuth(
               key: Key('JoinOrganisationAfterAuth')));
+    case Routes.editEventPage:
+      final Event event = settings.arguments! as Event;
+      return MaterialPageRoute(
+          builder: (context) => EditEventPage(
+                key: const Key('EditEvent'),
+                event: event,
+              ));
     default:
       return MaterialPageRoute(
           builder: (context) => const DemoPageView(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -116,10 +116,11 @@ Route<dynamic> generateRoute(RouteSettings settings) {
     case Routes.editEventPage:
       final Event event = settings.arguments! as Event;
       return MaterialPageRoute(
-          builder: (context) => EditEventPage(
-                key: const Key('EditEvent'),
-                event: event,
-              ));
+        builder: (context) => EditEventPage(
+          key: const Key('EditEvent'),
+          event: event,
+        ),
+      );
     default:
       return MaterialPageRoute(
           builder: (context) => const DemoPageView(

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -75,6 +75,23 @@ class EventService {
     }
   }
 
+  Future<void> editEvent(
+      {required String eventId,
+      required Map<String, dynamic> variables}) async {
+    navigationService
+        .pushDialog(const CustomProgressDialog(key: Key('EditEventProgress')));
+    final tokenResult = await _dbFunctions
+        .refreshAccessToken(userConfig.currentUser.refreshToken!);
+    debugPrint(tokenResult.toString());
+    final result = await _dbFunctions.gqlAuthMutation(
+        EventQueries().updateEvent(eventId: eventId),
+        variables: variables);
+    navigationService.pop();
+    if (result != null) {
+      navigationService.removeAllAndPush('/mainScreen', '/');
+    }
+  }
+
   void dispose() {
     _currentOrganizationStreamSubscription.cancel();
   }

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 
-import 'package:intl/intl.dart';
+import 'package:flutter/material.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/services/database_mutation_functions.dart';
 import 'package:talawa/services/user_config.dart';
 import 'package:talawa/utils/event_queries.dart';
+import 'package:talawa/widgets/custom_progress_dialog.dart';
 
 class EventService {
   EventService() {
@@ -22,54 +23,26 @@ class EventService {
   late StreamSubscription _currentOrganizationStreamSubscription;
   late Stream<Event> _eventStream;
 
-  final List<Event> _events = [];
   final StreamController<Event> _eventStreamController =
       StreamController<Event>();
   Stream<Event> get eventStream => _eventStream;
-  // ignore: prefer_final_fields
-  Set<String> _ids = {};
 
   void setOrgStreamSubscription() {
     _currentOrganizationStreamSubscription =
         _userConfig.currentOrfInfoStream.listen((updatedOrganization) {
       _currentOrg = updatedOrganization;
-      _events.clear();
-      _ids.clear();
-      getEvents();
     });
   }
 
   Future<void> getEvents() async {
     final String currentOrgID = _currentOrg.id!;
-    _dbFunctions.init();
     final String mutation = EventQueries().fetchOrgEvents(currentOrgID);
-
     final result = await _dbFunctions.gqlAuthMutation(mutation);
-    if (result.data!["events"] == null) return;
+    if (result == null) return;
     final List eventsJson = result.data!["events"] as List;
     eventsJson.forEach((eventJsonData) {
       final Event event = Event.fromJson(eventJsonData as Map<String, dynamic>);
-      if (!_ids.contains(event.id)) {
-        _ids.add(event.id!);
-        _events.add(event);
-      }
-    });
-
-    _events.removeWhere(
-      (element) =>
-          int.tryParse(element.startTime!) == null ||
-          int.tryParse(element.endTime!) == null ||
-          element.organization!.id != _currentOrg.id,
-    );
-    _events.sort((a, b) {
-      return DateTime.fromMicrosecondsSinceEpoch(int.parse(a.startTime!))
-          .compareTo(
-              DateTime.fromMicrosecondsSinceEpoch(int.parse(b.startTime!)));
-    });
-    _parseEventDateTime();
-
-    _events.forEach((element) {
-      _eventStreamController.add(element);
+      _eventStreamController.add(event);
     });
   }
 
@@ -85,19 +58,21 @@ class EventService {
     print(result);
   }
 
-  void _parseEventDateTime() {
-    _events.forEach((element) {
-      final DateTime _startDate =
-          DateTime.fromMicrosecondsSinceEpoch(int.parse(element.startTime!))
-              .toLocal();
-      final DateTime _endDate =
-          DateTime.fromMicrosecondsSinceEpoch(int.parse(element.endTime!))
-              .toLocal();
-      element.startDate = DateFormat('yMd').format(_startDate);
-      element.endDate = DateFormat('yMd').format(_endDate);
-      element.startTime = DateFormat.jm().format(_startDate);
-      element.endTime = DateFormat.jm().format(_endDate);
-    });
+  Future<void> deleteEvent(String eventId) async {
+    navigationService.pushDialog(
+        const CustomProgressDialog(key: Key('DeleteEventProgress')));
+    final tokenResult = await _dbFunctions
+        .refreshAccessToken(userConfig.currentUser.refreshToken!);
+    debugPrint(tokenResult.toString());
+    final result = await _dbFunctions.gqlAuthMutation(
+      EventQueries().deleteEvent(eventId),
+    );
+    navigationService.pop();
+    if (result != null) {
+      await getEvents();
+      print(result);
+      navigationService.pop();
+    }
   }
 
   void dispose() {

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -58,7 +58,7 @@ class EventService {
     print(result);
   }
 
-  Future<void> deleteEvent(String eventId) async {
+  Future<dynamic> deleteEvent(String eventId) async {
     navigationService.pushDialog(
         const CustomProgressDialog(key: Key('DeleteEventProgress')));
     final tokenResult = await _dbFunctions
@@ -68,11 +68,7 @@ class EventService {
       EventQueries().deleteEvent(eventId),
     );
     navigationService.pop();
-    if (result != null) {
-      await getEvents();
-      print(result);
-      navigationService.pop();
-    }
+    return result;
   }
 
   Future<void> editEvent(

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -74,8 +74,11 @@ class EventService {
   Future<void> editEvent(
       {required String eventId,
       required Map<String, dynamic> variables}) async {
-    navigationService
-        .pushDialog(const CustomProgressDialog(key: Key('EditEventProgress')));
+    navigationService.pushDialog(
+      const CustomProgressDialog(
+        key: Key('EditEventProgress'),
+      ),
+    );
     final tokenResult = await _dbFunctions
         .refreshAccessToken(userConfig.currentUser.refreshToken!);
     debugPrint(tokenResult.toString());

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -23,6 +23,7 @@ class MultiMediaPickerService {
 
   Future<File?> getPhotoFromGallery({bool camera = false}) async {
     try {
+      // ignore: deprecated_member_use
       final _image = await _picker.getImage(
           source: camera ? ImageSource.camera : ImageSource.gallery);
       if (_image != null) return File(_image.path);

--- a/lib/utils/event_queries.dart
+++ b/lib/utils/event_queries.dart
@@ -92,4 +92,39 @@ class EventQueries {
         }
     """;
   }
+
+  String updateEvent({
+    eventId,
+  }) {
+    return """mutation updateEvent( 
+        \$title:String!,
+        \$description: String!,
+        \$startTime: String,
+        \$endTime: String,
+        \$allDay: Boolean!,
+        \$recurring: Boolean!,
+        \$isPublic: Boolean!,
+        \$isRegisterable: Boolean!,
+        \$location: String,
+      ) {
+      updateEvent(
+         id: "$eventId"
+         data:{
+           title: \$title,
+           description: \$description,
+           isPublic: \$isPublic,
+           isRegisterable: \$isRegisterable,
+           recurring: \$recurring,
+           allDay: \$allDay,
+           startTime: \$startTime
+           endTime: \$endTime
+           location: \$location
+         }
+         ){
+            _id
+            title
+            description
+          }
+      }""";
+  }
 }

--- a/lib/utils/event_queries.dart
+++ b/lib/utils/event_queries.dart
@@ -80,4 +80,16 @@ class EventQueries {
     }
   """;
   }
+
+  String deleteEvent(String id) {
+    return """
+      mutation {
+        removeEvent(
+          id: "$id",
+          ){
+            _id
+          }
+        }
+    """;
+  }
 }

--- a/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
@@ -59,11 +59,12 @@ class EditEventViewModel extends BaseModel {
           eventStartTime.hour,
           eventStartTime.minute);
       final DateTime endTime = DateTime(
-          eventStartDate.year,
-          eventStartDate.month,
-          eventStartDate.day,
-          eventEndTime.hour,
-          eventEndTime.minute);
+        eventStartDate.year,
+        eventStartDate.month,
+        eventStartDate.day,
+        eventEndTime.hour,
+        eventEndTime.minute,
+      );
       final Map<String, dynamic> variables = {
         'title': eventTitleTextController.text,
         'description': eventDescriptionTextController.text,

--- a/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:talawa/locator.dart';
-import 'package:talawa/models/organization/org_info.dart';
-import 'package:talawa/services/database_mutation_functions.dart';
+import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/services/event_service.dart';
-import 'package:talawa/services/user_config.dart';
-import 'package:talawa/utils/event_queries.dart';
 import 'package:talawa/view_model/base_view_model.dart';
-import 'package:talawa/widgets/custom_progress_dialog.dart';
 
-class CreateEventViewModel extends BaseModel {
+class EditEventViewModel extends BaseModel {
+  late Event _event;
   TextEditingController eventTitleTextController = TextEditingController();
   TextEditingController eventLocationTextController = TextEditingController();
   TextEditingController eventDescriptionTextController =
@@ -26,34 +24,47 @@ class CreateEventViewModel extends BaseModel {
   final formKey = GlobalKey<FormState>();
 
   final _eventService = locator<EventService>();
-  final _dbFunctions = locator<DataBaseMutationFunctions>();
   AutovalidateMode validate = AutovalidateMode.disabled;
 
-  late OrgInfo _currentOrg;
-  final _userConfig = locator<UserConfig>();
-
-  initialize() {
-    _currentOrg = _userConfig.currentOrg;
+  initialize(Event event) {
+    _event = event;
+    _fillEditForm();
   }
 
-  Future<void> createEvent() async {
+  void _fillEditForm() {
+    eventTitleTextController.text = _event.title!;
+    eventLocationTextController.text = _event.location!;
+    eventDescriptionTextController.text = _event.description!;
+    isPublicSwitch = _event.isPublic!;
+    isRegisterableSwitch = _event.isRegisterable!;
+    eventStartDate = DateFormat().add_yMd().parse(_event.startDate!);
+    eventEndDate = DateFormat().add_yMd().parse(_event.endDate!);
+    eventStartTime =
+        TimeOfDay.fromDateTime(DateFormat("h:mm a").parse(_event.startTime!));
+    eventEndTime =
+        TimeOfDay.fromDateTime(DateFormat("h:mm a").parse(_event.endTime!));
+  }
+
+  Future<void> updateEvent() async {
     titleFocus.unfocus();
     locationFocus.unfocus();
     descriptionFocus.unfocus();
     validate = AutovalidateMode.always;
     if (formKey.currentState!.validate()) {
       validate = AutovalidateMode.disabled;
-
-      final DateTime startDate = eventStartDate;
-      final DateTime endDate = eventEndDate;
-      final DateTime startTime = DateTime(startDate.year, startDate.month,
-          startDate.day, eventStartTime.hour, eventStartTime.minute);
-      final DateTime endTime = DateTime(endDate.year, endDate.month,
-          endDate.day, eventEndTime.hour, eventEndTime.minute);
+      final DateTime startTime = DateTime(
+          eventStartDate.year,
+          eventStartDate.month,
+          eventStartDate.day,
+          eventStartTime.hour,
+          eventStartTime.minute);
+      final DateTime endTime = DateTime(
+          eventStartDate.year,
+          eventStartDate.month,
+          eventStartDate.day,
+          eventEndTime.hour,
+          eventEndTime.minute);
       final Map<String, dynamic> variables = {
-        'startDate': startDate.toString(),
-        'endDate': endDate.toString(),
-        'organizationId': _currentOrg.id!,
         'title': eventTitleTextController.text,
         'description': eventDescriptionTextController.text,
         'location': eventLocationTextController.text,
@@ -64,23 +75,7 @@ class CreateEventViewModel extends BaseModel {
         'startTime': startTime.microsecondsSinceEpoch.toString(),
         'endTime': endTime.microsecondsSinceEpoch.toString(),
       };
-
-      navigationService.pushDialog(
-          const CustomProgressDialog(key: Key('EventCreationProgress')));
-      final tokenResult = await _dbFunctions
-          .refreshAccessToken(userConfig.currentUser.refreshToken!);
-      print(tokenResult);
-      final result = await _dbFunctions.gqlAuthMutation(
-        EventQueries().addEvent(),
-        variables: variables,
-      );
-      navigationService.pop();
-      print('Result is : $result');
-      if (result != null) {
-        navigationService.pop();
-
-        _eventService.getEvents();
-      }
+      _eventService.editEvent(eventId: _event.id!, variables: variables);
     }
   }
 }

--- a/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:intl/intl.dart';
 import 'package:talawa/enums/enums.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
@@ -12,9 +13,11 @@ class ExploreEventsViewModel extends BaseModel {
 
   String _chosenValue = 'My Events';
   List<Event> _events = [];
-
+  final Set<String> _uniqueEventIds = {};
   late StreamSubscription _currentOrganizationStreamSubscription;
   late final List<Event> _bufferEvents;
+  List<Event> get events => _events;
+  EventService get eventService => _eventService;
 
   String get chosenValue => _chosenValue;
   choseValue(String value) {
@@ -38,32 +41,58 @@ class ExploreEventsViewModel extends BaseModel {
     }
   }
 
-  List<Event> get events => _events;
-
   void fetchNewEvents() {
+    notifyListeners();
     _eventService.getEvents();
   }
 
   void refreshEvents() {
     _events.clear();
+    _uniqueEventIds.clear();
     notifyListeners();
+    _eventService.getEvents();
   }
 
-  void initialise() {
+  Future<void> initialise() async {
     setState(ViewState.busy);
 
     _currentOrganizationStreamSubscription = userConfig.currentOrfInfoStream
         .listen((updatedOrganization) => refreshEvents());
-    _eventStreamSubscription =
-        _eventService.eventStream.listen((newEvent) => addNewEvent(newEvent));
-    _eventService.getEvents();
+    await _eventService.getEvents();
+
+    _eventStreamSubscription = _eventService.eventStream
+        .listen((newEvent) => checkIfExistsAndAddNewEvent(newEvent));
     _bufferEvents = _events;
     setState(ViewState.idle);
   }
 
+  void checkIfExistsAndAddNewEvent(Event newEvent) {
+    if ((!_uniqueEventIds.contains(newEvent.id)) &&
+        (int.tryParse(newEvent.startTime!) != null ||
+            int.tryParse(newEvent.endTime!) != null) &&
+        (newEvent.organization!.id == userConfig.currentOrg.id)) {
+      _uniqueEventIds.add(newEvent.id!);
+      _parseEventDateTime(newEvent);
+      notifyListeners();
+    }
+  }
+
+  void _parseEventDateTime(Event newEvent) {
+    final DateTime _startDate =
+        DateTime.fromMicrosecondsSinceEpoch(int.parse(newEvent.startTime!))
+            .toLocal();
+    final DateTime _endDate =
+        DateTime.fromMicrosecondsSinceEpoch(int.parse(newEvent.endTime!))
+            .toLocal();
+    newEvent.startDate = DateFormat('yMd').format(_startDate);
+    newEvent.endDate = DateFormat('yMd').format(_endDate);
+    newEvent.startTime = DateFormat.jm().format(_startDate);
+    newEvent.endTime = DateFormat.jm().format(_endDate);
+    _events.insert(0, newEvent);
+  }
+
   @override
   void dispose() {
-    // Canceling the subscription so that there will be no rebuild after the widget is disposed.
     _eventStreamSubscription.cancel();
     _currentOrganizationStreamSubscription.cancel();
     super.dispose();
@@ -71,6 +100,7 @@ class ExploreEventsViewModel extends BaseModel {
 
   addNewEvent(Event newEvent) {
     _events.insert(0, newEvent);
+    print(_events.length);
     notifyListeners();
   }
 }

--- a/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
@@ -91,6 +91,17 @@ class ExploreEventsViewModel extends BaseModel {
     _events.insert(0, newEvent);
   }
 
+  Future<void> deleteEvent({required String eventId}) async {
+    final result = await _eventService.deleteEvent(eventId);
+    if (result != null) {
+      navigationService.pop();
+      print(result);
+      _uniqueEventIds.remove(eventId);
+      _events.removeWhere((element) => element.id == eventId);
+      notifyListeners();
+    }
+  }
+
   @override
   void dispose() {
     _eventStreamSubscription.cancel();

--- a/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
@@ -61,8 +61,9 @@ class ExploreEventsViewModel extends BaseModel {
         .listen((updatedOrganization) => refreshEvents());
     await _eventService.getEvents();
 
-    _eventStreamSubscription = _eventService.eventStream
-        .listen((newEvent) => checkIfExistsAndAddNewEvent(newEvent));
+    _eventStreamSubscription = _eventService.eventStream.listen(
+      (newEvent) => checkIfExistsAndAddNewEvent(newEvent),
+    );
     _bufferEvents = _events;
     setState(ViewState.idle);
   }
@@ -79,12 +80,12 @@ class ExploreEventsViewModel extends BaseModel {
   }
 
   void _parseEventDateTime(Event newEvent) {
-    final DateTime _startDate =
-        DateTime.fromMicrosecondsSinceEpoch(int.parse(newEvent.startTime!))
-            .toLocal();
-    final DateTime _endDate =
-        DateTime.fromMicrosecondsSinceEpoch(int.parse(newEvent.endTime!))
-            .toLocal();
+    final DateTime _startDate = DateTime.fromMicrosecondsSinceEpoch(
+      int.parse(newEvent.startTime!),
+    ).toLocal();
+    final DateTime _endDate = DateTime.fromMicrosecondsSinceEpoch(
+      int.parse(newEvent.endTime!),
+    ).toLocal();
     newEvent.startDate = DateFormat('yMd').format(_startDate);
     newEvent.endDate = DateFormat('yMd').format(_endDate);
     newEvent.startTime = DateFormat.jm().format(_startDate);
@@ -93,23 +94,27 @@ class ExploreEventsViewModel extends BaseModel {
   }
 
   Future<void> deleteEvent({required String eventId}) async {
-    navigationService.pushDialog(CustomAlertDialog(
-      reverse: true,
-      dialogSubTitle: 'Are you sure you want to delete this event?',
-      successText: 'Delete',
-      success: () {
-        navigationService.pop();
-        _eventService.deleteEvent(eventId).then((result) {
-          if (result != null) {
-            navigationService.pop();
-            print(result);
-            _uniqueEventIds.remove(eventId);
-            _events.removeWhere((element) => element.id == eventId);
-            notifyListeners();
-          }
-        });
-      },
-    ));
+    navigationService.pushDialog(
+      CustomAlertDialog(
+        reverse: true,
+        dialogSubTitle: 'Are you sure you want to delete this event?',
+        successText: 'Delete',
+        success: () {
+          navigationService.pop();
+          _eventService.deleteEvent(eventId).then(
+            (result) {
+              if (result != null) {
+                navigationService.pop();
+                print(result);
+                _uniqueEventIds.remove(eventId);
+                _events.removeWhere((element) => element.id == eventId);
+                notifyListeners();
+              }
+            },
+          );
+        },
+      ),
+    );
   }
 
   @override

--- a/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart
@@ -6,6 +6,7 @@ import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/services/event_service.dart';
 import 'package:talawa/view_model/base_view_model.dart';
+import 'package:talawa/widgets/custom_alert_dialog.dart';
 
 class ExploreEventsViewModel extends BaseModel {
   final _eventService = locator<EventService>();
@@ -92,14 +93,23 @@ class ExploreEventsViewModel extends BaseModel {
   }
 
   Future<void> deleteEvent({required String eventId}) async {
-    final result = await _eventService.deleteEvent(eventId);
-    if (result != null) {
-      navigationService.pop();
-      print(result);
-      _uniqueEventIds.remove(eventId);
-      _events.removeWhere((element) => element.id == eventId);
-      notifyListeners();
-    }
+    navigationService.pushDialog(CustomAlertDialog(
+      reverse: true,
+      dialogSubTitle: 'Are you sure you want to delete this event?',
+      successText: 'Delete',
+      success: () {
+        navigationService.pop();
+        _eventService.deleteEvent(eventId).then((result) {
+          if (result != null) {
+            navigationService.pop();
+            print(result);
+            _uniqueEventIds.remove(eventId);
+            _events.removeWhere((element) => element.id == eventId);
+            notifyListeners();
+          }
+        });
+      },
+    ));
   }
 
   @override

--- a/lib/views/after_auth_screens/events/edit_event_page.dart
+++ b/lib/views/after_auth_screens/events/edit_event_page.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:talawa/locator.dart';
+import 'package:talawa/models/events/event_model.dart';
+import 'package:talawa/services/size_config.dart';
+import 'package:talawa/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart';
+import 'package:talawa/views/after_auth_screens/events/edit_events_form.dart';
+import 'package:talawa/views/base_view.dart';
+import 'package:talawa/widgets/date_time_picker.dart';
+import 'package:talawa/widgets/event_date_time_tile.dart';
+
+class EditEventPage extends StatefulWidget {
+  const EditEventPage({Key? key, required this.event}) : super(key: key);
+  final Event event;
+
+  @override
+  _EditEventPageState createState() => _EditEventPageState();
+}
+
+class _EditEventPageState extends State<EditEventPage> {
+  @override
+  Widget build(BuildContext context) {
+    final TextStyle _subtitleTextStyle =
+        Theme.of(context).textTheme.headline5!.copyWith(fontSize: 16);
+    return BaseView<EditEventViewModel>(
+        onModelReady: (model) => model.initialize(widget.event),
+        builder: (context, model, child) {
+          return Scaffold(
+            appBar: AppBar(
+              elevation: 1,
+              centerTitle: true,
+              leading: GestureDetector(
+                  onTap: () {
+                    navigationService.pop();
+                  },
+                  child: const Icon(Icons.close)),
+              title: Text(
+                'Edit Event',
+                style: Theme.of(context).textTheme.headline6!.copyWith(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 20,
+                    ),
+              ),
+              actions: [
+                TextButton(
+                    onPressed: () {
+                      model.updateEvent();
+                    },
+                    child: Text(
+                      'Done',
+                      style: Theme.of(context).textTheme.bodyText1!.copyWith(
+                          fontSize: 16, color: Theme.of(context).accentColor),
+                    )),
+              ],
+            ),
+            body: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(15),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(
+                          Icons.image,
+                        ),
+                        SizedBox(
+                          width: SizeConfig.screenWidth! * 0.036,
+                        ),
+                        TextButton(
+                            onPressed: () {},
+                            child: Text("Add Image", style: _subtitleTextStyle))
+                      ],
+                    ),
+                    const Divider(),
+                    EditEventForm(
+                      model: model,
+                    ),
+                    SizedBox(
+                      height: SizeConfig.screenHeight! * 0.013,
+                    ),
+                    const Divider(),
+                    Text('Select Start Date and Time',
+                        style: _subtitleTextStyle),
+                    SizedBox(
+                      height: SizeConfig.screenHeight! * 0.013,
+                    ),
+                    DateTimeTile(
+                        child: Row(
+                      children: [
+                        const Icon(
+                          Icons.calendar_today,
+                          color: Color(0xff524F4F),
+                          size: 19,
+                        ),
+                        SizedBox(
+                          width: SizeConfig.screenWidth! * 0.045,
+                        ),
+                        GestureDetector(
+                          onTap: () async {
+                            final _date = await customDatePicker(
+                                initialDate: model.eventStartDate);
+                            setState(() {
+                              model.eventStartDate = _date;
+                            });
+                          },
+                          child: Text(
+                            "${model.eventStartDate.toLocal()}".split(' ')[0],
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                        ),
+                        const Spacer(),
+                        const Icon(
+                          Icons.schedule,
+                          color: Color(0xff524F4F),
+                          size: 19,
+                        ),
+                        SizedBox(
+                          width: SizeConfig.screenWidth! * 0.045,
+                        ),
+                        GestureDetector(
+                          onTap: () async {
+                            final _time = await customTimePicker(
+                                initialTime: model.eventStartTime);
+
+                            setState(() {
+                              model.eventStartTime = _time;
+                            });
+                          },
+                          child: Text(
+                            model.eventStartTime.format(context),
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                        ),
+                      ],
+                    )),
+                    SizedBox(
+                      height: SizeConfig.screenHeight! * 0.026,
+                    ),
+                    Text(
+                      'Select End Date and Time',
+                      style: Theme.of(context)
+                          .textTheme
+                          .headline5!
+                          .copyWith(fontSize: 16),
+                    ),
+                    SizedBox(
+                      height: SizeConfig.screenHeight! * 0.013,
+                    ),
+                    DateTimeTile(
+                      child: Row(
+                        children: [
+                          const Icon(
+                            Icons.calendar_today,
+                            color: Color(0xff524F4F),
+                            size: 19,
+                          ),
+                          SizedBox(
+                            width: SizeConfig.screenWidth! * 0.045,
+                          ),
+                          GestureDetector(
+                            onTap: () async {
+                              final _date = await customDatePicker(
+                                  initialDate: model.eventEndDate);
+                              setState(() {
+                                model.eventEndDate = _date;
+                              });
+                            },
+                            child: Text(
+                              "${model.eventEndDate.toLocal()}".split(' ')[0],
+                              style: const TextStyle(fontSize: 16),
+                            ),
+                          ),
+                          const Spacer(),
+                          const Icon(
+                            Icons.schedule,
+                            color: Color(0xff524F4F),
+                            size: 19,
+                          ),
+                          SizedBox(
+                            width: SizeConfig.screenWidth! * 0.045,
+                          ),
+                          GestureDetector(
+                            onTap: () async {
+                              final _time = await customTimePicker(
+                                  initialTime: model.eventEndTime);
+
+                              setState(() {
+                                model.eventEndTime = _time;
+                              });
+                            },
+                            child: Text(
+                              model.eventEndTime.format(context),
+                              style: const TextStyle(fontSize: 16),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      height: SizeConfig.screenHeight! * 0.026,
+                    ),
+                    Row(
+                      children: [
+                        const Icon(Icons.restore),
+                        SizedBox(
+                          width: SizeConfig.screenWidth! * 0.045,
+                        ),
+                        Text('Does not repeat', style: _subtitleTextStyle)
+                      ],
+                    ),
+                    SizedBox(
+                      height: SizeConfig.screenHeight! * 0.026,
+                    ),
+                    const Divider(),
+                    Row(
+                      children: [
+                        Text('Keep Public', style: _subtitleTextStyle),
+                        SizedBox(
+                          width: SizeConfig.screenWidth! * 0.005,
+                        ),
+                        Switch(
+                          value: model.isPublicSwitch,
+                          onChanged: (value) {
+                            setState(() {
+                              model.isPublicSwitch = value;
+                              print(model.isPublicSwitch);
+                            });
+                          },
+                          activeColor: Theme.of(context).colorScheme.primary,
+                        ),
+                        const Spacer(),
+                        Text('Keep Registerable', style: _subtitleTextStyle),
+                        SizedBox(
+                          width: SizeConfig.screenWidth! * 0.005,
+                        ),
+                        Switch(
+                          value: model.isRegisterableSwitch,
+                          onChanged: (value) {
+                            setState(() {
+                              model.isRegisterableSwitch = value;
+                              print(model.isRegisterableSwitch);
+                            });
+                          },
+                          activeColor: Theme.of(context).colorScheme.primary,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        });
+  }
+}

--- a/lib/views/after_auth_screens/events/edit_event_page.dart
+++ b/lib/views/after_auth_screens/events/edit_event_page.dart
@@ -22,70 +22,70 @@ class _EditEventPageState extends State<EditEventPage> {
     final TextStyle _subtitleTextStyle =
         Theme.of(context).textTheme.headline5!.copyWith(fontSize: 16);
     return BaseView<EditEventViewModel>(
-        onModelReady: (model) => model.initialize(widget.event),
-        builder: (context, model, child) {
-          return Scaffold(
-            appBar: AppBar(
-              elevation: 1,
-              centerTitle: true,
-              leading: GestureDetector(
-                  onTap: () {
-                    navigationService.pop();
-                  },
-                  child: const Icon(Icons.close)),
-              title: Text(
-                'Edit Event',
-                style: Theme.of(context).textTheme.headline6!.copyWith(
-                      fontWeight: FontWeight.w600,
-                      fontSize: 20,
-                    ),
-              ),
-              actions: [
-                TextButton(
-                    onPressed: () {
-                      model.updateEvent();
-                    },
-                    child: Text(
-                      'Done',
-                      style: Theme.of(context).textTheme.bodyText1!.copyWith(
-                          fontSize: 16, color: Theme.of(context).accentColor),
-                    )),
-              ],
+      onModelReady: (model) => model.initialize(widget.event),
+      builder: (context, model, child) {
+        return Scaffold(
+          appBar: AppBar(
+            elevation: 1,
+            centerTitle: true,
+            leading: GestureDetector(
+                onTap: () {
+                  navigationService.pop();
+                },
+                child: const Icon(Icons.close)),
+            title: Text(
+              'Edit Event',
+              style: Theme.of(context).textTheme.headline6!.copyWith(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 20,
+                  ),
             ),
-            body: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.all(15),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        const Icon(
-                          Icons.image,
-                        ),
-                        SizedBox(
-                          width: SizeConfig.screenWidth! * 0.036,
-                        ),
-                        TextButton(
-                            onPressed: () {},
-                            child: Text("Add Image", style: _subtitleTextStyle))
-                      ],
-                    ),
-                    const Divider(),
-                    EditEventForm(
-                      model: model,
-                    ),
-                    SizedBox(
-                      height: SizeConfig.screenHeight! * 0.013,
-                    ),
-                    const Divider(),
-                    Text('Select Start Date and Time',
-                        style: _subtitleTextStyle),
-                    SizedBox(
-                      height: SizeConfig.screenHeight! * 0.013,
-                    ),
-                    DateTimeTile(
-                        child: Row(
+            actions: [
+              TextButton(
+                  onPressed: () {
+                    model.updateEvent();
+                  },
+                  child: Text(
+                    'Done',
+                    style: Theme.of(context).textTheme.bodyText1!.copyWith(
+                        fontSize: 16, color: Theme.of(context).accentColor),
+                  )),
+            ],
+          ),
+          body: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(15),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.image,
+                      ),
+                      SizedBox(
+                        width: SizeConfig.screenWidth! * 0.036,
+                      ),
+                      TextButton(
+                        onPressed: () {},
+                        child: Text("Add Image", style: _subtitleTextStyle),
+                      )
+                    ],
+                  ),
+                  const Divider(),
+                  EditEventForm(
+                    model: model,
+                  ),
+                  SizedBox(
+                    height: SizeConfig.screenHeight! * 0.013,
+                  ),
+                  const Divider(),
+                  Text('Select Start Date and Time', style: _subtitleTextStyle),
+                  SizedBox(
+                    height: SizeConfig.screenHeight! * 0.013,
+                  ),
+                  DateTimeTile(
+                    child: Row(
                       children: [
                         const Icon(
                           Icons.calendar_today,
@@ -132,124 +132,126 @@ class _EditEventPageState extends State<EditEventPage> {
                           ),
                         ),
                       ],
-                    )),
-                    SizedBox(
-                      height: SizeConfig.screenHeight! * 0.026,
                     ),
-                    Text(
-                      'Select End Date and Time',
-                      style: Theme.of(context)
-                          .textTheme
-                          .headline5!
-                          .copyWith(fontSize: 16),
-                    ),
-                    SizedBox(
-                      height: SizeConfig.screenHeight! * 0.013,
-                    ),
-                    DateTimeTile(
-                      child: Row(
-                        children: [
-                          const Icon(
-                            Icons.calendar_today,
-                            color: Color(0xff524F4F),
-                            size: 19,
-                          ),
-                          SizedBox(
-                            width: SizeConfig.screenWidth! * 0.045,
-                          ),
-                          GestureDetector(
-                            onTap: () async {
-                              final _date = await customDatePicker(
-                                  initialDate: model.eventEndDate);
-                              setState(() {
-                                model.eventEndDate = _date;
-                              });
-                            },
-                            child: Text(
-                              "${model.eventEndDate.toLocal()}".split(' ')[0],
-                              style: const TextStyle(fontSize: 16),
-                            ),
-                          ),
-                          const Spacer(),
-                          const Icon(
-                            Icons.schedule,
-                            color: Color(0xff524F4F),
-                            size: 19,
-                          ),
-                          SizedBox(
-                            width: SizeConfig.screenWidth! * 0.045,
-                          ),
-                          GestureDetector(
-                            onTap: () async {
-                              final _time = await customTimePicker(
-                                  initialTime: model.eventEndTime);
-
-                              setState(() {
-                                model.eventEndTime = _time;
-                              });
-                            },
-                            child: Text(
-                              model.eventEndTime.format(context),
-                              style: const TextStyle(fontSize: 16),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    SizedBox(
-                      height: SizeConfig.screenHeight! * 0.026,
-                    ),
-                    Row(
+                  ),
+                  SizedBox(
+                    height: SizeConfig.screenHeight! * 0.026,
+                  ),
+                  Text(
+                    'Select End Date and Time',
+                    style: Theme.of(context)
+                        .textTheme
+                        .headline5!
+                        .copyWith(fontSize: 16),
+                  ),
+                  SizedBox(
+                    height: SizeConfig.screenHeight! * 0.013,
+                  ),
+                  DateTimeTile(
+                    child: Row(
                       children: [
-                        const Icon(Icons.restore),
+                        const Icon(
+                          Icons.calendar_today,
+                          color: Color(0xff524F4F),
+                          size: 19,
+                        ),
                         SizedBox(
                           width: SizeConfig.screenWidth! * 0.045,
                         ),
-                        Text('Does not repeat', style: _subtitleTextStyle)
-                      ],
-                    ),
-                    SizedBox(
-                      height: SizeConfig.screenHeight! * 0.026,
-                    ),
-                    const Divider(),
-                    Row(
-                      children: [
-                        Text('Keep Public', style: _subtitleTextStyle),
-                        SizedBox(
-                          width: SizeConfig.screenWidth! * 0.005,
-                        ),
-                        Switch(
-                          value: model.isPublicSwitch,
-                          onChanged: (value) {
+                        GestureDetector(
+                          onTap: () async {
+                            final _date = await customDatePicker(
+                                initialDate: model.eventEndDate);
                             setState(() {
-                              model.isPublicSwitch = value;
-                              print(model.isPublicSwitch);
+                              model.eventEndDate = _date;
                             });
                           },
-                          activeColor: Theme.of(context).colorScheme.primary,
+                          child: Text(
+                            "${model.eventEndDate.toLocal()}".split(' ')[0],
+                            style: const TextStyle(fontSize: 16),
+                          ),
                         ),
                         const Spacer(),
-                        Text('Keep Registerable', style: _subtitleTextStyle),
-                        SizedBox(
-                          width: SizeConfig.screenWidth! * 0.005,
+                        const Icon(
+                          Icons.schedule,
+                          color: Color(0xff524F4F),
+                          size: 19,
                         ),
-                        Switch(
-                          value: model.isRegisterableSwitch,
-                          onChanged: (value) {
+                        SizedBox(
+                          width: SizeConfig.screenWidth! * 0.045,
+                        ),
+                        GestureDetector(
+                          onTap: () async {
+                            final _time = await customTimePicker(
+                                initialTime: model.eventEndTime);
+
                             setState(() {
-                              model.isRegisterableSwitch = value;
-                              print(model.isRegisterableSwitch);
+                              model.eventEndTime = _time;
                             });
                           },
-                          activeColor: Theme.of(context).colorScheme.primary,
+                          child: Text(
+                            model.eventEndTime.format(context),
+                            style: const TextStyle(fontSize: 16),
+                          ),
                         ),
                       ],
                     ),
-                  ],
-                ),
+                  ),
+                  SizedBox(
+                    height: SizeConfig.screenHeight! * 0.026,
+                  ),
+                  Row(
+                    children: [
+                      const Icon(Icons.restore),
+                      SizedBox(
+                        width: SizeConfig.screenWidth! * 0.045,
+                      ),
+                      Text('Does not repeat', style: _subtitleTextStyle)
+                    ],
+                  ),
+                  SizedBox(
+                    height: SizeConfig.screenHeight! * 0.026,
+                  ),
+                  const Divider(),
+                  Row(
+                    children: [
+                      Text('Keep Public', style: _subtitleTextStyle),
+                      SizedBox(
+                        width: SizeConfig.screenWidth! * 0.005,
+                      ),
+                      Switch(
+                        value: model.isPublicSwitch,
+                        onChanged: (value) {
+                          setState(() {
+                            model.isPublicSwitch = value;
+                            print(model.isPublicSwitch);
+                          });
+                        },
+                        activeColor: Theme.of(context).colorScheme.primary,
+                      ),
+                      const Spacer(),
+                      Text('Keep Registerable', style: _subtitleTextStyle),
+                      SizedBox(
+                        width: SizeConfig.screenWidth! * 0.005,
+                      ),
+                      Switch(
+                        value: model.isRegisterableSwitch,
+                        onChanged: (value) {
+                          setState(() {
+                            model.isRegisterableSwitch = value;
+                            print(model.isRegisterableSwitch);
+                          });
+                        },
+                        activeColor: Theme.of(context).colorScheme.primary,
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
-          );
-        });
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/views/after_auth_screens/events/edit_events_form.dart
+++ b/lib/views/after_auth_screens/events/edit_events_form.dart
@@ -45,64 +45,68 @@ class EditEventForm extends StatelessWidget {
             height: SizeConfig.screenHeight! * 0.013,
           ),
           TextFormField(
-              textInputAction: TextInputAction.next,
-              keyboardType: TextInputType.streetAddress,
-              controller: model.eventLocationTextController,
-              focusNode: model.locationFocus,
-              validator: (value) =>
-                  Validator.validateEventForm(value!, 'Location'),
-              decoration: InputDecoration(
-                hintText: 'Where is the event?',
-                labelText: 'Add Location',
-                labelStyle: Theme.of(context).textTheme.subtitle1,
-                border: InputBorder.none,
-                focusedBorder: InputBorder.none,
-                enabledBorder: InputBorder.none,
-                prefixIcon: Container(
-                    transform: Matrix4.translationValues(
-                        -SizeConfig.screenWidth! * 0.027, 0.0, 0.0),
-                    child: const Icon(
-                      Icons.place,
-                      size: 25,
-                    )),
-                suffixIcon: IconButton(
-                    onPressed: () {
-                      FocusScope.of(context).requestFocus(model.locationFocus);
-                    },
-                    icon: const Icon(Icons.edit)),
-              )),
+            textInputAction: TextInputAction.next,
+            keyboardType: TextInputType.streetAddress,
+            controller: model.eventLocationTextController,
+            focusNode: model.locationFocus,
+            validator: (value) =>
+                Validator.validateEventForm(value!, 'Location'),
+            decoration: InputDecoration(
+              hintText: 'Where is the event?',
+              labelText: 'Add Location',
+              labelStyle: Theme.of(context).textTheme.subtitle1,
+              border: InputBorder.none,
+              focusedBorder: InputBorder.none,
+              enabledBorder: InputBorder.none,
+              prefixIcon: Container(
+                  transform: Matrix4.translationValues(
+                      -SizeConfig.screenWidth! * 0.027, 0.0, 0.0),
+                  child: const Icon(
+                    Icons.place,
+                    size: 25,
+                  )),
+              suffixIcon: IconButton(
+                onPressed: () {
+                  FocusScope.of(context).requestFocus(model.locationFocus);
+                },
+                icon: const Icon(Icons.edit),
+              ),
+            ),
+          ),
           SizedBox(
             height: SizeConfig.screenHeight! * 0.013,
           ),
           TextFormField(
-              keyboardType: TextInputType.multiline,
-              controller: model.eventDescriptionTextController,
-              focusNode: model.descriptionFocus,
-              validator: (value) =>
-                  Validator.validateEventForm(value!, 'Description'),
-              maxLines: 10,
-              minLines: 1,
-              decoration: InputDecoration(
-                hintText: 'Describe the event',
-                labelText: 'Add Description',
-                labelStyle: Theme.of(context).textTheme.subtitle1,
-                border: InputBorder.none,
-                focusedBorder: InputBorder.none,
-                enabledBorder: InputBorder.none,
-                prefixIcon: Container(
-                    transform: Matrix4.translationValues(
-                        -SizeConfig.screenWidth! * 0.027, 0.0, 0.0),
-                    child: const Icon(
-                      Icons.view_headline,
-                      size: 25,
-                    )),
-                suffixIcon: IconButton(
-                    onPressed: () {
-                      FocusScope.of(context)
-                          .requestFocus(model.descriptionFocus);
-                    },
-                    icon: const Icon(Icons.edit)),
-              )),
+            keyboardType: TextInputType.multiline,
+            controller: model.eventDescriptionTextController,
+            focusNode: model.descriptionFocus,
+            validator: (value) =>
+                Validator.validateEventForm(value!, 'Description'),
+            maxLines: 10,
+            minLines: 1,
+            decoration: InputDecoration(
+              hintText: 'Describe the event',
+              labelText: 'Add Description',
+              labelStyle: Theme.of(context).textTheme.subtitle1,
+              border: InputBorder.none,
+              focusedBorder: InputBorder.none,
+              enabledBorder: InputBorder.none,
+              prefixIcon: Container(
+                transform: Matrix4.translationValues(
+                    -SizeConfig.screenWidth! * 0.027, 0.0, 0.0),
+                child: const Icon(
+                  Icons.view_headline,
+                  size: 25,
+                ),
+              ),
+              suffixIcon: IconButton(
+                onPressed: () {
+                  FocusScope.of(context).requestFocus(model.descriptionFocus);
+                },
+                icon: const Icon(Icons.edit),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/views/after_auth_screens/events/edit_events_form.dart
+++ b/lib/views/after_auth_screens/events/edit_events_form.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:talawa/services/size_config.dart';
+import 'package:talawa/utils/validators.dart';
+import 'package:talawa/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart';
+
+class EditEventForm extends StatelessWidget {
+  const EditEventForm({Key? key, required this.model}) : super(key: key);
+  final EditEventViewModel model;
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: model.formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextFormField(
+              textInputAction: TextInputAction.next,
+              controller: model.eventTitleTextController,
+              keyboardType: TextInputType.name,
+              maxLength: 20,
+              focusNode: model.titleFocus,
+              validator: (value) =>
+                  Validator.validateEventForm(value!, 'Title'),
+              decoration: InputDecoration(
+                labelText: 'Add Event Title',
+                isDense: true,
+                labelStyle: Theme.of(context).textTheme.subtitle1,
+                focusedBorder: InputBorder.none,
+                counterText: "",
+                enabledBorder: InputBorder.none,
+                prefixIcon: Container(
+                    transform: Matrix4.translationValues(
+                        -SizeConfig.screenWidth! * 0.027, 0.0, 0.0),
+                    child: const Icon(
+                      Icons.title,
+                      size: 25,
+                    )),
+                suffixIcon: IconButton(
+                    onPressed: () {
+                      FocusScope.of(context).requestFocus(model.titleFocus);
+                    },
+                    icon: const Icon(Icons.edit)),
+              )),
+          SizedBox(
+            height: SizeConfig.screenHeight! * 0.013,
+          ),
+          TextFormField(
+              textInputAction: TextInputAction.next,
+              keyboardType: TextInputType.streetAddress,
+              controller: model.eventLocationTextController,
+              focusNode: model.locationFocus,
+              validator: (value) =>
+                  Validator.validateEventForm(value!, 'Location'),
+              decoration: InputDecoration(
+                hintText: 'Where is the event?',
+                labelText: 'Add Location',
+                labelStyle: Theme.of(context).textTheme.subtitle1,
+                border: InputBorder.none,
+                focusedBorder: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                prefixIcon: Container(
+                    transform: Matrix4.translationValues(
+                        -SizeConfig.screenWidth! * 0.027, 0.0, 0.0),
+                    child: const Icon(
+                      Icons.place,
+                      size: 25,
+                    )),
+                suffixIcon: IconButton(
+                    onPressed: () {
+                      FocusScope.of(context).requestFocus(model.locationFocus);
+                    },
+                    icon: const Icon(Icons.edit)),
+              )),
+          SizedBox(
+            height: SizeConfig.screenHeight! * 0.013,
+          ),
+          TextFormField(
+              keyboardType: TextInputType.multiline,
+              controller: model.eventDescriptionTextController,
+              focusNode: model.descriptionFocus,
+              validator: (value) =>
+                  Validator.validateEventForm(value!, 'Description'),
+              maxLines: 10,
+              minLines: 1,
+              decoration: InputDecoration(
+                hintText: 'Describe the event',
+                labelText: 'Add Description',
+                labelStyle: Theme.of(context).textTheme.subtitle1,
+                border: InputBorder.none,
+                focusedBorder: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                prefixIcon: Container(
+                    transform: Matrix4.translationValues(
+                        -SizeConfig.screenWidth! * 0.027, 0.0, 0.0),
+                    child: const Icon(
+                      Icons.view_headline,
+                      size: 25,
+                    )),
+                suffixIcon: IconButton(
+                    onPressed: () {
+                      FocusScope.of(context)
+                          .requestFocus(model.descriptionFocus);
+                    },
+                    icon: const Icon(Icons.edit)),
+              )),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/after_auth_screens/events/event_info_page.dart
+++ b/lib/views/after_auth_screens/events/event_info_page.dart
@@ -4,13 +4,13 @@ import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
+import 'package:talawa/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart';
 import 'package:talawa/widgets/custom_list_tile.dart';
 import 'package:talawa/widgets/event_admin_fab.dart';
 
 class EventInfoPage extends StatefulWidget {
-  const EventInfoPage({Key? key, required this.event}) : super(key: key);
-  final Event event;
-
+  const EventInfoPage({Key? key, required this.agrs}) : super(key: key);
+  final Map<String, dynamic> agrs;
   @override
   _EventInfoPageState createState() => _EventInfoPageState();
 }
@@ -18,6 +18,7 @@ class EventInfoPage extends StatefulWidget {
 class _EventInfoPageState extends State<EventInfoPage> {
   @override
   Widget build(BuildContext context) {
+    final Event event = widget.agrs["event"] as Event;
     return Scaffold(
       body: CustomScrollView(
         slivers: [
@@ -33,25 +34,28 @@ class _EventInfoPageState extends State<EventInfoPage> {
               ),
             ),
           ),
-          _eventInfoBody()
+          _eventInfoBody(event)
         ],
       ),
-      floatingActionButton:
-          widget.event.creator!.id != userConfig.currentUser.id
-              ? FloatingActionButton.extended(
-                  onPressed: () {},
-                  label: Text(
-                    "Register",
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyText2!
-                        .copyWith(color: Theme.of(context).accentColor),
-                  ))
-              : eventAdminFab(context: context, event: widget.event),
+      floatingActionButton: event.creator!.id != userConfig.currentUser.id
+          ? FloatingActionButton.extended(
+              onPressed: () {},
+              label: Text(
+                "Register",
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyText2!
+                    .copyWith(color: Theme.of(context).accentColor),
+              ))
+          : eventAdminFab(
+              context: context,
+              event: event,
+              exploreEventsViewModel: widget.agrs["exploreEventViewModel"]
+                  as ExploreEventsViewModel),
     );
   }
 
-  Widget _eventInfoBody() {
+  Widget _eventInfoBody(Event event) {
     return SliverToBoxAdapter(
       child: Padding(
         padding: const EdgeInsets.all(10),
@@ -62,7 +66,7 @@ class _EventInfoPageState extends State<EventInfoPage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  widget.event.title!,
+                  event.title!,
                   style: Theme.of(context)
                       .textTheme
                       .headline4!
@@ -73,9 +77,9 @@ class _EventInfoPageState extends State<EventInfoPage> {
             ),
             Row(
               children: [
-                widget.event.creator!.firstName != null
+                event.creator!.firstName != null
                     ? Text(
-                        "${AppLocalizations.of(context)!.strictTranslate("Created by")}: ${widget.event.creator!.firstName} ${widget.event.creator!.lastName}",
+                        "${AppLocalizations.of(context)!.strictTranslate("Created by")}: ${event.creator!.firstName} ${event.creator!.lastName}",
                         style: Theme.of(context)
                             .textTheme
                             .bodyText2!
@@ -104,11 +108,11 @@ class _EventInfoPageState extends State<EventInfoPage> {
                   width: SizeConfig.screenWidth! * 0.027,
                 ),
                 Text(
-                  "${widget.event.startDate!} - ${widget.event.endDate!}",
+                  "${event.startDate!} - ${event.endDate!}",
                   style: Theme.of(context).textTheme.caption,
                 ),
                 const Spacer(),
-                widget.event.isPublic!
+                event.isPublic!
                     ? Icon(
                         Icons.lock_open,
                         size: 13,
@@ -122,7 +126,7 @@ class _EventInfoPageState extends State<EventInfoPage> {
                 SizedBox(
                   width: SizeConfig.screenWidth! * 0.027,
                 ),
-                widget.event.isPublic!
+                event.isPublic!
                     ? Text(
                         AppLocalizations.of(context)!.strictTranslate('public'),
                         style: Theme.of(context).textTheme.caption,
@@ -148,7 +152,7 @@ class _EventInfoPageState extends State<EventInfoPage> {
                   width: SizeConfig.screenWidth! * 0.025,
                 ),
                 Text(
-                  "${widget.event.startTime!} - ${widget.event.endTime!}",
+                  "${event.startTime!} - ${event.endTime!}",
                   style: Theme.of(context).textTheme.caption,
                 ),
               ],
@@ -169,7 +173,7 @@ class _EventInfoPageState extends State<EventInfoPage> {
                 SizedBox(
                   width: SizeConfig.screenWidth! * 0.88,
                   child: Text(
-                    widget.event.location!,
+                    event.location!,
                     style: Theme.of(context).textTheme.caption,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.left,
@@ -190,7 +194,7 @@ class _EventInfoPageState extends State<EventInfoPage> {
             ),
             SizedBox(width: SizeConfig.screenWidth! * 0.013),
             Text(
-              widget.event.description!,
+              event.description!,
               style: Theme.of(context).textTheme.caption,
             ),
             SizedBox(height: SizeConfig.screenHeight! * 0.013),

--- a/lib/views/after_auth_screens/events/event_info_page.dart
+++ b/lib/views/after_auth_screens/events/event_info_page.dart
@@ -5,6 +5,7 @@ import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
 import 'package:talawa/widgets/custom_list_tile.dart';
+import 'package:talawa/widgets/event_admin_fab.dart';
 
 class EventInfoPage extends StatefulWidget {
   const EventInfoPage({Key? key, required this.event}) : super(key: key);
@@ -35,17 +36,18 @@ class _EventInfoPageState extends State<EventInfoPage> {
           _eventInfoBody()
         ],
       ),
-      floatingActionButton: FloatingActionButton.extended(
-          onPressed: () {
-            //EventService().registerForAnEvent(widget.event.id!);
-          },
-          label: Text(
-            AppLocalizations.of(context)!.strictTranslate("Register"),
-            style: Theme.of(context)
-                .textTheme
-                .bodyText2!
-                .copyWith(color: Theme.of(context).accentColor),
-          )),
+      floatingActionButton:
+          widget.event.creator!.id != userConfig.currentUser.id
+              ? FloatingActionButton.extended(
+                  onPressed: () {},
+                  label: Text(
+                    "Register",
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyText2!
+                        .copyWith(color: Theme.of(context).accentColor),
+                  ))
+              : eventAdminFab(context: context, event: widget.event),
     );
   }
 

--- a/lib/views/after_auth_screens/events/explore_events.dart
+++ b/lib/views/after_auth_screens/events/explore_events.dart
@@ -130,7 +130,10 @@ class ExploreEvents extends StatelessWidget {
                                         onTap: () {
                                           navigationService.pushScreen(
                                               "/eventInfo",
-                                              arguments: model.events[index]);
+                                              arguments: {
+                                                "event": model.events[index],
+                                                "exploreEventViewModel": model
+                                              });
                                         },
                                         child: EventCard(
                                           event: model.events[index],

--- a/lib/views/after_auth_screens/events/explore_events.dart
+++ b/lib/views/after_auth_screens/events/explore_events.dart
@@ -42,7 +42,7 @@ class ExploreEvents extends StatelessWidget {
               ],
             ),
             body: model.isBusy
-                ? const CircularProgressIndicator()
+                ? const Center(child: CircularProgressIndicator())
                 : RefreshIndicator(
                     onRefresh: () async => model.fetchNewEvents(),
                     child: Stack(

--- a/lib/widgets/event_admin_fab.dart
+++ b/lib/widgets/event_admin_fab.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
-import 'package:talawa/services/event_service.dart';
+import 'package:talawa/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart';
 
-Widget eventAdminFab({required BuildContext context, required Event event}) {
+Widget eventAdminFab(
+    {required BuildContext context,
+    required Event event,
+    required ExploreEventsViewModel exploreEventsViewModel}) {
   return SpeedDial(
     icon: Icons.menu,
     activeIcon: Icons.close,
@@ -28,7 +31,7 @@ Widget eventAdminFab({required BuildContext context, required Event event}) {
         backgroundColor: Theme.of(context).primaryColor,
         labelBackgroundColor: Theme.of(context).primaryColor,
         onTap: () {
-          EventService().deleteEvent(event.id!);
+          exploreEventsViewModel.deleteEvent(eventId: event.id!);
         },
       ),
       SpeedDialChild(

--- a/lib/widgets/event_admin_fab.dart
+++ b/lib/widgets/event_admin_fab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:talawa/models/events/event_model.dart';
+import 'package:talawa/services/event_service.dart';
 
 Widget eventAdminFab({required BuildContext context, required Event event}) {
   return SpeedDial(
@@ -25,7 +26,9 @@ Widget eventAdminFab({required BuildContext context, required Event event}) {
         foregroundColor: Theme.of(context).accentColor,
         backgroundColor: Theme.of(context).primaryColor,
         labelBackgroundColor: Theme.of(context).primaryColor,
-        onTap: () {},
+        onTap: () {
+          EventService().deleteEvent(event.id!);
+        },
       ),
       SpeedDialChild(
         child: const Icon(

--- a/lib/widgets/event_admin_fab.dart
+++ b/lib/widgets/event_admin_fab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/services/event_service.dart';
 
@@ -42,7 +43,9 @@ Widget eventAdminFab({required BuildContext context, required Event event}) {
         foregroundColor: Theme.of(context).accentColor,
         backgroundColor: Theme.of(context).primaryColor,
         labelBackgroundColor: Theme.of(context).primaryColor,
-        onTap: () {},
+        onTap: () {
+          navigationService.pushScreen("/editEventPage", arguments: event);
+        },
       ),
     ],
   );

--- a/lib/widgets/event_admin_fab.dart
+++ b/lib/widgets/event_admin_fab.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:talawa/models/events/event_model.dart';
+
+Widget eventAdminFab({required BuildContext context, required Event event}) {
+  return SpeedDial(
+    icon: Icons.menu,
+    activeIcon: Icons.close,
+    buttonSize: 55.0,
+    overlayColor: Theme.of(context).colorScheme.onBackground,
+    overlayOpacity: 0.5,
+    backgroundColor: Theme.of(context).primaryColor,
+    foregroundColor: Theme.of(context).accentColor,
+    elevation: 8.0,
+    children: [
+      SpeedDialChild(
+        child: const Icon(
+          Icons.delete,
+        ),
+        label: 'Delete Event',
+        labelStyle: Theme.of(context)
+            .textTheme
+            .headline6!
+            .copyWith(color: Theme.of(context).accentColor),
+        foregroundColor: Theme.of(context).accentColor,
+        backgroundColor: Theme.of(context).primaryColor,
+        labelBackgroundColor: Theme.of(context).primaryColor,
+        onTap: () {},
+      ),
+      SpeedDialChild(
+        child: const Icon(
+          Icons.edit,
+        ),
+        label: 'Edit Event',
+        labelStyle: Theme.of(context)
+            .textTheme
+            .headline6!
+            .copyWith(color: Theme.of(context).accentColor),
+        foregroundColor: Theme.of(context).accentColor,
+        backgroundColor: Theme.of(context).primaryColor,
+        labelBackgroundColor: Theme.of(context).primaryColor,
+        onTap: () {},
+      ),
+    ],
+  );
+}

--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -55,7 +55,7 @@ class EventCard extends StatelessWidget {
                             size: 13,
                           ),
                           SizedBox(
-                            width: SizeConfig.screenWidth! * 0.027,
+                            width: SizeConfig.screenWidth! * 0.025,
                           ),
                           Text(
                             "${event.startDate!} - ${event.endDate!}",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  flutter_speed_dial: ^3.0.5
   get_it: ^7.1.3
   graphql_flutter: ^5.0.0
   hive: ^2.0.4


### PR DESCRIPTION

**What kind of change does this PR introduce?**
Added functionality to Edit and Delete an Event. This can be done only by event creators using the speed dial.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #906 

**Did you add tests for your changes?**
No
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

https://user-images.githubusercontent.com/57677520/124155363-081cb680-dab4-11eb-938e-14050df59e59.mp4


<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
Not required


**Summary**
- Now only the creators of event can edit or delete event.
- Added edit_event screen with MVVM
- Added  flutter_speed_dial: package


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
