### PR TITLE
fix language selection header size

### DIFF
--- a/lib/views/pre_auth_screens/select_language.dart
+++ b/lib/views/pre_auth_screens/select_language.dart
@@ -29,11 +29,16 @@ class _SelectLanguageState extends State<SelectLanguage> {
           children: [
             Padding(
               padding: EdgeInsets.only(top: SizeConfig.screenWidth! * 0.06),
-              child: Text(
-                AppLocalizations.of(context)!
-                    .strictTranslate('Select Language'),
-                style: Theme.of(context).textTheme.headline5,
-                key: const Key('Select Language'),
+              child: SizedBox(
+                height: SizeConfig.screenHeight! * 0.08,
+                child: FittedBox(
+                  child: Text(
+                    AppLocalizations.of(context)!
+                        .strictTranslate('Select Language'),
+                    style: Theme.of(context).textTheme.headline5,
+                    key: const Key('Select Language'),
+                  ),
+                ),
               ),
             ),
             SizedBox(


### PR DESCRIPTION
- Fixes difference in size of header when selecting different languages at language selection screen. The issue occurs due to change in font size of different languages. Solution would be to wrap the heading text into a fitted box.
- Issue number #1050 

### Before
![2021_12_20_20_34_12](https://user-images.githubusercontent.com/62198564/147023888-05ce64f2-98b2-4f06-a793-9b18868f666a.gif)

### After 
![2021_12_20_20_38_32](https://user-images.githubusercontent.com/62198564/147023899-be2c78dc-bd4a-4177-a56b-f61a09d31f0e.gif)

- Tests are not needed. Can easily be seen visually.
