### PR TITLE
Updated workflow to copy documentation from talawa to talawa-docs

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -95,6 +95,23 @@ jobs:
           git push
           echo -e "🚀${Green} Hurrah! doc updated${NoColor}"
 
+  Copy-HTML-to-talawa-docs:
+    runs-on: ubuntu-latest
+    needs: Update-Documentation
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      with:
+        source_file: 'docs/talawa/'
+        destination_repo: 'PalisadoesFoundation/talawa-docs'
+        destination_branch: 'talawa-docs-develop'
+        destination_folder: 'static/talawa'
+        user_email: '${{env.email}}'
+        user_name: '${{github.actor}}'
+        commit_message: 'Updating talawa HTML documentation as new PR merged into talawa'
+
   Flutter-Testing:
     name: Testing codebase
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Using workflow, to copy documentation files from talawa itself to talawa-docs
