### PR TITLE
Fixes: #1145 Added password validation criteria in all languages supported

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -48,7 +48,7 @@
     "Email must not be left blank": "E-Mail darf nicht leer sein",
     "Please enter a valid Email Address": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
     "Password must not be left blank": "Passwort darf nicht leer bleiben",
-    "Invalid Password": "Ungültiges Passwort",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "Ihr Passwort muss mindestens 8 Zeichen lang sein, mindestens eine Ziffer, einen Groß- und einen Kleinbuchstaben und ein Sonderzeichen (@, #, $, etc.) enthalten.",
     "Password must not contain spaces": "Passwort darf keine Leerzeichen enthalten",
     "Password does not match original": "Passwort stimmt nicht mit Original überein",
     "Join Organisation": "Der Organisation beitreten",

--- a/lang/en.json
+++ b/lang/en.json
@@ -50,7 +50,7 @@
     "Email must not be left blank": "Email must not be left blank",
     "Please enter a valid Email Address": "Please enter a valid Email Address",
     "Password must not be left blank": "Password must not be left blank",
-    "Invalid Password": "Invalid Password",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)",
     "Password must not contain spaces": "Password must not contain spaces",
     "Password does not match original": "Password does not match original",
     "Join Organisation": "Join Organisation",

--- a/lang/es.json
+++ b/lang/es.json
@@ -48,7 +48,7 @@
     "Email must not be left blank": "El correo electrónico no debe dejarse en blanco",
     "Please enter a valid Email Address": "Por favor, introduce una dirección de correo electrónico válida",
     "Password must not be left blank": "La contraseña no debe dejarse en blanco",
-    "Invalid Password": "Contraseña invalida",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "Su contraseña debe tener al menos 8 caracteres, contener al menos una letra numérica, una mayúscula y una minúscula y un carácter especial (@, #, $, etc.)",
     "Password must not contain spaces": "La contraseña no debe contener espacios",
     "Password does not match original": "La contraseña no coincide con la original",
     "Join Organisation": "Unirse a la organización",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -51,7 +51,7 @@
     "Email must not be left blank": "L'e-mail ne doit pas être laissé vide",
     "Please enter a valid Email Address": "S'il vous plaît, mettez une adresse email valide",
     "Password must not be left blank": "Le mot de passe ne doit pas être laissé vide",
-    "Invalid Password": "Mot de passe incorrect",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "Votre mot de passe doit comporter au moins 8 caractères, contenir au moins un chiffre, une lettre majuscule et une lettre minuscule et un caractère spécial (@, #, $, etc.)",
     "Password must not contain spaces": "Le mot de passe ne doit pas contenir d'espaces",
     "Password does not match original": "Le mot de passe ne correspond pas à l'original",
     "Join Organisation": "Rejoindre l'organisation",

--- a/lang/hi.json
+++ b/lang/hi.json
@@ -48,7 +48,7 @@
     "Email must not be left blank": "ईमेल खाली नहीं छोड़ना चाहिए",
     "Please enter a valid Email Address": "कृपया एक वैध ई - मेल एड्रेस डालें",
     "Password must not be left blank": "पासवर्ड खाली नहीं छोड़ना चाहिए",
-    "Invalid Password": "अवैध पासवर्ड",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "आपका पासवर्ड कम से कम 8 वर्णों का होना चाहिए, जिसमें कम से कम एक संख्यात्मक, एक अपरकेस और एक लोअरकेस अक्षर और एक विशेष वर्ण (@,#,$, आदि) हो।",
     "Password must not contain spaces": "पासवर्ड में रिक्त स्थान नहीं होना चाहिए",
     "Password does not match original": "पासवर्ड मूल से मेल नहीं खाता",
     "Join Organisation": "संगठन में शामिल हों",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -48,7 +48,7 @@
     "Email must not be left blank": "メールを空白のままにしないでください",
     "Please enter a valid Email Address": "有効なメールアドレスを入力してください",
     "Password must not be left blank": "パスワードは空白のままにしないでください",
-    "Invalid Password": "無効なパスワード",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "パスワードは8文字以上で、数字が1つ、大文字と小文字が1つ、特殊文字（@、＃、$など）が1つ含まれている必要があります。",
     "Password must not contain spaces": "パスワードにスペースを含めることはできません",
     "Password does not match original": "パスワードが元のパスワードと一致しません",
     "Join Organisation": "組織に参加する",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -48,7 +48,7 @@
     "Email must not be left blank": "O e-mail não deve ser deixado em branco",
     "Please enter a valid Email Address": "Por favor insira um endereço de e-mail válido",
     "Password must not be left blank": "A senha não deve ser deixada em branco",
-    "Invalid Password": "senha inválida",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "Sua senha deve ter pelo menos 8 caracteres, conter pelo menos um número, uma letra maiúscula e uma minúscula e um caractere especial (@,#,$,etc.)",
     "Password must not contain spaces": "A senha não deve conter espaços",
     "Password does not match original": "A senha não corresponde ao original",
     "Join Organisation": "Junte-se à organização",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -48,7 +48,7 @@
     "Email must not be left blank": "电子邮件不得留空",
     "Please enter a valid Email Address": "请输入有效的电子邮件地址",
     "Password must not be left blank": "密码不能为空",
-    "Invalid Password": "无效的密码",
+    "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,$,etc.)": "您的密码长度必须至少为 8 个字符，至少包含 1 个数字、1 个大写和 1 个小写字母以及 1 个特殊字符（@、#、$ 等）",
     "Password must not contain spaces": "密码不能包含空格",
     "Password does not match original": "密码与原密码不符",
     "Join Organisation": "加入组织",

--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -73,7 +73,7 @@ class Validator {
     final RegExp noSpaceRegex = RegExp(noSpaces);
 
     if (!regExp.hasMatch(password)) {
-      return "Invalid Password";
+      return "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)";
     }
     if (!noSpaceRegex.hasMatch(password)) {
       return "Password must not contain spaces";

--- a/test/widget_tests/pre_auth_screens/change_password_page_test.dart
+++ b/test/widget_tests/pre_auth_screens/change_password_page_test.dart
@@ -141,7 +141,8 @@ void main() {
       //initializing the null pass Submission widget Finder
       final nullPassSubmission = find.text('Password must not be left blank');
       //initializing the invalid password submission widget Finder
-      final invalidPassSubmission = find.text('Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)');
+      final invalidPassSubmission = find.text(
+          'Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)');
       //initializing the invalid password submission widget Finder
       final misMatchPassSubmission =
           find.text('Password does not match original');
@@ -260,7 +261,8 @@ void main() {
       //initializing the null pass Submission widget Finder
       final nullPassSubmission = find.text('Password must not be left blank');
       //initializing the invalid password submission widget Finder
-      final invalidPassSubmission = find.text('Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)');
+      final invalidPassSubmission = find.text(
+          'Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)');
       //initializing the invalid password submission widget Finder
       final misMatchPassSubmission =
           find.text('Password does not match original');

--- a/test/widget_tests/pre_auth_screens/change_password_page_test.dart
+++ b/test/widget_tests/pre_auth_screens/change_password_page_test.dart
@@ -141,7 +141,7 @@ void main() {
       //initializing the null pass Submission widget Finder
       final nullPassSubmission = find.text('Password must not be left blank');
       //initializing the invalid password submission widget Finder
-      final invalidPassSubmission = find.text('Invalid Password');
+      final invalidPassSubmission = find.text('Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)');
       //initializing the invalid password submission widget Finder
       final misMatchPassSubmission =
           find.text('Password does not match original');
@@ -260,7 +260,7 @@ void main() {
       //initializing the null pass Submission widget Finder
       final nullPassSubmission = find.text('Password must not be left blank');
       //initializing the invalid password submission widget Finder
-      final invalidPassSubmission = find.text('Invalid Password');
+      final invalidPassSubmission = find.text('Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)');
       //initializing the invalid password submission widget Finder
       final misMatchPassSubmission =
           find.text('Password does not match original');


### PR DESCRIPTION

**What kind of change does this PR introduce?**
Added password validation criteria for signup page in all supported languages.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1145 

**Did you add tests for your changes?**
No. I am waiting for one other PR to be merged then I will write the tests.
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
<img src="https://user-images.githubusercontent.com/54404474/150571893-c84b21e6-f80e-4194-8ff8-3aea5d314e83.png" height="550" width="280" />   <img src="https://user-images.githubusercontent.com/54404474/150571907-98959b6b-ec33-46a0-b4b3-9197d5c612bd.png" height="550" width="280" />




**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Earlier it was just showing invalid password for all cases and doesn't state the desired password criteria. Now I have added the password criteria and added translation in all supported languages by the app.
Issues resolved by merging this PR is #1145 .


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
