### PR TITLE
Add Annotation for SignupDetailsViewModel in test_helpers.dart

### DIFF
--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -23,6 +23,7 @@ import 'package:talawa/view_model/after_auth_view_models/feed_view_models/organi
 import 'package:talawa/view_model/after_auth_view_models/profile_view_models/profile_page_view_model.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
 import 'package:talawa/view_model/main_screen_view_model.dart';
+import 'package:talawa/view_model/pre_auth_view_models/signup_details_view_model.dart';
 import 'package:talawa/view_model/pre_auth_view_models/waiting_view_model.dart';
 import 'package:talawa/view_model/widgets_view_models/like_button_view_model.dart';
 import 'test_helpers.mocks.dart';
@@ -36,6 +37,7 @@ import 'test_helpers.mocks.dart';
   MockSpec<UserConfig>(returnNullOnMissingStub: true),
   MockSpec<AppLanguage>(returnNullOnMissingStub: true),
   MockSpec<Connectivity>(returnNullOnMissingStub: true),
+  MockSpec<SignupDetailsViewModel>(returnNullOnMissingStub: true),
 ])
 void _removeRegistrationIfExists<T extends Object>() {
   if (locator.isRegistered<T>()) {

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -3,29 +3,39 @@
 // Do not manually edit this file.
 
 import 'dart:async' as _i4;
-import 'dart:io' as _i16;
+import 'dart:io' as _i14;
 import 'dart:ui' as _i9;
 
-import 'package:connectivity_plus/connectivity_plus.dart' as _i10;
+import 'package:connectivity_plus/connectivity_plus.dart' as _i20;
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart'
-    as _i11;
+as _i21;
 import 'package:flutter/material.dart' as _i1;
 import 'package:graphql_flutter/graphql_flutter.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i2;
-import 'package:talawa/enums/enums.dart' as _i21;
-import 'package:talawa/models/events/event_model.dart' as _i18;
+import 'package:talawa/enums/enums.dart' as _i19;
+import 'package:talawa/models/events/event_model.dart' as _i16;
 import 'package:talawa/models/organization/org_info.dart' as _i5;
-import 'package:talawa/models/post/post_model.dart' as _i14;
+import 'package:talawa/models/post/post_model.dart' as _i12;
 import 'package:talawa/models/user/user_info.dart' as _i6;
 import 'package:talawa/services/database_mutation_functions.dart' as _i8;
-import 'package:talawa/services/event_service.dart' as _i17;
-import 'package:talawa/services/graphql_config.dart' as _i12;
+import 'package:talawa/services/event_service.dart' as _i15;
+import 'package:talawa/services/graphql_config.dart' as _i10;
 import 'package:talawa/services/navigation_service.dart' as _i7;
-import 'package:talawa/services/post_service.dart' as _i13;
+import 'package:talawa/services/post_service.dart' as _i11;
 import 'package:talawa/services/third_party_service/multi_media_pick_service.dart'
-    as _i15;
-import 'package:talawa/services/user_config.dart' as _i19;
-import 'package:talawa/view_model/lang_view_model.dart' as _i20;
+as _i13;
+import 'package:talawa/services/user_config.dart' as _i17;
+import 'package:talawa/view_model/lang_view_model.dart' as _i18;
+import 'package:talawa/view_model/pre_auth_view_models/signup_details_view_model.dart'
+as _i22;
+
+// ignore_for_file: avoid_redundant_argument_values
+// ignore_for_file: avoid_setters_without_getters
+// ignore_for_file: comment_references
+// ignore_for_file: implementation_imports
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+// ignore_for_file: prefer_const_constructors
+// ignore_for_file: unnecessary_parenthesis
 
 class _FakeGlobalKey_0<T extends _i1.State<_i1.StatefulWidget>> extends _i2.Fake
     implements _i1.GlobalKey<T> {}
@@ -49,27 +59,13 @@ class _FakeDataBaseMutationFunctions_7 extends _i2.Fake
 
 class _FakeLocale_8 extends _i2.Fake implements _i9.Locale {}
 
-/// A class which mocks [Connectivity].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockConnectivity extends _i2.Mock implements _i10.Connectivity {
-  MockConnectivity() {
-    _i2.throwOnMissingStub(this);
-  }
+class _FakeTextEditingController_9 extends _i2.Fake
+    implements _i1.TextEditingController {}
 
+class _FakeFocusNode_10 extends _i2.Fake implements _i1.FocusNode {
   @override
-  _i4.Stream<_i11.ConnectivityResult> get onConnectivityChanged =>
-      (super.noSuchMethod(Invocation.getter(#onConnectivityChanged),
-              returnValue: Stream<_i11.ConnectivityResult>.empty())
-          as _i4.Stream<_i11.ConnectivityResult>);
-  @override
-  _i4.Future<_i11.ConnectivityResult> checkConnectivity() =>
-      (super.noSuchMethod(Invocation.method(#checkConnectivity, []),
-              returnValue: Future<_i11.ConnectivityResult>.value(
-                  _i11.ConnectivityResult.wifi))
-          as _i4.Future<_i11.ConnectivityResult>);
-  @override
-  String toString() => super.toString();
+  String toString({_i1.DiagnosticLevel? minLevel = _i1.DiagnosticLevel.info}) =>
+      super.toString();
 }
 
 /// A class which mocks [NavigationService].
@@ -79,8 +75,8 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
   @override
   _i1.GlobalKey<_i1.NavigatorState> get navigatorKey =>
       (super.noSuchMethod(Invocation.getter(#navigatorKey),
-              returnValue: _FakeGlobalKey_0<_i1.NavigatorState>())
-          as _i1.GlobalKey<_i1.NavigatorState>);
+          returnValue: _FakeGlobalKey_0<_i1.NavigatorState>())
+      as _i1.GlobalKey<_i1.NavigatorState>);
   @override
   set navigatorKey(_i1.GlobalKey<_i1.NavigatorState>? _navigatorKey) =>
       super.noSuchMethod(Invocation.setter(#navigatorKey, _navigatorKey),
@@ -92,14 +88,14 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> popAndPushScreen(String? routeName,
-          {dynamic arguments}) =>
+      {dynamic arguments}) =>
       (super.noSuchMethod(
           Invocation.method(
               #popAndPushScreen, [routeName], {#arguments: arguments}),
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> pushReplacementScreen(String? routeName,
-          {dynamic arguments}) =>
+      {dynamic arguments}) =>
       (super.noSuchMethod(
           Invocation.method(
               #pushReplacementScreen, [routeName], {#arguments: arguments}),
@@ -111,7 +107,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
           returnValueForMissingStub: null);
   @override
   _i4.Future<dynamic> removeAllAndPush(String? routeName, String? tillRoute,
-          {dynamic arguments}) =>
+      {dynamic arguments}) =>
       (super.noSuchMethod(
           Invocation.method(#removeAllAndPush, [routeName, tillRoute],
               {#arguments: arguments}),
@@ -122,7 +118,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
           returnValueForMissingStub: null);
   @override
   void showSnackBar(String? message,
-          {Duration? duration = const Duration(seconds: 2)}) =>
+      {Duration? duration = const Duration(seconds: 2)}) =>
       super.noSuchMethod(
           Invocation.method(#showSnackBar, [message], {#duration: duration}),
           returnValueForMissingStub: null);
@@ -136,7 +132,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
 /// A class which mocks [GraphqlConfig].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGraphqlConfig extends _i2.Mock implements _i12.GraphqlConfig {
+class MockGraphqlConfig extends _i2.Mock implements _i10.GraphqlConfig {
   @override
   _i3.HttpLink get httpLink => (super.noSuchMethod(Invocation.getter(#httpLink),
       returnValue: _FakeHttpLink_1()) as _i3.HttpLink);
@@ -167,16 +163,16 @@ class MockGraphqlConfig extends _i2.Mock implements _i12.GraphqlConfig {
 /// A class which mocks [PostService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPostService extends _i2.Mock implements _i13.PostService {
+class MockPostService extends _i2.Mock implements _i11.PostService {
   @override
-  _i4.Stream<List<_i14.Post>> get postStream =>
+  _i4.Stream<List<_i12.Post>> get postStream =>
       (super.noSuchMethod(Invocation.getter(#postStream),
-              returnValue: Stream<List<_i14.Post>>.empty())
-          as _i4.Stream<List<_i14.Post>>);
+          returnValue: Stream<List<_i12.Post>>.empty())
+      as _i4.Stream<List<_i12.Post>>);
   @override
-  _i4.Stream<_i14.Post> get updatedPostStream =>
+  _i4.Stream<_i12.Post> get updatedPostStream =>
       (super.noSuchMethod(Invocation.getter(#updatedPostStream),
-          returnValue: Stream<_i14.Post>.empty()) as _i4.Stream<_i14.Post>);
+          returnValue: Stream<_i12.Post>.empty()) as _i4.Stream<_i12.Post>);
   @override
   void setOrgStreamSubscription() =>
       super.noSuchMethod(Invocation.method(#setOrgStreamSubscription, []),
@@ -208,20 +204,20 @@ class MockPostService extends _i2.Mock implements _i13.PostService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockMultiMediaPickerService extends _i2.Mock
-    implements _i15.MultiMediaPickerService {
+    implements _i13.MultiMediaPickerService {
   @override
   _i4.Stream<dynamic> get fileStream =>
       (super.noSuchMethod(Invocation.getter(#fileStream),
           returnValue: Stream<dynamic>.empty()) as _i4.Stream<dynamic>);
   @override
-  _i4.Future<_i16.File?> getPhotoFromGallery({bool? camera = false}) =>
+  _i4.Future<_i14.File?> getPhotoFromGallery({bool? camera = false}) =>
       (super.noSuchMethod(
           Invocation.method(#getPhotoFromGallery, [], {#camera: camera}),
-          returnValue: Future<_i16.File?>.value()) as _i4.Future<_i16.File?>);
+          returnValue: Future<_i14.File?>.value()) as _i4.Future<_i14.File?>);
   @override
-  _i4.Future<_i16.File?> cropImage({_i16.File? imageFile}) => (super
+  _i4.Future<_i14.File?> cropImage({_i14.File? imageFile}) => (super
       .noSuchMethod(Invocation.method(#cropImage, [], {#imageFile: imageFile}),
-          returnValue: Future<_i16.File?>.value()) as _i4.Future<_i16.File?>);
+      returnValue: Future<_i14.File?>.value()) as _i4.Future<_i14.File?>);
   @override
   String toString() => super.toString();
 }
@@ -229,11 +225,11 @@ class MockMultiMediaPickerService extends _i2.Mock
 /// A class which mocks [EventService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEventService extends _i2.Mock implements _i17.EventService {
+class MockEventService extends _i2.Mock implements _i15.EventService {
   @override
-  _i4.Stream<_i18.Event> get eventStream =>
+  _i4.Stream<_i16.Event> get eventStream =>
       (super.noSuchMethod(Invocation.getter(#eventStream),
-          returnValue: Stream<_i18.Event>.empty()) as _i4.Stream<_i18.Event>);
+          returnValue: Stream<_i16.Event>.empty()) as _i4.Stream<_i16.Event>);
   @override
   void setOrgStreamSubscription() =>
       super.noSuchMethod(Invocation.method(#setOrgStreamSubscription, []),
@@ -244,17 +240,16 @@ class MockEventService extends _i2.Mock implements _i17.EventService {
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i4.Future<void> registerForAnEvent(String? eventId) =>
+  _i4.Future<dynamic> registerForAnEvent(String? eventId) =>
       (super.noSuchMethod(Invocation.method(#registerForAnEvent, [eventId]),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+          returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> deleteEvent(String? eventId) =>
       (super.noSuchMethod(Invocation.method(#deleteEvent, [eventId]),
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<void> editEvent(
-          {String? eventId, Map<String, dynamic>? variables}) =>
+      {String? eventId, Map<String, dynamic>? variables}) =>
       (super.noSuchMethod(
           Invocation.method(
               #editEvent, [], {#eventId: eventId, #variables: variables}),
@@ -270,7 +265,7 @@ class MockEventService extends _i2.Mock implements _i17.EventService {
 /// A class which mocks [UserConfig].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUserConfig extends _i2.Mock implements _i19.UserConfig {
+class MockUserConfig extends _i2.Mock implements _i17.UserConfig {
   @override
   _i4.Stream<_i5.OrgInfo> get currentOrfInfoStream =>
       (super.noSuchMethod(Invocation.getter(#currentOrfInfoStream),
@@ -278,8 +273,8 @@ class MockUserConfig extends _i2.Mock implements _i19.UserConfig {
   @override
   _i4.StreamController<_i5.OrgInfo> get currentOrgInfoController =>
       (super.noSuchMethod(Invocation.getter(#currentOrgInfoController),
-              returnValue: _FakeStreamController_3<_i5.OrgInfo>())
-          as _i4.StreamController<_i5.OrgInfo>);
+          returnValue: _FakeStreamController_3<_i5.OrgInfo>())
+      as _i4.StreamController<_i5.OrgInfo>);
   @override
   _i5.OrgInfo get currentOrg =>
       (super.noSuchMethod(Invocation.getter(#currentOrg),
@@ -287,7 +282,7 @@ class MockUserConfig extends _i2.Mock implements _i19.UserConfig {
   @override
   String get currentOrgName =>
       (super.noSuchMethod(Invocation.getter(#currentOrgName), returnValue: '')
-          as String);
+      as String);
   @override
   set currentOrg(_i5.OrgInfo? org) =>
       super.noSuchMethod(Invocation.setter(#currentOrg, org),
@@ -319,7 +314,7 @@ class MockUserConfig extends _i2.Mock implements _i19.UserConfig {
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> updateUserMemberRequestOrg(
-          List<_i5.OrgInfo>? orgDetails) =>
+      List<_i5.OrgInfo>? orgDetails) =>
       (super.noSuchMethod(
           Invocation.method(#updateUserMemberRequestOrg, [orgDetails]),
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
@@ -329,7 +324,7 @@ class MockUserConfig extends _i2.Mock implements _i19.UserConfig {
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> updateAccessToken(
-          {String? accessToken, String? refreshToken}) =>
+      {String? accessToken, String? refreshToken}) =>
       (super.noSuchMethod(
           Invocation.method(#updateAccessToken, [],
               {#accessToken: accessToken, #refreshToken: refreshToken}),
@@ -349,11 +344,11 @@ class MockUserConfig extends _i2.Mock implements _i19.UserConfig {
 /// A class which mocks [AppLanguage].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAppLanguage extends _i2.Mock implements _i20.AppLanguage {
+class MockAppLanguage extends _i2.Mock implements _i18.AppLanguage {
   @override
   bool get isTest =>
       (super.noSuchMethod(Invocation.getter(#isTest), returnValue: false)
-          as bool);
+      as bool);
   @override
   _i7.NavigationService get navigationService =>
       (super.noSuchMethod(Invocation.getter(#navigationService),
@@ -361,22 +356,22 @@ class MockAppLanguage extends _i2.Mock implements _i20.AppLanguage {
   @override
   _i8.DataBaseMutationFunctions get databaseFunctions =>
       (super.noSuchMethod(Invocation.getter(#databaseFunctions),
-              returnValue: _FakeDataBaseMutationFunctions_7())
-          as _i8.DataBaseMutationFunctions);
+          returnValue: _FakeDataBaseMutationFunctions_7())
+      as _i8.DataBaseMutationFunctions);
   @override
   _i9.Locale get appLocal => (super.noSuchMethod(Invocation.getter(#appLocal),
       returnValue: _FakeLocale_8()) as _i9.Locale);
   @override
-  _i21.ViewState get state => (super.noSuchMethod(Invocation.getter(#state),
-      returnValue: _i21.ViewState.idle) as _i21.ViewState);
+  _i19.ViewState get state => (super.noSuchMethod(Invocation.getter(#state),
+      returnValue: _i19.ViewState.idle) as _i19.ViewState);
   @override
   bool get isBusy =>
       (super.noSuchMethod(Invocation.getter(#isBusy), returnValue: false)
-          as bool);
+      as bool);
   @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+      as bool);
   @override
   _i4.Future<void> initialize() =>
       (super.noSuchMethod(Invocation.method(#initialize, []),
@@ -408,7 +403,159 @@ class MockAppLanguage extends _i2.Mock implements _i20.AppLanguage {
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  void setState(_i21.ViewState? viewState) =>
+  void setState(_i19.ViewState? viewState) =>
+      super.noSuchMethod(Invocation.method(#setState, [viewState]),
+          returnValueForMissingStub: null);
+  @override
+  void addListener(_i9.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#addListener, [listener]),
+          returnValueForMissingStub: null);
+  @override
+  void removeListener(_i9.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
+          returnValueForMissingStub: null);
+  @override
+  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
+      returnValueForMissingStub: null);
+  @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
+  @override
+  String toString() => super.toString();
+}
+
+/// A class which mocks [Connectivity].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockConnectivity extends _i2.Mock implements _i20.Connectivity {
+  @override
+  _i4.Stream<_i21.ConnectivityResult> get onConnectivityChanged =>
+      (super.noSuchMethod(Invocation.getter(#onConnectivityChanged),
+          returnValue: Stream<_i21.ConnectivityResult>.empty())
+      as _i4.Stream<_i21.ConnectivityResult>);
+  @override
+  _i4.Future<_i21.ConnectivityResult> checkConnectivity() =>
+      (super.noSuchMethod(Invocation.method(#checkConnectivity, []),
+          returnValue: Future<_i21.ConnectivityResult>.value(
+              _i21.ConnectivityResult.wifi))
+      as _i4.Future<_i21.ConnectivityResult>);
+  @override
+  String toString() => super.toString();
+}
+
+/// A class which mocks [SignupDetailsViewModel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockSignupDetailsViewModel extends _i2.Mock
+    implements _i22.SignupDetailsViewModel {
+  @override
+  _i1.GlobalKey<_i1.FormState> get formKey =>
+      (super.noSuchMethod(Invocation.getter(#formKey),
+          returnValue: _FakeGlobalKey_0<_i1.FormState>())
+      as _i1.GlobalKey<_i1.FormState>);
+  @override
+  List<Map<String, dynamic>> get greeting =>
+      (super.noSuchMethod(Invocation.getter(#greeting),
+          returnValue: <Map<String, dynamic>>[]) as List<Map<String, dynamic>>);
+  @override
+  set greeting(List<Map<String, dynamic>>? _greeting) =>
+      super.noSuchMethod(Invocation.setter(#greeting, _greeting),
+          returnValueForMissingStub: null);
+  @override
+  _i5.OrgInfo get selectedOrganization =>
+      (super.noSuchMethod(Invocation.getter(#selectedOrganization),
+          returnValue: _FakeOrgInfo_4()) as _i5.OrgInfo);
+  @override
+  set selectedOrganization(_i5.OrgInfo? _selectedOrganization) =>
+      super.noSuchMethod(
+          Invocation.setter(#selectedOrganization, _selectedOrganization),
+          returnValueForMissingStub: null);
+  @override
+  _i1.TextEditingController get confirmPassword =>
+      (super.noSuchMethod(Invocation.getter(#confirmPassword),
+          returnValue: _FakeTextEditingController_9())
+      as _i1.TextEditingController);
+  @override
+  set confirmPassword(_i1.TextEditingController? _confirmPassword) =>
+      super.noSuchMethod(Invocation.setter(#confirmPassword, _confirmPassword),
+          returnValueForMissingStub: null);
+  @override
+  _i1.TextEditingController get firstName =>
+      (super.noSuchMethod(Invocation.getter(#firstName),
+          returnValue: _FakeTextEditingController_9())
+      as _i1.TextEditingController);
+  @override
+  set firstName(_i1.TextEditingController? _firstName) =>
+      super.noSuchMethod(Invocation.setter(#firstName, _firstName),
+          returnValueForMissingStub: null);
+  @override
+  _i1.TextEditingController get lastName =>
+      (super.noSuchMethod(Invocation.getter(#lastName),
+          returnValue: _FakeTextEditingController_9())
+      as _i1.TextEditingController);
+  @override
+  set lastName(_i1.TextEditingController? _lastName) =>
+      super.noSuchMethod(Invocation.setter(#lastName, _lastName),
+          returnValueForMissingStub: null);
+  @override
+  _i1.TextEditingController get password =>
+      (super.noSuchMethod(Invocation.getter(#password),
+          returnValue: _FakeTextEditingController_9())
+      as _i1.TextEditingController);
+  @override
+  set password(_i1.TextEditingController? _password) =>
+      super.noSuchMethod(Invocation.setter(#password, _password),
+          returnValueForMissingStub: null);
+  @override
+  _i1.TextEditingController get email =>
+      (super.noSuchMethod(Invocation.getter(#email),
+          returnValue: _FakeTextEditingController_9())
+      as _i1.TextEditingController);
+  @override
+  set email(_i1.TextEditingController? _email) =>
+      super.noSuchMethod(Invocation.setter(#email, _email),
+          returnValueForMissingStub: null);
+  @override
+  _i1.AutovalidateMode get validate =>
+      (super.noSuchMethod(Invocation.getter(#validate),
+          returnValue: _i1.AutovalidateMode.disabled) as _i1.AutovalidateMode);
+  @override
+  set validate(_i1.AutovalidateMode? _validate) =>
+      super.noSuchMethod(Invocation.setter(#validate, _validate),
+          returnValueForMissingStub: null);
+  @override
+  _i1.FocusNode get confirmFocus =>
+      (super.noSuchMethod(Invocation.getter(#confirmFocus),
+          returnValue: _FakeFocusNode_10()) as _i1.FocusNode);
+  @override
+  set confirmFocus(_i1.FocusNode? _confirmFocus) =>
+      super.noSuchMethod(Invocation.setter(#confirmFocus, _confirmFocus),
+          returnValueForMissingStub: null);
+  @override
+  bool get hidePassword =>
+      (super.noSuchMethod(Invocation.getter(#hidePassword), returnValue: false)
+      as bool);
+  @override
+  set hidePassword(bool? _hidePassword) =>
+      super.noSuchMethod(Invocation.setter(#hidePassword, _hidePassword),
+          returnValueForMissingStub: null);
+  @override
+  _i19.ViewState get state => (super.noSuchMethod(Invocation.getter(#state),
+      returnValue: _i19.ViewState.idle) as _i19.ViewState);
+  @override
+  bool get isBusy =>
+      (super.noSuchMethod(Invocation.getter(#isBusy), returnValue: false)
+      as bool);
+  @override
+  bool get hasListeners =>
+      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
+      as bool);
+  @override
+  dynamic initialise(_i5.OrgInfo? org) =>
+      super.noSuchMethod(Invocation.method(#initialise, [org]));
+  @override
+  void setState(_i19.ViewState? viewState) =>
       super.noSuchMethod(Invocation.method(#setState, [viewState]),
           returnValueForMissingStub: null);
   @override

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -8,7 +8,7 @@ import 'dart:ui' as _i9;
 
 import 'package:connectivity_plus/connectivity_plus.dart' as _i20;
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart'
-as _i21;
+    as _i21;
 import 'package:flutter/material.dart' as _i1;
 import 'package:graphql_flutter/graphql_flutter.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i2;
@@ -23,11 +23,11 @@ import 'package:talawa/services/graphql_config.dart' as _i10;
 import 'package:talawa/services/navigation_service.dart' as _i7;
 import 'package:talawa/services/post_service.dart' as _i11;
 import 'package:talawa/services/third_party_service/multi_media_pick_service.dart'
-as _i13;
+    as _i13;
 import 'package:talawa/services/user_config.dart' as _i17;
 import 'package:talawa/view_model/lang_view_model.dart' as _i18;
 import 'package:talawa/view_model/pre_auth_view_models/signup_details_view_model.dart'
-as _i22;
+    as _i22;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -75,8 +75,8 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
   @override
   _i1.GlobalKey<_i1.NavigatorState> get navigatorKey =>
       (super.noSuchMethod(Invocation.getter(#navigatorKey),
-          returnValue: _FakeGlobalKey_0<_i1.NavigatorState>())
-      as _i1.GlobalKey<_i1.NavigatorState>);
+              returnValue: _FakeGlobalKey_0<_i1.NavigatorState>())
+          as _i1.GlobalKey<_i1.NavigatorState>);
   @override
   set navigatorKey(_i1.GlobalKey<_i1.NavigatorState>? _navigatorKey) =>
       super.noSuchMethod(Invocation.setter(#navigatorKey, _navigatorKey),
@@ -88,14 +88,14 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> popAndPushScreen(String? routeName,
-      {dynamic arguments}) =>
+          {dynamic arguments}) =>
       (super.noSuchMethod(
           Invocation.method(
               #popAndPushScreen, [routeName], {#arguments: arguments}),
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> pushReplacementScreen(String? routeName,
-      {dynamic arguments}) =>
+          {dynamic arguments}) =>
       (super.noSuchMethod(
           Invocation.method(
               #pushReplacementScreen, [routeName], {#arguments: arguments}),
@@ -107,7 +107,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
           returnValueForMissingStub: null);
   @override
   _i4.Future<dynamic> removeAllAndPush(String? routeName, String? tillRoute,
-      {dynamic arguments}) =>
+          {dynamic arguments}) =>
       (super.noSuchMethod(
           Invocation.method(#removeAllAndPush, [routeName, tillRoute],
               {#arguments: arguments}),
@@ -118,7 +118,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
           returnValueForMissingStub: null);
   @override
   void showSnackBar(String? message,
-      {Duration? duration = const Duration(seconds: 2)}) =>
+          {Duration? duration = const Duration(seconds: 2)}) =>
       super.noSuchMethod(
           Invocation.method(#showSnackBar, [message], {#duration: duration}),
           returnValueForMissingStub: null);
@@ -167,8 +167,8 @@ class MockPostService extends _i2.Mock implements _i11.PostService {
   @override
   _i4.Stream<List<_i12.Post>> get postStream =>
       (super.noSuchMethod(Invocation.getter(#postStream),
-          returnValue: Stream<List<_i12.Post>>.empty())
-      as _i4.Stream<List<_i12.Post>>);
+              returnValue: Stream<List<_i12.Post>>.empty())
+          as _i4.Stream<List<_i12.Post>>);
   @override
   _i4.Stream<_i12.Post> get updatedPostStream =>
       (super.noSuchMethod(Invocation.getter(#updatedPostStream),
@@ -217,7 +217,7 @@ class MockMultiMediaPickerService extends _i2.Mock
   @override
   _i4.Future<_i14.File?> cropImage({_i14.File? imageFile}) => (super
       .noSuchMethod(Invocation.method(#cropImage, [], {#imageFile: imageFile}),
-      returnValue: Future<_i14.File?>.value()) as _i4.Future<_i14.File?>);
+          returnValue: Future<_i14.File?>.value()) as _i4.Future<_i14.File?>);
   @override
   String toString() => super.toString();
 }
@@ -249,7 +249,7 @@ class MockEventService extends _i2.Mock implements _i15.EventService {
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<void> editEvent(
-      {String? eventId, Map<String, dynamic>? variables}) =>
+          {String? eventId, Map<String, dynamic>? variables}) =>
       (super.noSuchMethod(
           Invocation.method(
               #editEvent, [], {#eventId: eventId, #variables: variables}),
@@ -273,8 +273,8 @@ class MockUserConfig extends _i2.Mock implements _i17.UserConfig {
   @override
   _i4.StreamController<_i5.OrgInfo> get currentOrgInfoController =>
       (super.noSuchMethod(Invocation.getter(#currentOrgInfoController),
-          returnValue: _FakeStreamController_3<_i5.OrgInfo>())
-      as _i4.StreamController<_i5.OrgInfo>);
+              returnValue: _FakeStreamController_3<_i5.OrgInfo>())
+          as _i4.StreamController<_i5.OrgInfo>);
   @override
   _i5.OrgInfo get currentOrg =>
       (super.noSuchMethod(Invocation.getter(#currentOrg),
@@ -282,7 +282,7 @@ class MockUserConfig extends _i2.Mock implements _i17.UserConfig {
   @override
   String get currentOrgName =>
       (super.noSuchMethod(Invocation.getter(#currentOrgName), returnValue: '')
-      as String);
+          as String);
   @override
   set currentOrg(_i5.OrgInfo? org) =>
       super.noSuchMethod(Invocation.setter(#currentOrg, org),
@@ -314,7 +314,7 @@ class MockUserConfig extends _i2.Mock implements _i17.UserConfig {
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> updateUserMemberRequestOrg(
-      List<_i5.OrgInfo>? orgDetails) =>
+          List<_i5.OrgInfo>? orgDetails) =>
       (super.noSuchMethod(
           Invocation.method(#updateUserMemberRequestOrg, [orgDetails]),
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
@@ -324,7 +324,7 @@ class MockUserConfig extends _i2.Mock implements _i17.UserConfig {
           returnValue: Future<dynamic>.value()) as _i4.Future<dynamic>);
   @override
   _i4.Future<dynamic> updateAccessToken(
-      {String? accessToken, String? refreshToken}) =>
+          {String? accessToken, String? refreshToken}) =>
       (super.noSuchMethod(
           Invocation.method(#updateAccessToken, [],
               {#accessToken: accessToken, #refreshToken: refreshToken}),
@@ -348,7 +348,7 @@ class MockAppLanguage extends _i2.Mock implements _i18.AppLanguage {
   @override
   bool get isTest =>
       (super.noSuchMethod(Invocation.getter(#isTest), returnValue: false)
-      as bool);
+          as bool);
   @override
   _i7.NavigationService get navigationService =>
       (super.noSuchMethod(Invocation.getter(#navigationService),
@@ -356,8 +356,8 @@ class MockAppLanguage extends _i2.Mock implements _i18.AppLanguage {
   @override
   _i8.DataBaseMutationFunctions get databaseFunctions =>
       (super.noSuchMethod(Invocation.getter(#databaseFunctions),
-          returnValue: _FakeDataBaseMutationFunctions_7())
-      as _i8.DataBaseMutationFunctions);
+              returnValue: _FakeDataBaseMutationFunctions_7())
+          as _i8.DataBaseMutationFunctions);
   @override
   _i9.Locale get appLocal => (super.noSuchMethod(Invocation.getter(#appLocal),
       returnValue: _FakeLocale_8()) as _i9.Locale);
@@ -367,11 +367,11 @@ class MockAppLanguage extends _i2.Mock implements _i18.AppLanguage {
   @override
   bool get isBusy =>
       (super.noSuchMethod(Invocation.getter(#isBusy), returnValue: false)
-      as bool);
+          as bool);
   @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-      as bool);
+          as bool);
   @override
   _i4.Future<void> initialize() =>
       (super.noSuchMethod(Invocation.method(#initialize, []),
@@ -432,14 +432,14 @@ class MockConnectivity extends _i2.Mock implements _i20.Connectivity {
   @override
   _i4.Stream<_i21.ConnectivityResult> get onConnectivityChanged =>
       (super.noSuchMethod(Invocation.getter(#onConnectivityChanged),
-          returnValue: Stream<_i21.ConnectivityResult>.empty())
-      as _i4.Stream<_i21.ConnectivityResult>);
+              returnValue: Stream<_i21.ConnectivityResult>.empty())
+          as _i4.Stream<_i21.ConnectivityResult>);
   @override
   _i4.Future<_i21.ConnectivityResult> checkConnectivity() =>
       (super.noSuchMethod(Invocation.method(#checkConnectivity, []),
-          returnValue: Future<_i21.ConnectivityResult>.value(
-              _i21.ConnectivityResult.wifi))
-      as _i4.Future<_i21.ConnectivityResult>);
+              returnValue: Future<_i21.ConnectivityResult>.value(
+                  _i21.ConnectivityResult.wifi))
+          as _i4.Future<_i21.ConnectivityResult>);
   @override
   String toString() => super.toString();
 }
@@ -452,8 +452,8 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.GlobalKey<_i1.FormState> get formKey =>
       (super.noSuchMethod(Invocation.getter(#formKey),
-          returnValue: _FakeGlobalKey_0<_i1.FormState>())
-      as _i1.GlobalKey<_i1.FormState>);
+              returnValue: _FakeGlobalKey_0<_i1.FormState>())
+          as _i1.GlobalKey<_i1.FormState>);
   @override
   List<Map<String, dynamic>> get greeting =>
       (super.noSuchMethod(Invocation.getter(#greeting),
@@ -474,8 +474,8 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get confirmPassword =>
       (super.noSuchMethod(Invocation.getter(#confirmPassword),
-          returnValue: _FakeTextEditingController_9())
-      as _i1.TextEditingController);
+              returnValue: _FakeTextEditingController_9())
+          as _i1.TextEditingController);
   @override
   set confirmPassword(_i1.TextEditingController? _confirmPassword) =>
       super.noSuchMethod(Invocation.setter(#confirmPassword, _confirmPassword),
@@ -483,8 +483,8 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get firstName =>
       (super.noSuchMethod(Invocation.getter(#firstName),
-          returnValue: _FakeTextEditingController_9())
-      as _i1.TextEditingController);
+              returnValue: _FakeTextEditingController_9())
+          as _i1.TextEditingController);
   @override
   set firstName(_i1.TextEditingController? _firstName) =>
       super.noSuchMethod(Invocation.setter(#firstName, _firstName),
@@ -492,8 +492,8 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get lastName =>
       (super.noSuchMethod(Invocation.getter(#lastName),
-          returnValue: _FakeTextEditingController_9())
-      as _i1.TextEditingController);
+              returnValue: _FakeTextEditingController_9())
+          as _i1.TextEditingController);
   @override
   set lastName(_i1.TextEditingController? _lastName) =>
       super.noSuchMethod(Invocation.setter(#lastName, _lastName),
@@ -501,8 +501,8 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get password =>
       (super.noSuchMethod(Invocation.getter(#password),
-          returnValue: _FakeTextEditingController_9())
-      as _i1.TextEditingController);
+              returnValue: _FakeTextEditingController_9())
+          as _i1.TextEditingController);
   @override
   set password(_i1.TextEditingController? _password) =>
       super.noSuchMethod(Invocation.setter(#password, _password),
@@ -510,8 +510,8 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get email =>
       (super.noSuchMethod(Invocation.getter(#email),
-          returnValue: _FakeTextEditingController_9())
-      as _i1.TextEditingController);
+              returnValue: _FakeTextEditingController_9())
+          as _i1.TextEditingController);
   @override
   set email(_i1.TextEditingController? _email) =>
       super.noSuchMethod(Invocation.setter(#email, _email),
@@ -535,7 +535,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   bool get hidePassword =>
       (super.noSuchMethod(Invocation.getter(#hidePassword), returnValue: false)
-      as bool);
+          as bool);
   @override
   set hidePassword(bool? _hidePassword) =>
       super.noSuchMethod(Invocation.setter(#hidePassword, _hidePassword),
@@ -546,11 +546,11 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   bool get isBusy =>
       (super.noSuchMethod(Invocation.getter(#isBusy), returnValue: false)
-      as bool);
+          as bool);
   @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-      as bool);
+          as bool);
   @override
   dynamic initialise(_i5.OrgInfo? org) =>
       super.noSuchMethod(Invocation.method(#initialise, [org]));

--- a/test/view_model_tests/signup_details_view_model_test.dart
+++ b/test/view_model_tests/signup_details_view_model_test.dart
@@ -28,21 +28,22 @@ void main() {
   group('SignUp Tests', () {
     final model = MockSignupDetailsViewModel();
 
-    test('Test validation for first and last name' , (){
+    test('Test validation for first and last name', () {
       final String? blankFirstName = Validator.validateFirstName("");
       expect(blankFirstName, "Firstname must not be left blank.");
 
       final String? blankLastName = Validator.validateLastName("");
       expect(blankLastName, "Lastname must not be left blank.");
 
-      final String? validFirstName = Validator.validateFirstName("testFirstName");
-      expect(validFirstName , null);
+      final String? validFirstName =
+          Validator.validateFirstName("testFirstName");
+      expect(validFirstName, null);
 
       final String? validLastName = Validator.validateLastName("testLastName");
-      expect(validLastName , null);
+      expect(validLastName, null);
     });
 
-    test('Test validation for Email', (){
+    test('Test validation for Email', () {
       final String? blankEmail = Validator.validateEmail("");
       expect(blankEmail, "Email must not be left blank");
 
@@ -55,13 +56,14 @@ void main() {
       final String? invalidEmail3 = Validator.validateEmail("@test.com");
       expect(invalidEmail3, "Please enter a valid Email Address");
 
-      final String? validEmail = Validator.validateEmail("testName@testOrg.com");
+      final String? validEmail =
+          Validator.validateEmail("testName@testOrg.com");
       expect(validEmail, null);
     });
 
-    test('Test validation for password' , (){
+    test('Test validation for password', () {
       final String? blankPassword = Validator.validatePassword("");
-      expect(blankPassword , "Password must not be left blank");
+      expect(blankPassword, "Password must not be left blank");
 
       final String? invalidPassword1 = Validator.validatePassword("test");
       expect(invalidPassword1, "Invalid Password");
@@ -70,39 +72,41 @@ void main() {
       expect(invalidPassword2, "Invalid Password");
 
       final String? invalidPassword3 = Validator.validatePassword("TEST");
-      expect(invalidPassword3 , "Invalid Password");
+      expect(invalidPassword3, "Invalid Password");
 
       final String? invalidPassword4 = Validator.validatePassword("test123");
-      expect(invalidPassword4 , "Invalid Password");
+      expect(invalidPassword4, "Invalid Password");
 
       final String? invalidPassword5 = Validator.validatePassword("test123!");
-      expect(invalidPassword5 , "Invalid Password");
+      expect(invalidPassword5, "Invalid Password");
 
       final String? validPassword = Validator.validatePassword("tesT123!");
-      expect(validPassword , null);
+      expect(validPassword, null);
 
       // test for confirm password
-      final String? differentPassword = Validator.validatePasswordConfirm("tesT123", "test1234");
-      expect(differentPassword , "Password does not match original");
+      final String? differentPassword =
+          Validator.validatePasswordConfirm("tesT123", "test1234");
+      expect(differentPassword, "Password does not match original");
 
-      final String? matchingPassword = Validator.validatePasswordConfirm("tesT123", "tesT123");
+      final String? matchingPassword =
+          Validator.validatePasswordConfirm("tesT123", "tesT123");
       expect(matchingPassword, null);
     });
 
-    test('Test sign up function' , () async{
+    test('Test sign up function', () async {
       final User newUser = User();
 
-      when(model.signUp()).thenAnswer((realInvocation){
-        if(newUser.id == null || newUser.id == ""){
+      when(model.signUp()).thenAnswer((realInvocation) {
+        if (newUser.id == null || newUser.id == "") {
           return "User Id can't be blank";
         }
-        if(newUser.firstName == null || newUser.firstName == ""){
+        if (newUser.firstName == null || newUser.firstName == "") {
           return "First Name can't be blank";
         }
-        if(newUser.lastName == null || newUser.lastName == ""){
+        if (newUser.lastName == null || newUser.lastName == "") {
           return "Last Name can't be blank";
         }
-        if(newUser.email == null || newUser.email == ""){
+        if (newUser.email == null || newUser.email == "") {
           return "Email can't be blank";
         }
         return {
@@ -130,10 +134,7 @@ void main() {
         "firstName": newUser.firstName,
         "lastName": newUser.lastName,
         "email": newUser.email,
-      }
-      );
-
+      });
     });
-
   });
 }

--- a/test/view_model_tests/signup_details_view_model_test.dart
+++ b/test/view_model_tests/signup_details_view_model_test.dart
@@ -66,19 +66,24 @@ void main() {
       expect(blankPassword, "Password must not be left blank");
 
       final String? invalidPassword1 = Validator.validatePassword("test");
-      expect(invalidPassword1, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
+      expect(invalidPassword1,
+          "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword2 = Validator.validatePassword("123");
-      expect(invalidPassword2, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
+      expect(invalidPassword2,
+          "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword3 = Validator.validatePassword("TEST");
-      expect(invalidPassword3, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
+      expect(invalidPassword3,
+          "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword4 = Validator.validatePassword("test123");
-      expect(invalidPassword4, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
+      expect(invalidPassword4,
+          "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword5 = Validator.validatePassword("test123!");
-      expect(invalidPassword5, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
+      expect(invalidPassword5,
+          "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? validPassword = Validator.validatePassword("tesT123!");
       expect(validPassword, null);

--- a/test/view_model_tests/signup_details_view_model_test.dart
+++ b/test/view_model_tests/signup_details_view_model_test.dart
@@ -117,18 +117,24 @@ void main() {
         };
       });
 
+      //checking with blank user Id
       expect(model.signUp(), "User Id can't be blank");
 
       newUser.id = "5";
+      //checking with blank first name
       expect(model.signUp(), "First Name can't be blank");
 
       newUser.firstName = "testFirstName";
+      //checking with blank last name
       expect(model.signUp(), "Last Name can't be blank");
 
       newUser.lastName = "testLastName";
+      //checking with blank email
       expect(model.signUp(), "Email can't be blank");
 
       newUser.email = "testName@testOrg.com";
+      // checking with all details
+      // should give proper response
       expect(model.signUp(), {
         "id": newUser.id,
         "firstName": newUser.firstName,

--- a/test/view_model_tests/signup_details_view_model_test.dart
+++ b/test/view_model_tests/signup_details_view_model_test.dart
@@ -66,19 +66,19 @@ void main() {
       expect(blankPassword, "Password must not be left blank");
 
       final String? invalidPassword1 = Validator.validatePassword("test");
-      expect(invalidPassword1, "Invalid Password");
+      expect(invalidPassword1, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword2 = Validator.validatePassword("123");
-      expect(invalidPassword2, "Invalid Password");
+      expect(invalidPassword2, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword3 = Validator.validatePassword("TEST");
-      expect(invalidPassword3, "Invalid Password");
+      expect(invalidPassword3, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword4 = Validator.validatePassword("test123");
-      expect(invalidPassword4, "Invalid Password");
+      expect(invalidPassword4, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? invalidPassword5 = Validator.validatePassword("test123!");
-      expect(invalidPassword5, "Invalid Password");
+      expect(invalidPassword5, "Your password must be at least 8 characters long, contain at least one numeric, one uppercase and one lowercase letters and one special character (@,#,\$,etc.)");
 
       final String? validPassword = Validator.validatePassword("tesT123!");
       expect(validPassword, null);

--- a/test/view_model_tests/signup_details_view_model_test.dart
+++ b/test/view_model_tests/signup_details_view_model_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:talawa/models/user/user_info.dart';
+import 'package:talawa/services/graphql_config.dart';
+import 'package:talawa/services/size_config.dart';
+import 'package:talawa/utils/validators.dart';
+import '../helpers/test_helpers.dart';
+import '../helpers/test_helpers.mocks.dart';
+import '../helpers/test_locator.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+void main() {
+  testSetupLocator();
+  locator<GraphqlConfig>().test();
+  locator<SizeConfig>().test();
+
+  setUp(() {
+    registerServices();
+    locator<SizeConfig>().test();
+  });
+
+  tearDown(() {
+    unregisterServices();
+  });
+
+  group('SignUp Tests', () {
+    final model = MockSignupDetailsViewModel();
+
+    test('Test validation for first and last name' , (){
+      final String? blankFirstName = Validator.validateFirstName("");
+      expect(blankFirstName, "Firstname must not be left blank.");
+
+      final String? blankLastName = Validator.validateLastName("");
+      expect(blankLastName, "Lastname must not be left blank.");
+
+      final String? validFirstName = Validator.validateFirstName("testFirstName");
+      expect(validFirstName , null);
+
+      final String? validLastName = Validator.validateLastName("testLastName");
+      expect(validLastName , null);
+    });
+
+    test('Test validation for Email', (){
+      final String? blankEmail = Validator.validateEmail("");
+      expect(blankEmail, "Email must not be left blank");
+
+      final String? invalidEmail1 = Validator.validateEmail("testInvalidEmail");
+      expect(invalidEmail1, "Please enter a valid Email Address");
+
+      final String? invalidEmail2 = Validator.validateEmail("test@.com");
+      expect(invalidEmail2, "Please enter a valid Email Address");
+
+      final String? invalidEmail3 = Validator.validateEmail("@test.com");
+      expect(invalidEmail3, "Please enter a valid Email Address");
+
+      final String? validEmail = Validator.validateEmail("testName@testOrg.com");
+      expect(validEmail, null);
+    });
+
+    test('Test validation for password' , (){
+      final String? blankPassword = Validator.validatePassword("");
+      expect(blankPassword , "Password must not be left blank");
+
+      final String? invalidPassword1 = Validator.validatePassword("test");
+      expect(invalidPassword1, "Invalid Password");
+
+      final String? invalidPassword2 = Validator.validatePassword("123");
+      expect(invalidPassword2, "Invalid Password");
+
+      final String? invalidPassword3 = Validator.validatePassword("TEST");
+      expect(invalidPassword3 , "Invalid Password");
+
+      final String? invalidPassword4 = Validator.validatePassword("test123");
+      expect(invalidPassword4 , "Invalid Password");
+
+      final String? invalidPassword5 = Validator.validatePassword("test123!");
+      expect(invalidPassword5 , "Invalid Password");
+
+      final String? validPassword = Validator.validatePassword("tesT123!");
+      expect(validPassword , null);
+
+      // test for confirm password
+      final String? differentPassword = Validator.validatePasswordConfirm("tesT123", "test1234");
+      expect(differentPassword , "Password does not match original");
+
+      final String? matchingPassword = Validator.validatePasswordConfirm("tesT123", "tesT123");
+      expect(matchingPassword, null);
+    });
+
+    test('Test sign up function' , () async{
+      final User newUser = User();
+
+      when(model.signUp()).thenAnswer((realInvocation){
+        if(newUser.id == null || newUser.id == ""){
+          return "User Id can't be blank";
+        }
+        if(newUser.firstName == null || newUser.firstName == ""){
+          return "First Name can't be blank";
+        }
+        if(newUser.lastName == null || newUser.lastName == ""){
+          return "Last Name can't be blank";
+        }
+        if(newUser.email == null || newUser.email == ""){
+          return "Email can't be blank";
+        }
+        return {
+          "id": newUser.id,
+          "firstName": newUser.firstName,
+          "lastName": newUser.lastName,
+          "email": newUser.email,
+        };
+      });
+
+      expect(model.signUp(), "User Id can't be blank");
+
+      newUser.id = "5";
+      expect(model.signUp(), "First Name can't be blank");
+
+      newUser.firstName = "testFirstName";
+      expect(model.signUp(), "Last Name can't be blank");
+
+      newUser.lastName = "testLastName";
+      expect(model.signUp(), "Email can't be blank");
+
+      newUser.email = "testName@testOrg.com";
+      expect(model.signUp(), {
+        "id": newUser.id,
+        "firstName": newUser.firstName,
+        "lastName": newUser.lastName,
+        "email": newUser.email,
+      }
+      );
+
+    });
+
+  });
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Added an annotation for SignUpDetailsViewModel in test_helpers.dart.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Related to [PR #1115](https://github.com/PalisadoesFoundation/talawa/pull/1115)

**Summary**
This change is made because otherwise the SignupDetailsViewModel won't be generated if the test_helpers.mock is generated again.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
