### PR TITLE
added tests for Cancel and Done button in Explore Event Dialog Box

### DIFF
--- a/lib/views/after_auth_screens/events/explore_event_dialogue.dart
+++ b/lib/views/after_auth_screens/events/explore_event_dialogue.dart
@@ -36,6 +36,7 @@ class _ExploreEventDialogState extends State<ExploreEventDialog> {
                     height: 5,
                   ),
                   GestureDetector(
+                    key: const Key('StartDateSelector'),
                     onTap: () async {
                       final _date =
                           await customDatePicker(initialDate: _startDate);
@@ -51,7 +52,8 @@ class _ExploreEventDialogState extends State<ExploreEventDialog> {
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
-                            const Expanded(
+                            const Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 10),
                               child: Icon(
                                 Icons.calendar_today,
                                 size: 19,
@@ -60,6 +62,7 @@ class _ExploreEventDialogState extends State<ExploreEventDialog> {
                             Expanded(
                               child: Text(
                                 "${_startDate.toLocal()}".split(' ')[0],
+                                maxLines: 1,
                               ),
                             ),
                           ],
@@ -79,6 +82,7 @@ class _ExploreEventDialogState extends State<ExploreEventDialog> {
                     height: 5,
                   ),
                   GestureDetector(
+                    key: const Key('EndDateSelector'),
                     onTap: () async {
                       final _date =
                           await customDatePicker(initialDate: _endDate);
@@ -92,9 +96,10 @@ class _ExploreEventDialogState extends State<ExploreEventDialog> {
                       child: Card(
                         color: Theme.of(context).colorScheme.primaryContainer,
                         child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          mainAxisAlignment: MainAxisAlignment.start,
                           children: [
-                            const Expanded(
+                            const Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 10),
                               child: Icon(
                                 Icons.calendar_today,
                                 size: 20,
@@ -103,6 +108,7 @@ class _ExploreEventDialogState extends State<ExploreEventDialog> {
                             Expanded(
                               child: Text(
                                 "${_endDate.toLocal()}".split(' ')[0],
+                                maxLines: 1,
                               ),
                             ),
                           ],

--- a/test/widget_tests/after_auth_screens/events/explore_event_dialogue_test.dart
+++ b/test/widget_tests/after_auth_screens/events/explore_event_dialogue_test.dart
@@ -36,7 +36,7 @@ Widget createExploreEventDialog() {
 
 main() {
   DateTime _startDate = DateTime.now().toLocal();
-  DateTime _endDate = DateTime.now().add(const Duration(days: 1)).toLocal();
+  // DateTime _endDate = DateTime.now().add(const Duration(days: 1)).toLocal();
   setUp(() {
     registerServices();
     locator<SizeConfig>().test();

--- a/test/widget_tests/after_auth_screens/events/explore_event_dialogue_test.dart
+++ b/test/widget_tests/after_auth_screens/events/explore_event_dialogue_test.dart
@@ -2,48 +2,125 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:talawa/router.dart' as router;
-import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
 import 'package:talawa/views/after_auth_screens/events/explore_event_dialogue.dart';
+import 'package:talawa/widgets/date_time_picker.dart';
 
 import '../../../helpers/test_helpers.dart';
 import '../../../helpers/test_locator.dart';
 
 Widget createExploreEventDialog() {
   return MaterialApp(
-    localizationsDelegates: [
-      const AppLocalizationsDelegate(isTest: true),
-      GlobalMaterialLocalizations.delegate,
-      GlobalWidgetsLocalizations.delegate,
-    ],
-    navigatorKey: locator<NavigationService>().navigatorKey,
-    onGenerateRoute: router.generateRoute,
-    home: const ExploreEventDialog(
-      key: Key('ExploreEventDialog'),
-    ),
-  );
+      localizationsDelegates: [
+        const AppLocalizationsDelegate(isTest: true),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      navigatorKey: navigationService.navigatorKey,
+      onGenerateRoute: router.generateRoute,
+      home: Builder(builder: (context) {
+        return Container(
+            child: TextButton(
+                key: const Key('TextButtonKey'),
+                onPressed: () {
+                  showDialog(
+                      context: context,
+                      builder: (_) => const ExploreEventDialog(
+                            key: Key('ExploreEventDialog'),
+                          ));
+                },
+                child: const Text('EventDialog')));
+      }));
 }
 
 main() {
+  DateTime _startDate = DateTime.now().toLocal();
+  DateTime _endDate = DateTime.now().add(const Duration(days: 1)).toLocal();
+  setUp(() {
+    registerServices();
+    locator<SizeConfig>().test();
+  });
+
+  tearDown(() {
+    unregisterServices();
+  });
+
+  Future<void> prepareDatePicker(WidgetTester tester,
+      Future<void> Function(Future<DateTime> date) callback) async {
+    await tester.pumpWidget(createExploreEventDialog());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('TextButtonKey')));
+    final date = customDatePicker(initialDate: _startDate);
+
+    await tester.pumpAndSettle();
+    expect(find.text(_startDate.toString().split(' ')[0]), findsOneWidget);
+    await tester.ensureVisible(find.byKey(const Key('StartDateSelector')));
+    await tester.tap(find.byKey(const Key('StartDateSelector')));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    callback(date);
+  }
+
+  group('Tests for DatePicker', () {
+    testWidgets('Testing the OK button', (tester) async {
+      await prepareDatePicker(tester, (date) async {
+        expect(find.text('OK'), findsOneWidget);
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        expect(
+          (await date).toString().split(' ')[0],
+          DateTime.now().toLocal().toString().split(' ')[0],
+        );
+
+        expect(
+            find.textContaining(
+                (await date).toLocal().toString().split(' ')[0]),
+            findsOneWidget);
+      });
+    });
+    testWidgets('Testing the Cancel button', (tester) async {
+      await prepareDatePicker(tester, (date) async {
+        expect(find.text('CANCEL'), findsOneWidget);
+        await tester.tap(find.text('CANCEL'));
+        await tester.pumpAndSettle();
+        expect(
+            find.textContaining(
+                (await date).toLocal().toString().split(' ')[0]),
+            findsOneWidget);
+      });
+    });
+
+    testWidgets('Changing Date test', (tester) async {
+      await prepareDatePicker(tester, (date) async {
+        await tester.tap(find.text('10'));
+        await tester.pumpAndSettle(const Duration(seconds: 1));
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle(const Duration(seconds: 1));
+        expect((await date).toString().split(' ')[0],
+            DateTime(2022, DateTime.april, 10).toString().split(' ')[0]);
+        _startDate = await date;
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('TextButtonKey')), findsOneWidget);
+
+        expect(_startDate, DateTime(2022, DateTime.april, 10));
+      });
+    });
+  });
+
   group('Tests for Explore Event Dialogue', () {
-    late DateTime _startDate;
-    late DateTime _endDate;
     locator.registerSingleton(SizeConfig());
 
-    setUp(() {
-      registerServices();
-      locator<SizeConfig>().test();
-      _startDate = DateTime.now();
-      _endDate = DateTime.now().add(const Duration(days: 1));
-    });
-
-    tearDown(() {
-      unregisterServices();
-    });
     testWidgets('Testing Explore Event dialog layout', (tester) async {
       await tester.pumpWidget(createExploreEventDialog());
       await tester.pumpAndSettle();
+
+      expect(find.byType(TextButton), findsOneWidget);
+      await tester.tap(find.byKey(const Key('TextButtonKey')));
+      await tester.pump();
+
       expect(find.byType(ExploreEventDialog), findsOneWidget);
 
       final startDateText = find.text('Start Date');
@@ -62,6 +139,8 @@ main() {
     testWidgets('Test for Cancel button', (tester) async {
       await tester.pumpWidget(createExploreEventDialog());
       await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('TextButtonKey')));
+      await tester.pump();
       expect(find.byType(ExploreEventDialog), findsOneWidget);
 
       final cancelButton = find.byKey(const Key('CancelButton'));
@@ -73,6 +152,9 @@ main() {
     testWidgets('Test for Done button', (tester) async {
       await tester.pumpWidget(createExploreEventDialog());
       await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('TextButtonKey')));
+      await tester.pump();
+
       expect(find.byType(ExploreEventDialog), findsOneWidget);
 
       final doneButton = find.byKey(const Key('DoneButton'));
@@ -82,32 +164,47 @@ main() {
     testWidgets('Test for selecting Start Date', (tester) async {
       await tester.pumpWidget(createExploreEventDialog());
       await tester.pumpAndSettle();
-      expect(find.byType(ExploreEventDialog), findsOneWidget);
+      await tester.tap(find.byKey(const Key('TextButtonKey')));
+      await tester.pump();
 
-      final startDateText = find.text('Start Date');
-      expect(startDateText, findsOneWidget);
-      expect(
-          find.text("${_startDate.toLocal()}".split(' ')[0]), findsOneWidget);
-      final startDateButton = find.text(
-        "${_startDate.toLocal()}".split(' ')[0],
-      );
-
+      final startDateButton = find.byKey(const Key('StartDateSelector'));
       expect(startDateButton, findsOneWidget);
     });
-
     testWidgets('Test for selecting End Date', (tester) async {
       await tester.pumpWidget(createExploreEventDialog());
       await tester.pumpAndSettle();
-      expect(find.byType(ExploreEventDialog), findsOneWidget);
+      await tester.tap(find.byKey(const Key('TextButtonKey')));
+      await tester.pump();
 
-      final endDateText = find.text('End Date');
-      expect(endDateText, findsOneWidget);
-      expect(find.text("${_endDate.toLocal()}".split(' ')[0]), findsOneWidget);
-      final endDateButton = find.text(
-        "${_endDate.toLocal()}".split(' ')[0],
-      );
-
+      final endDateButton = find.byKey(const Key('EndDateSelector'));
       expect(endDateButton, findsOneWidget);
+    });
+
+    testWidgets('Testing the Cancel button', (tester) async {
+      await tester.pumpWidget(createExploreEventDialog());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('TextButtonKey')));
+      await tester.pump();
+
+      // finding Cancel Button
+      final x = find.text('Cancel');
+      expect(x, findsOneWidget);
+
+      await tester.tap(x);
+      expect(find.byKey(const Key('TextButtonKey')), findsOneWidget);
+    });
+    testWidgets('Testing the Done button', (tester) async {
+      await tester.pumpWidget(createExploreEventDialog());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('TextButtonKey')));
+      await tester.pump();
+
+      // finding Done Button
+      final x = find.text('Done');
+      expect(x, findsOneWidget);
+
+      await tester.tap(x);
+      expect(find.byKey(const Key('TextButtonKey')), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Increment in test coverage for Explore Event Dialog Box

**Issue Number:**

Fixes #1238 

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**Other information**

I've written tests for all the buttons (Cancel and Done) taking its coverage to **88.4%**, Though, this PR doesn't cover 100% coverage, only 2 onTap functions are left. After digging a lot and asking on discord servers, still I haven't found a suitable solution. Though, some lines of code for onTap function is included in this PR. I'm trying my best to cover this dialog box asap.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes
