### PR TITLE
Send Message to Direct Chat Mutation

### DIFF
--- a/lib/models/chats/chat_message.dart
+++ b/lib/models/chats/chat_message.dart
@@ -15,7 +15,7 @@ class ChatMessage {
       _$ChatMessageFromJson(json);
   Map<String, dynamic> toJson() => _$ChatMessageToJson(this);
 
-  String id;
+  String? id;
   ChatUser? sender;
   ChatUser? receiver;
   String? messageContent;

--- a/lib/models/chats/chat_message.g.dart
+++ b/lib/models/chats/chat_message.g.dart
@@ -8,7 +8,7 @@ part of 'chat_message.dart';
 
 ChatMessage _$ChatMessageFromJson(Map<String, dynamic> json) {
   return ChatMessage(
-    json['_id'] as String,
+    json['_id'] as String?,
     json['sender'] == null
         ? null
         : ChatUser.fromJson(json['sender'] as Map<String, dynamic>),

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/chats/chat_list_tile_data_model.dart';
 import 'package:talawa/models/chats/chat_message.dart';
@@ -19,6 +20,8 @@ class ChatService {
 
   final _userConfig = locator<UserConfig>();
 
+  late Stream<QueryResult> chatStream;
+
   final StreamController<ChatListTileDataModel> _chatController =
       StreamController<ChatListTileDataModel>();
 
@@ -27,6 +30,31 @@ class ChatService {
 
   Stream<ChatListTileDataModel> get chatListStream => _chatListStream;
   Stream<ChatMessage> get chatMessagesStream => _chatMessagesStream;
+
+  // Stream<QueryResult> getMessagesFromDirectChat() async* {
+  //   final operation = SubscriptionOptions(
+  //       document: gql(ChatQueries().messageSentToDirectChatsubscription),
+  //       operationName: 'messageSentToDirectChat');
+  //   chatStream = graphqlConfig.clientToQuery().subscribe(operation);
+
+  //   _cha
+  // }
+
+  Future<void> sendMessageToDirectChat(
+      String chatId, String messageContent) async {
+    final result = await _dbFunctions.gqlAuthMutation(
+        ChatQueries().sendMessageToDirectChat(),
+        variables: {"chatId": chatId, "messageContent": messageContent});
+
+    // print(ChatQueries().sendMessageToDirectChat());
+
+    final message = ChatMessage.fromJson(
+        result.data['sendMessageToDirectChat'] as Map<String, dynamic>);
+
+    _chatMessageController.add(message);
+
+    print(result.data);
+  }
 
   Future<void> getDirectChatsByUserId() async {
     final userId = _userConfig.currentUser.id;
@@ -47,7 +75,7 @@ class ChatService {
     });
   }
 
-  Future<void> getDirectChatsByChatId(chatId) async {
+  Future<void> getDirectChatMessagesByChatId(chatId) async {
     final String query =
         ChatQueries().fetchDirectChatMessagesByChatId(chatId as String);
 

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -46,10 +46,9 @@ class ChatService {
         ChatQueries().sendMessageToDirectChat(),
         variables: {"chatId": chatId, "messageContent": messageContent});
 
-    // print(ChatQueries().sendMessageToDirectChat());
-
     final message = ChatMessage.fromJson(
-        result.data['sendMessageToDirectChat'] as Map<String, dynamic>);
+      result.data['sendMessageToDirectChat'] as Map<String, dynamic>,
+    );
 
     _chatMessageController.add(message);
 

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/chats/chat_list_tile_data_model.dart';
@@ -52,7 +53,7 @@ class ChatService {
 
     _chatMessageController.add(message);
 
-    print(result.data);
+    debugPrint(result.data.toString());
   }
 
   Future<void> getDirectChatsByUserId() async {

--- a/lib/services/graphql_config.dart
+++ b/lib/services/graphql_config.dart
@@ -22,31 +22,24 @@ class GraphqlConfig {
     return true;
   }
 
-  void getOrgUrl() {
+  getOrgUrl() {
     final box = Hive.box('url');
     final String? url = box.get(urlKey) as String?;
     final String? imgUrl = box.get(imageUrlKey) as String?;
     orgURI = url ?? ' ';
     displayImgRoute = imgUrl ?? ' ';
     httpLink = HttpLink(orgURI!);
-    webSocketLink = WebSocketLink(
-      orgURI!,
-      config: const SocketClientConfig(
-        autoReconnect: true,
-      ),
-    );
     clientToQuery();
     authClient();
   }
 
-  // static final WebSocketLink _webSocketLink =
-
   GraphQLClient clientToQuery() {
-    final link = Link.split(
-        (request) => request.isSubscription, webSocketLink, httpLink);
+    //TODO: Implement websocket link from OrgUrl
+    // final link = Link.split(
+    //     (request) => request.isSubscription, webSocketLink, httpLink);
     return GraphQLClient(
       cache: GraphQLCache(partialDataPolicy: PartialDataCachePolicy.accept),
-      link: link,
+      link: httpLink,
     );
   }
 

--- a/lib/services/graphql_config.dart
+++ b/lib/services/graphql_config.dart
@@ -10,6 +10,7 @@ class GraphqlConfig {
   static String? orgURI = ' ';
   static String? token;
   late HttpLink httpLink;
+  late WebSocketLink webSocketLink;
 
 //prefix route for showing images
   String? displayImgRoute;
@@ -21,27 +22,28 @@ class GraphqlConfig {
     return true;
   }
 
-  getOrgUrl() {
+  void getOrgUrl() {
     final box = Hive.box('url');
     final String? url = box.get(urlKey) as String?;
     final String? imgUrl = box.get(imageUrlKey) as String?;
     orgURI = url ?? ' ';
     displayImgRoute = imgUrl ?? ' ';
     httpLink = HttpLink(orgURI!);
+    webSocketLink = WebSocketLink(
+      orgURI!,
+      config: const SocketClientConfig(
+        autoReconnect: true,
+      ),
+    );
     clientToQuery();
     authClient();
   }
 
-  static final WebSocketLink _webSocketLink = WebSocketLink(
-    'ws://sriram.dscnitrourkela.org/graphql',
-    config: const SocketClientConfig(
-      autoReconnect: true,
-    ),
-  );
+  // static final WebSocketLink _webSocketLink =
 
   GraphQLClient clientToQuery() {
     final link = Link.split(
-        (request) => request.isSubscription, _webSocketLink, httpLink);
+        (request) => request.isSubscription, webSocketLink, httpLink);
     return GraphQLClient(
       cache: GraphQLCache(partialDataPolicy: PartialDataCachePolicy.accept),
       link: link,

--- a/lib/services/graphql_config.dart
+++ b/lib/services/graphql_config.dart
@@ -32,10 +32,19 @@ class GraphqlConfig {
     authClient();
   }
 
+  static final WebSocketLink _webSocketLink = WebSocketLink(
+    'ws://sriram.dscnitrourkela.org/graphql',
+    config: const SocketClientConfig(
+      autoReconnect: true,
+    ),
+  );
+
   GraphQLClient clientToQuery() {
+    final link = Link.split(
+        (request) => request.isSubscription, _webSocketLink, httpLink);
     return GraphQLClient(
       cache: GraphQLCache(partialDataPolicy: PartialDataCachePolicy.accept),
-      link: httpLink,
+      link: link,
     );
   }
 

--- a/lib/utils/chat_queries.dart
+++ b/lib/utils/chat_queries.dart
@@ -34,4 +34,45 @@ class ChatQueries {
         }
     ''';
   }
+
+  String get messageSentToDirectChatsubscription => '''
+      subscription{
+        messageSentToDirectChat{
+          _id
+          messageContent
+          sender {
+              _id
+              firstName
+              image
+            }
+            receiver {
+              _id
+              firstName
+              image
+            }
+        }
+      }
+  ''';
+
+  String sendMessageToDirectChat() {
+    return '''
+      mutation sendMessageToDirectChat(
+        \$chatId: ID!
+        \$messageContent: String!
+        ){
+        sendMessageToDirectChat(
+          chatId: \$chatId
+          messageContent: \$messageContent
+        ) {
+          messageContent
+            sender{
+              firstName
+            }
+            receiver{
+              firstName
+            }
+          }
+        }
+    ''';
+  }
 }

--- a/lib/view_model/after_auth_view_models/chat_view_models/direct_chat_view_model.dart
+++ b/lib/view_model/after_auth_view_models/chat_view_models/direct_chat_view_model.dart
@@ -57,7 +57,8 @@ class DirectChatViewModel extends BaseModel {
   Future<void> getChatMessages(String chatId) async {
     _chatMessagesByUser.clear();
     chatState = ChatState.loading;
-    await _chatService.getDirectChatsByChatId(chatId);
+    // await _chatService.getMessagesFromDirectChat();
+    await _chatService.getDirectChatMessagesByChatId(chatId);
     final List<ChatMessage> _messages = [];
     _chatMessageSubscription =
         _chatService.chatMessagesStream.listen((newMessage) {
@@ -66,6 +67,16 @@ class DirectChatViewModel extends BaseModel {
     });
     chatState = ChatState.complete;
     notifyListeners();
+  }
+
+  Future<void> sendMessageToDirectChat(
+      String chatId, String messageContent) async {
+    chatState = ChatState.loading;
+    await _chatService.sendMessageToDirectChat(chatId, messageContent);
+    _chatService.chatMessagesStream.listen((newMessage) {
+      _chatMessagesByUser[chatId]!.add(newMessage);
+    });
+    chatState = ChatState.complete;
   }
 
   @override

--- a/lib/views/after_auth_screens/chat/chat_message_screen.dart
+++ b/lib/views/after_auth_screens/chat/chat_message_screen.dart
@@ -60,7 +60,7 @@ class ChatMessageScreen extends StatelessWidget {
                           ),
                         ),
                       ),
-                      const ChatInputField(),
+                      ChatInputField(chatId: chatId, model: model),
                     ],
                   )
                 : const Center(

--- a/lib/views/after_auth_screens/chat/widgets/chat_input_field.dart
+++ b/lib/views/after_auth_screens/chat/widgets/chat_input_field.dart
@@ -1,10 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:talawa/services/size_config.dart';
+import 'package:talawa/view_model/after_auth_view_models/chat_view_models/direct_chat_view_model.dart';
 
-class ChatInputField extends StatelessWidget {
+class ChatInputField extends StatefulWidget {
   const ChatInputField({
+    required this.chatId,
+    required this.model,
     Key? key,
   }) : super(key: key);
+
+  final DirectChatViewModel model;
+  final String chatId;
+
+  @override
+  State<ChatInputField> createState() => _ChatInputFieldState();
+}
+
+class _ChatInputFieldState extends State<ChatInputField> {
+  final controller = TextEditingController();
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -39,11 +58,17 @@ class ChatInputField extends StatelessWidget {
                   SizedBox(width: SizeConfig.blockSizeHorizontal),
                   Expanded(
                     child: TextField(
+                      controller: controller,
                       decoration: InputDecoration(
                         enabledBorder: InputBorder.none,
                         disabledBorder: InputBorder.none,
                         focusedBorder: InputBorder.none,
                         suffixIcon: GestureDetector(
+                          onTap: () {
+                            widget.model.sendMessageToDirectChat(
+                                widget.chatId, controller.text);
+                            controller.clear();
+                          },
                           child: Icon(
                             Icons.send,
                             color: Theme.of(context)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
@@ -70,14 +70,14 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.10"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.2"
   built_collection:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependency_overrides:
   platform: ^3.1.0
 
 dev_dependencies:
-  build_runner: ^2.1.1
+  build_runner: ^2.1.10
   flutter_test:
     sdk: flutter
   hive_generator: ^1.1.0

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -286,6 +286,15 @@ class MockEventService extends _i2.Mock implements _i10.EventService {
 /// See the documentation for Mockito's code generation for more information.
 class MockChatService extends _i2.Mock implements _i18.ChatService {
   @override
+  _i4.Stream<_i3.QueryResult> get chatStream =>
+      (super.noSuchMethod(Invocation.getter(#chatStream),
+              returnValue: Stream<_i3.QueryResult>.empty())
+          as _i4.Stream<_i3.QueryResult>);
+  @override
+  set chatStream(_i4.Stream<_i3.QueryResult>? _chatStream) =>
+      super.noSuchMethod(Invocation.setter(#chatStream, _chatStream),
+          returnValueForMissingStub: null);
+  @override
   _i4.Stream<_i19.ChatListTileDataModel> get chatListStream =>
       (super.noSuchMethod(Invocation.getter(#chatListStream),
               returnValue: Stream<_i19.ChatListTileDataModel>.empty())
@@ -296,13 +305,20 @@ class MockChatService extends _i2.Mock implements _i18.ChatService {
               returnValue: Stream<_i20.ChatMessage>.empty())
           as _i4.Stream<_i20.ChatMessage>);
   @override
+  _i4.Future<void> sendMessageToDirectChat(
+          String? chatId, String? messageContent) =>
+      (super.noSuchMethod(
+          Invocation.method(#sendMessageToDirectChat, [chatId, messageContent]),
+          returnValue: Future<void>.value(),
+          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+  @override
   _i4.Future<void> getDirectChatsByUserId() =>
       (super.noSuchMethod(Invocation.method(#getDirectChatsByUserId, []),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i4.Future<void> getDirectChatsByChatId(dynamic chatId) =>
-      (super.noSuchMethod(Invocation.method(#getDirectChatsByChatId, [chatId]),
+  _i4.Future<void> getDirectChatMessagesByChatId(dynamic chatId) => (super
+      .noSuchMethod(Invocation.method(#getDirectChatMessagesByChatId, [chatId]),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Adds send message to direct chat feature
- Queries for subscription
- Work In Progress: Using Subscription for instant reflection of message

Fixes #1313 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

N.A.

**If relevant, did you update the documentation?**

N.A

**Summary**

Now, one can send a message by typing it in the text field of direct chat. Though the message would be sent to the direct chat, it won't reflect directly on the UI as messages are being fetched using graphql query as of now. GraphQL subscriptions are WIP using which messages will be reflected instantly in future.

**Does this PR introduce a breaking change?**

No

**Other information**
N.A>

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
