### PR TITLE
Minute fix in header size of language selection screen

### DIFF
--- a/lib/views/pre_auth_screens/select_language.dart
+++ b/lib/views/pre_auth_screens/select_language.dart
@@ -30,7 +30,7 @@ class _SelectLanguageState extends State<SelectLanguage> {
             Padding(
               padding: EdgeInsets.only(top: SizeConfig.screenWidth! * 0.06),
               child: SizedBox(
-                height: SizeConfig.screenHeight! * 0.08,
+                height: SizeConfig.screenHeight! * 0.045,
                 child: FittedBox(
                   child: Text(
                     AppLocalizations.of(context)!

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -573,7 +573,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -949,7 +949,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   timelines:
     dependency: "direct main"
     description:
@@ -1012,7 +1012,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   vibration:
     dependency: "direct main"
     description:


### PR DESCRIPTION
- Fixes a minute bug in size of header of language selection screen. It was way too big before.

### Before
![Screenshot_20211223-194338](https://user-images.githubusercontent.com/62198564/147253548-5bf14251-6fdf-4946-ba7c-256ccb71d3bd.jpg)

### After
![Screenshot_20211223-194421](https://user-images.githubusercontent.com/62198564/147253585-ae32dd8b-c767-4ba0-b2e4-9e9d49d5065a.jpg)

- Note: I've not done any changes in pubspec, so I don't know why it's in the commit. So if it's not in the main branch, kindly ignore that file and merge only header fix.