### PR TITLE
Fix #1371 In login screen , keyboard covering huge portion of UI

### DIFF
--- a/lib/view_model/pre_auth_view_models/login_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/login_view_model.dart
@@ -18,6 +18,7 @@ class LoginViewModel extends BaseModel {
   FocusNode emailFocus = FocusNode();
   AutovalidateMode validate = AutovalidateMode.disabled;
   bool hidePassword = true;
+  bool isTextFieldsFocused = false;
 
   initialize() {
     greeting = [
@@ -48,6 +49,23 @@ class LoginViewModel extends BaseModel {
             .copyWith(fontSize: 24)
       },
     ];
+
+    emailFocus.addListener(() {
+      textFieldFocusCheck();
+    });
+    passwordFocus.addListener(() {
+      textFieldFocusCheck();
+    });
+  }
+
+  textFieldFocusCheck() {
+    if (emailFocus.hasFocus || passwordFocus.hasFocus) {
+      isTextFieldsFocused = true;
+      notifyListeners();
+    } else {
+      isTextFieldsFocused = false;
+      notifyListeners();
+    }
   }
 
   login() async {

--- a/lib/views/pre_auth_screens/login.dart
+++ b/lib/views/pre_auth_screens/login.dart
@@ -41,7 +41,8 @@ class _LoginState extends State<Login> {
               curve: Curves.fastOutSlowIn,
               margin: EdgeInsets.fromLTRB(
                 SizeConfig.screenWidth! * 0.06,
-                SizeConfig.screenHeight! * (model.isTextFieldsFocused ? 0.01 : 0.2),
+                SizeConfig.screenHeight! *
+                    (model.isTextFieldsFocused ? 0.01 : 0.2),
                 SizeConfig.screenWidth! * 0.06,
                 0.0,
               ),

--- a/lib/views/pre_auth_screens/login.dart
+++ b/lib/views/pre_auth_screens/login.dart
@@ -36,10 +36,12 @@ class _LoginState extends State<Login> {
           ),
           body: SingleChildScrollView(
             physics: const NeverScrollableScrollPhysics(),
-            child: Container(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 400),
+              curve: Curves.fastOutSlowIn,
               margin: EdgeInsets.fromLTRB(
                 SizeConfig.screenWidth! * 0.06,
-                SizeConfig.screenHeight! * 0.2,
+                SizeConfig.screenHeight! * (model.isTextFieldsFocused ? 0.01 : 0.2),
                 SizeConfig.screenWidth! * 0.06,
                 0.0,
               ),

--- a/test/widget_tests/pre_auth_screens/login_test.dart
+++ b/test/widget_tests/pre_auth_screens/login_test.dart
@@ -262,7 +262,7 @@ void main() {
     await tester.tap(emailInputFieldWidget);
     await tester.pumpAndSettle();
 
-    // When the email textfield is focused, the top margin is 0.01% of the screen height
+    // When the Email TextField is focused, top margin becomes 10% of the screen height.
     expect(
       find.byWidgetPredicate((Widget widget) {
         if (widget is AnimatedContainer) {
@@ -279,7 +279,7 @@ void main() {
     await tester.tap(passwordInputFieldWidget);
     await tester.pumpAndSettle();
 
-    // When the password textfield is focused, the top margin is 0.01% of the screen height
+    //  When the password TextField is focused, top margin becomes 10% of the screen height.
     expect(
       find.byWidgetPredicate((Widget widget) {
         if (widget is AnimatedContainer) {

--- a/test/widget_tests/pre_auth_screens/login_test.dart
+++ b/test/widget_tests/pre_auth_screens/login_test.dart
@@ -245,7 +245,7 @@ void main() {
     final passwordInputFieldWidget =
         find.byKey(const Key('PasswordInputField'));
 
-    // When the textfields is not focused, the top margin is 0.2% of the screen height
+    // When the TextField are not focused, the top margin is 20% of the screen height.
     expect(
       find.byWidgetPredicate((Widget widget) {
         if (widget is AnimatedContainer) {

--- a/test/widget_tests/pre_auth_screens/login_test.dart
+++ b/test/widget_tests/pre_auth_screens/login_test.dart
@@ -236,19 +236,21 @@ void main() {
     });
   });
 
-  testWidgets('Check if textfields are visible while opening keyboard', (tester)async{
+  testWidgets('Check if textfields are visible while opening keyboard',
+      (tester) async {
     await showLoginScreen(tester);
 
     final screenHeight = SizeConfig.screenHeight!;
     final emailInputFieldWidget = find.byKey(const Key('EmailInputField'));
-    final passwordInputFieldWidget = find.byKey(const Key('PasswordInputField'));
+    final passwordInputFieldWidget =
+        find.byKey(const Key('PasswordInputField'));
 
     // When the textfields is not focused, the top margin is 0.2% of the screen height
     expect(
       find.byWidgetPredicate((Widget widget) {
         if (widget is AnimatedContainer) {
           final double topMargin = widget.margin!.vertical;
-          return topMargin == screenHeight*0.2;
+          return topMargin == screenHeight * 0.2;
         } else {
           return false;
         }
@@ -265,7 +267,7 @@ void main() {
       find.byWidgetPredicate((Widget widget) {
         if (widget is AnimatedContainer) {
           final double topMargin = widget.margin!.vertical;
-          return topMargin == screenHeight*0.01;
+          return topMargin == screenHeight * 0.01;
         } else {
           return false;
         }
@@ -282,7 +284,7 @@ void main() {
       find.byWidgetPredicate((Widget widget) {
         if (widget is AnimatedContainer) {
           final double topMargin = widget.margin!.vertical;
-          return topMargin == screenHeight*0.01;
+          return topMargin == screenHeight * 0.01;
         } else {
           return false;
         }

--- a/test/widget_tests/pre_auth_screens/login_test.dart
+++ b/test/widget_tests/pre_auth_screens/login_test.dart
@@ -235,4 +235,59 @@ void main() {
       expect(find.byType(Recover), findsOneWidget);
     });
   });
+
+  testWidgets('Check if textfields are visible while opening keyboard', (tester)async{
+    await showLoginScreen(tester);
+
+    final screenHeight = SizeConfig.screenHeight!;
+    final emailInputFieldWidget = find.byKey(const Key('EmailInputField'));
+    final passwordInputFieldWidget = find.byKey(const Key('PasswordInputField'));
+
+    // When the textfields is not focused, the top margin is 0.2% of the screen height
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        if (widget is AnimatedContainer) {
+          final double topMargin = widget.margin!.vertical;
+          return topMargin == screenHeight*0.2;
+        } else {
+          return false;
+        }
+      }),
+      findsOneWidget,
+    );
+
+    // Focus the email textfield
+    await tester.tap(emailInputFieldWidget);
+    await tester.pumpAndSettle();
+
+    // When the email textfield is focused, the top margin is 0.01% of the screen height
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        if (widget is AnimatedContainer) {
+          final double topMargin = widget.margin!.vertical;
+          return topMargin == screenHeight*0.01;
+        } else {
+          return false;
+        }
+      }),
+      findsOneWidget,
+    );
+
+    // Focus the password textfield
+    await tester.tap(passwordInputFieldWidget);
+    await tester.pumpAndSettle();
+
+    // When the password textfield is focused, the top margin is 0.01% of the screen height
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        if (widget is AnimatedContainer) {
+          final double topMargin = widget.margin!.vertical;
+          return topMargin == screenHeight*0.01;
+        } else {
+          return false;
+        }
+      }),
+      findsOneWidget,
+    );
+  });
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR added an listener on Textfield FocusNode on login screen. When the textfield focused and keyboard apeared in screen, top margin will be reduced , when all the textfields unfocused or the keyboard disappeared the top margin will back to normal state.

**Issue Number:**

Fixes #1371 

**Did you add tests for your changes?**
That doesn't required test. Only UI changes. 

**Snapshots/Videos:**
Old UX
<img src="https://user-images.githubusercontent.com/57363826/207862412-14730238-99ae-4062-bc76-e8422c6dad14.png" width="200px"/>

New UX

https://user-images.githubusercontent.com/57363826/207865695-75e70990-01ed-43c4-8a09-be5c203077d4.mp4


**Summary**
This PR added an listener on Textfield FocusNode on login screen. When the Textfield focused and keyboard apeared in screen, top margin will be reduced , when all the textfields unfocused or the keyboard disappeared the top margin will back to normal state.

The container has been replaced with __AnimatedContainer__ to add animation while decreasing/increasing the top margin. 

**Does this PR introduce a breaking change?**
No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes