### PR TITLE
Removing inview_notifier_list package

### DIFF
--- a/lib/views/after_auth_screens/feed/individual_post.dart
+++ b/lib/views/after_auth_screens/feed/individual_post.dart
@@ -60,7 +60,6 @@ class _IndividualPostViewState extends State<IndividualPostView> {
       body: ListView(
         children: [
           NewsPost(
-            isInView: true,
             post: widget.post,
           ),
           Padding(

--- a/lib/widgets/post_list_widget.dart
+++ b/lib/widgets/post_list_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:inview_notifier_list/inview_notifier_list.dart';
 import 'package:talawa/models/post/post_model.dart';
 import 'package:talawa/widgets/post_widget.dart';
 
@@ -14,39 +13,26 @@ class PostListWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InViewNotifierList(
-      contextCacheCount: 15,
+    return ListView.builder(
       scrollDirection: Axis.vertical,
       physics: const NeverScrollableScrollPhysics(),
       shrinkWrap: true,
-      initialInViewIds: ['0'],
-      isInViewPortCondition:
-          (double deltaTop, double deltaBottom, double viewPortDimension) {
-        return deltaTop < (0.5 * viewPortDimension) &&
-            deltaBottom > (0.5 * viewPortDimension);
-      },
       itemCount: posts.length,
-      builder: (BuildContext context, int index) {
-        return InViewNotifierWidget(
-          id: '$index',
-          builder: (BuildContext context, bool isInView, Widget? child) {
-            return Column(
-              children: [
-                NewsPost(
-                  post: posts[index],
-                  function: function,
-                  isInView: isInView,
-                ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 10.0),
-                  child: Divider(
-                    height: 8,
-                    thickness: 8,
-                  ),
-                )
-              ],
-            );
-          },
+      itemBuilder: (BuildContext context, int index) {
+        return Column(
+          children: [
+            NewsPost(
+              post: posts[index],
+              function: function,
+            ),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 10.0),
+              child: Divider(
+                height: 8,
+                thickness: 8,
+              ),
+            )
+          ],
         );
       },
     );

--- a/lib/widgets/post_widget.dart
+++ b/lib/widgets/post_widget.dart
@@ -13,12 +13,10 @@ class NewsPost extends StatelessWidget {
     Key? key,
     required this.post,
     this.function,
-    required this.isInView,
   }) : super(key: key);
 
   final Post post;
   final Function? function;
-  final bool isInView;
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +42,7 @@ class NewsPost extends StatelessWidget {
         Container(
           height: 400,
           color: Theme.of(context).colorScheme.primaryVariant.withOpacity(0.5),
-          child: PostContainer(isInView: isInView, id: post.sId),
+          child: PostContainer(id: post.sId),
         ),
         BaseView<LikeButtonViewModel>(
           onModelReady: (model) =>
@@ -115,11 +113,9 @@ class NewsPost extends StatelessWidget {
 
 class PostContainer extends StatefulWidget {
   const PostContainer({
-    required this.isInView,
     required this.id,
     Key? key,
   }) : super(key: key);
-  final bool isInView;
   final String id;
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -518,13 +518,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
-  inview_notifier_list:
-    dependency: "direct main"
-    description:
-      name: inview_notifier_list
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,6 @@ dependencies:
   image_cropper: ^1.4.1
   image_picker: ^0.8.1+3
   intl: ^0.17.0
-  inview_notifier_list: ^2.0.0
   json_annotation: ^4.0.1
   mockito: ^5.0.14
   path_provider: ^2.0.2


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Removes the package inview_notifier_list as it was not used and only passed through the widget tree.Replaced it with _visibility_detector_ packaege

**Issue Number:**

Fixes #1093 
