### PR TITLE
added tests for scanQR on SetUrl Page

### DIFF
--- a/test/widget_tests/pre_auth_screens/set_url_page_test.dart
+++ b/test/widget_tests/pre_auth_screens/set_url_page_test.dart
@@ -297,6 +297,21 @@ Future<void> main() async {
         'Login',
       );
     });
+
+    testWidgets("Check navigation to Login page when Login button is pressed.",
+        (tester) async {
+      await tester.pumpWidget(createSetUrlScreenDark());
+      await tester.pump();
+      expect(find.byKey(const Key('SetUrlScreenScaffold')), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const Key('UrlInputField')),
+        'https://talawa-graphql-api.herokuapp.com/graphql',
+      );
+      await tester.tap(find.byKey(const Key('LoginButton')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('UrlPageText')), findsOneWidget);
+    });
     testWidgets("Testing if signup button works", (tester) async {
       //pushing setUrlScreen
       await tester.pumpWidget(createSetUrlScreenLight());

--- a/test/widget_tests/pre_auth_screens/set_url_page_test.dart
+++ b/test/widget_tests/pre_auth_screens/set_url_page_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 // import 'package:path_provider/path_provider.dart' as path;
 import 'package:provider/provider.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:talawa/constants/custom_theme.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/organization/org_info.dart';
@@ -365,6 +366,21 @@ Future<void> main() async {
       );
 
       expect((tester.firstWidget(iconButton) as Icon).size, 30);
+    });
+    testWidgets("Check if QR button works", (tester) async {
+      //pushing setUrlScreen
+      await tester.pumpWidget(createSetUrlScreenDark());
+      await tester.pumpAndSettle();
+
+      final iconButton = find.byIcon(Icons.qr_code_scanner);
+      print('ICON BUTTON: $iconButton');
+
+      // tapping the qr button
+      await tester.tap(iconButton);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ClipRRect), findsOneWidget);
+      expect(find.byType(QRView), findsOneWidget);
     });
     testWidgets("Testing if app logo shows up", (tester) async {
       //pushing setUrlScreen


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Creating tests for Set Url page (on pressing scan QR)


**Issue Number:**
Fixes #1248 

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**
No


**Other information**

<!--Add extra information about this PR here-->
Creating a test when the user presses the QR iconButton in setUrl page.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
