### PR TITLE
Enhancing push workflow to support custom lint

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -45,8 +45,8 @@ jobs:
         run: flutter format --set-exit-if-changed .
       - name: Analysing codebase for default linting
         run: flutter analyze --no-pub
-      - name: Analysing codebase for custom linting
-        run: flutter pub run custom_lint
+      #- name: Analysing codebase for custom linting
+        #run: flutter pub run custom_lint
 #       - name: Echo the GitHub environment for troubleshooting
 #         run: echo "$GITHUB_CONTEXT"
 #       - name: Echo the GitHub context for troubleshooting
@@ -55,13 +55,13 @@ jobs:
         uses: actions/setup-python@v4
       - name: Granting permission to documentationcheck.py
         run: chmod +x ./.github/workflows/documentationcheck.py
-      #- name: execute py script
-        ## For more information on the GitHub context used for the "--repository" flag used by this script visit:
-        ## https://docs.github.com/en/actions/learn-github-actions/contexts
-        #run: |
-          #git branch
-          #pip install GitPython
-          #python ./.github/workflows/documentationcheck.py --repository ${{github.repository}} --merge_branch_name ${{github.ref_name}}
+      - name: execute py script
+        # For more information on the GitHub context used for the "--repository" flag used by this script visit:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts
+        run: |
+          git branch
+          pip install GitPython
+          python ./.github/workflows/documentationcheck.py --repository ${{github.repository}} --merge_branch_name ${{github.ref_name}}
 
   Update-Documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -43,8 +43,10 @@ jobs:
         run: flutter pub get
       - name: Checking for correct formatting of code
         run: flutter format --set-exit-if-changed .
-      - name: Analysing codebase for linting
+      - name: Analysing codebase for default linting
         run: flutter analyze --no-pub
+      - name: Analysing codebase for custom linting
+        run: flutter pub run custom_lint
 #       - name: Echo the GitHub environment for troubleshooting
 #         run: echo "$GITHUB_CONTEXT"
 #       - name: Echo the GitHub context for troubleshooting

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -53,13 +53,13 @@ jobs:
         uses: actions/setup-python@v4
       - name: Granting permission to documentationcheck.py
         run: chmod +x ./.github/workflows/documentationcheck.py
-      - name: execute py script
-        # For more information on the GitHub context used for the "--repository" flag used by this script visit:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts
-        run: |
-          git branch
-          pip install GitPython
-          python ./.github/workflows/documentationcheck.py --repository ${{github.repository}} --merge_branch_name ${{github.ref_name}}
+      #- name: execute py script
+        ## For more information on the GitHub context used for the "--repository" flag used by this script visit:
+        ## https://docs.github.com/en/actions/learn-github-actions/contexts
+        #run: |
+          #git branch
+          #pip install GitPython
+          #python ./.github/workflows/documentationcheck.py --repository ${{github.repository}} --merge_branch_name ${{github.ref_name}}
 
   Update-Documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -76,7 +76,7 @@ jobs:
           channel: 'stable'
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: '2.18.0'
+          sdk: '2.19.2'
       - run: |
           cd talawa_lint && flutter pub get && cd ..
           flutter pub get

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,15 +5,15 @@ analyzer:
     - lib/generated_plugin_registrant.dart
     - test/helpers/test_helpers.mocks.dart
 
-#   plugins:
-#     custom_lint
+  plugins:
+    custom_lint
 
-# custom_lint:
-#   rules:
-#     - talawa_lint
+custom_lint:
+  rules:
+    - talawa_lint
 
-#   exclude:
-#     - test/
+  exclude:
+    - test/
 
 linter:
   rules:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -274,7 +274,7 @@ packages:
     source: hosted
     version: "2.0.15"
   custom_lint:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: custom_lint
       sha256: "29b7e51b5e75fcd5ffce8fc12af87b71cbde7a59d080467b187630231aeb42c0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1506,6 +1506,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  talawa_lint:
+    dependency: "direct dev"
+    description:
+      path: talawa_lint
+      relative: true
+    source: path
+    version: "0.0.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
+  custom_lint:
   flutter_test:
     sdk: flutter
   hive_generator: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,8 +85,8 @@ dev_dependencies:
   json_serializable: ^6.6.1
   lint: ^2.0.1
   mocktail_image_network: ^0.3.1
-  # talawa_lint:
-  #   path: talawa_lint/
+  talawa_lint:
+    path: talawa_lint/
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Fixes: #1479 
See #1584 

### Changes
1. Bump Dart SDK being used in `push.yml`
2. Uncomment the lines responsible for telling `Talawa` that it depends on `talawa_lint`, which means
    - Now `Talawa` and `talawa_lint` are connected.
    - Contributors will now get warnings/errors according to our new custom lint rules in their IDE itself.
    - We can analyze our codebase for custom lint rules from the workflow
3. Added (but commented for now) the commands necessary to analyze the codebase for our custom lint rules.