### PR TITLE
Complete test coverage for select_organization.dart

### DIFF
--- a/test/widget_tests/pre_auth_screens/select_organization_test.dart
+++ b/test/widget_tests/pre_auth_screens/select_organization_test.dart
@@ -191,5 +191,41 @@ void main() {
         expect(columnWidget.children[7], isA<SizedBox>());
       });
     });
+
+    testWidgets("Test onTapOrgInfo for CustomListTile",
+        (WidgetTester tester) async {
+      final SelectOrganizationViewModel customViewModel =
+          SelectOrganizationViewModel();
+      locator.unregister<SelectOrganizationViewModel>();
+      locator.registerLazySingleton(() => customViewModel);
+
+      final OrgInfo orgInfo = OrgInfo(
+        name: "JamRock",
+        creatorInfo: User(firstName: "Patrick", lastName: "Witter"),
+        isPublic: true,
+      );
+
+      await tester.runAsync(() async {
+        await tester.pumpWidget(createSelectOrgPage(customorgID: "-1"));
+        await tester.pump();
+        customViewModel.selectedOrganization.id = "3";
+        customViewModel.selectedOrganization = orgInfo;
+        customViewModel.notifyListeners();
+        await tester.pump();
+        final selectOrgfinder = find.byKey(selectOrgKey);
+
+        final columnFinder = find
+            .descendant(of: selectOrgfinder, matching: find.byType(Column))
+            .first;
+
+        final columnWidget = tester.firstWidget(columnFinder) as Column;
+
+        await tester.tap(find.byWidget(columnWidget.children[2]));
+
+        verify(
+          locator<SelectOrganizationViewModel>().selectOrg(orgInfo),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR adds a new test to the `select_organization_test.dart` file to complete the test coverage for the same. The current test file did not include a test to check the `onTapOrgInfo` functionality of the `CustomListTile`. In this PR, I have added a test for the same and verified that the `selectOrg()` function of the `SelectOrganizationViewModel` is being called.

**Issue Number:**

Fixes #1524 

**Did you add tests for your changes?**

Yes, this is a test related PR.

**Snapshots/Videos:**

Test coverage before the changes
![image](https://user-images.githubusercontent.com/55295613/221033923-a2714dcf-952d-4a0a-81c8-bd4e84c8ae78.png)

Test coverage after the changes
![image](https://user-images.githubusercontent.com/55295613/221033952-8453b60c-c128-4101-99e6-0bc5146dcf53.png)

**If relevant, did you update the documentation?**

N/A

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes