### PR TITLE
Renderflex overflow of drawer fixed

### DIFF
--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -26,8 +26,7 @@ class CustomDrawer extends StatelessWidget {
             width: SizeConfig.screenWidth! * 0.6,
             alignment: Alignment.centerLeft,
             child: Drawer(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              child: ListView(
                 children: [
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -119,9 +118,9 @@ class CustomDrawer extends StatelessWidget {
                             .strictTranslate("Leave Current Organization")),
                       ),
                       SizedBox(
-                        height: SizeConfig.screenHeight! * 0.02,
+                        height: SizeConfig.screenHeight! * 0.05,
                       ),
-                      const FromPalisadoes(),
+                      const FromPalisadoes()
                     ],
                   ),
                 ],

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -66,7 +66,7 @@ class CustomDrawer extends StatelessWidget {
                             ),
                           ),
                           SizedBox(
-                            height: SizeConfig.screenHeight! * 0.45,
+                            height: SizeConfig.screenHeight! * 0.41,
                             child: Scrollbar(
                               controller: model.controller,
                               isAlwaysShown: true,
@@ -117,6 +117,9 @@ class CustomDrawer extends StatelessWidget {
                         leading: const Icon(Icons.logout, size: 30),
                         title: Text(AppLocalizations.of(context)!
                             .strictTranslate("Leave Current Organization")),
+                      ),
+                      SizedBox(
+                        height: SizeConfig.screenHeight! * 0.02,
                       ),
                       const FromPalisadoes(),
                     ],


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix : renderflex overflow of custom drawer.

#979 

**Did you add tests for your changes?**
Yes 

**If relevant, did you update the documentation?**
No need

**Screenshots**
![Screenshot_1630475298](https://user-images.githubusercontent.com/81760629/131619374-e776d2a7-7a1d-432f-b54d-f2ee0a47481e.png)


**Summary**
Dynamic changes in the view and renders of the screen. No user is able to access "Leave Current organization" screen.


**Does this PR introduce a breaking change?**
No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
