### PR TITLE
Prevent elements of Select Language from touching notch

### DIFF
--- a/lib/views/pre_auth_screens/select_language.dart
+++ b/lib/views/pre_auth_screens/select_language.dart
@@ -15,134 +15,134 @@ class SelectLanguage extends StatefulWidget {
 class _SelectLanguageState extends State<SelectLanguage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      key: const Key('SelectLanguageScreenScaffold'),
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      body: Padding(
-        padding: EdgeInsets.fromLTRB(
-            SizeConfig.screenWidth! * 0.06,
-            SizeConfig.safeBlockVertical! * 4,
-            SizeConfig.screenWidth! * 0.06,
-            0.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: EdgeInsets.only(top: SizeConfig.screenWidth! * 0.06),
-              child: SizedBox(
-                height: SizeConfig.screenHeight! * 0.045,
-                child: FittedBox(
-                  child: Text(
-                    AppLocalizations.of(context)!
-                        .strictTranslate('Select Language'),
-                    style: Theme.of(context).textTheme.headline5,
-                    key: const Key('Select Language'),
+    return SafeArea(
+      child: Scaffold(
+        key: const Key('SelectLanguageScreenScaffold'),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        body: Padding(
+          padding: EdgeInsets.fromLTRB(SizeConfig.screenWidth! * 0.06, 0.0,
+              SizeConfig.screenWidth! * 0.06, 0.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: EdgeInsets.only(top: SizeConfig.screenWidth! * 0.06),
+                child: SizedBox(
+                  height: SizeConfig.screenHeight! * 0.045,
+                  child: FittedBox(
+                    child: Text(
+                      AppLocalizations.of(context)!
+                          .strictTranslate('Select Language'),
+                      style: Theme.of(context).textTheme.headline5,
+                      key: const Key('Select Language'),
+                    ),
                   ),
                 ),
               ),
-            ),
-            SizedBox(
-              height: SizeConfig.screenHeight! * 0.018,
-            ),
-            // const CupertinoSearchTextField(
-            //   key: Key('SearchField'),
-            // ),
-            SizedBox(
-              height: SizeConfig.screenHeight! * 0.016,
-            ),
-            Expanded(
-                child: ListView.builder(
-                    key: const Key('LanguagesList'),
-                    itemCount: languages.length,
-                    itemBuilder: (BuildContext context, int index) {
-                      return InkWell(
-                        key: Key(Provider.of<AppLanguage>(context)
-                                    .appLocal
-                                    .languageCode ==
-                                languages[index].langCode
-                            ? 'Selected'
-                            : 'NotSelected'),
-                        onTap: () async {
-                          await Provider.of<AppLanguage>(
-                            context,
-                            listen: false,
-                          ).changeLanguage(
-                            Locale(languages[index].langCode),
-                          );
-                        },
-                        child: Consumer<AppLanguage>(
-                          builder: (context, appLang, _) {
-                            return Container(
-                              key: Key('LanguageItem$index'),
-                              alignment: Alignment.centerLeft,
-                              height: SizeConfig.screenHeight! * 0.063,
-                              padding: EdgeInsets.symmetric(
-                                horizontal: SizeConfig.screenWidth! * 0.06,
-                              ),
-                              decoration: BoxDecoration(
-                                  color: languages[index].langCode ==
-                                          appLang.appLocal.languageCode
-                                      ? const Color(0xFFC4C4C4)
-                                          .withOpacity(0.15)
-                                      : Colors.transparent),
-                              child: index == 0
-                                  ? Row(
-                                      key: const Key('LanguageItem'),
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.spaceBetween,
-                                      children: [
-                                        Text(
-                                          languages[index].langName,
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .headline6,
-                                        ),
-                                        Text(
-                                          AppLocalizations.of(context)!
-                                              .strictTranslate('Default'),
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodyText2!
-                                              .copyWith(
-                                                  color:
-                                                      const Color(0xFF4285F4)),
-                                        ),
-                                      ],
-                                    )
-                                  : Text(
-                                      languages[index].langName,
-                                      style:
-                                          Theme.of(context).textTheme.headline6,
-                                      key: const Key('LanguageItem'),
-                                    ),
+              SizedBox(
+                height: SizeConfig.screenHeight! * 0.018,
+              ),
+              // const CupertinoSearchTextField(
+              //   key: Key('SearchField'),
+              // ),
+              SizedBox(
+                height: SizeConfig.screenHeight! * 0.016,
+              ),
+              Expanded(
+                  child: ListView.builder(
+                      key: const Key('LanguagesList'),
+                      itemCount: languages.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return InkWell(
+                          key: Key(Provider.of<AppLanguage>(context)
+                                      .appLocal
+                                      .languageCode ==
+                                  languages[index].langCode
+                              ? 'Selected'
+                              : 'NotSelected'),
+                          onTap: () async {
+                            await Provider.of<AppLanguage>(
+                              context,
+                              listen: false,
+                            ).changeLanguage(
+                              Locale(languages[index].langCode),
                             );
                           },
-                        ),
-                      );
-                    })),
-            const Divider(
-              color: Color(0xffe5e5e5),
-            ),
-            Container(
-              height: SizeConfig.screenHeight! * 0.08,
-              alignment: Alignment.centerRight,
-              child: TextButton(
-                key: const Key('NavigateToUrlPage'),
-                onPressed: () async {
-                  Provider.of<AppLanguage>(context, listen: false)
-                      .selectLanguagePress();
-                },
-                child: Text(
-                  AppLocalizations.of(context)!.strictTranslate('Select'),
-                  style: Theme.of(context).textTheme.headline5!.copyWith(
-                        fontSize: 18,
-                        color: const Color(0xFF008A37),
-                      ),
-                  key: const Key('SelectLangTextButton'),
-                ),
+                          child: Consumer<AppLanguage>(
+                            builder: (context, appLang, _) {
+                              return Container(
+                                key: Key('LanguageItem$index'),
+                                alignment: Alignment.centerLeft,
+                                height: SizeConfig.screenHeight! * 0.063,
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: SizeConfig.screenWidth! * 0.06,
+                                ),
+                                decoration: BoxDecoration(
+                                    color: languages[index].langCode ==
+                                            appLang.appLocal.languageCode
+                                        ? const Color(0xFFC4C4C4)
+                                            .withOpacity(0.15)
+                                        : Colors.transparent),
+                                child: index == 0
+                                    ? Row(
+                                        key: const Key('LanguageItem'),
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.spaceBetween,
+                                        children: [
+                                          Text(
+                                            languages[index].langName,
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .headline6,
+                                          ),
+                                          Text(
+                                            AppLocalizations.of(context)!
+                                                .strictTranslate('Default'),
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .bodyText2!
+                                                .copyWith(
+                                                    color: const Color(
+                                                        0xFF4285F4)),
+                                          ),
+                                        ],
+                                      )
+                                    : Text(
+                                        languages[index].langName,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .headline6,
+                                        key: const Key('LanguageItem'),
+                                      ),
+                              );
+                            },
+                          ),
+                        );
+                      })),
+              const Divider(
+                color: Color(0xffe5e5e5),
               ),
-            )
-          ],
+              Container(
+                height: SizeConfig.screenHeight! * 0.08,
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  key: const Key('NavigateToUrlPage'),
+                  onPressed: () async {
+                    Provider.of<AppLanguage>(context, listen: false)
+                        .selectLanguagePress();
+                  },
+                  child: Text(
+                    AppLocalizations.of(context)!.strictTranslate('Select'),
+                    style: Theme.of(context).textTheme.headline5!.copyWith(
+                          fontSize: 18,
+                          color: const Color(0xFF008A37),
+                        ),
+                    key: const Key('SelectLangTextButton'),
+                  ),
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
**What kind of change does this PR introduce?**

BugFix

**Issue Number:**

Fixes #1038 

**Did you add tests for your changes?**

N.A.

**Snapshots/Videos:**

N.A.

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

Since the edge parts of the app in the select language screen are unaccessible in devices without notch display, SafeArea has been wrapped around the scaffold.

**Does this PR introduce a breaking change?**

No

**Other information**

N.A.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
