### PR TITLE
Fixes Pull Request workflow 

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,5 @@
 name: PR Workflow
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   PR-Greeting:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes the pull request workflow so that GitHub secrets can now be accessed by first-interaction action.

**Issue Number:**

Fixes #1036 

**Did you add tests for your changes?**

N.A.

**Snapshots/Videos:**

N.A.

**If relevant, did you update the documentation?**

N.A.

**Summary**

Whenever a first-time contributor sends a pull request, first-interaction actions run and add a greeting message to the PR. But this action fails now as it can't access the GitHub token from GitHub secrets due to a deprecated event. This PR updates the event to the latest one so that the issue gets resolved.

**Does this PR introduce a breaking change?**

No

**Other information**

N.A.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes
