### PR TITLE
Test Chat Message Screen

### DIFF
--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -8,6 +8,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:talawa/enums/enums.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/chats/chat_list_tile_data_model.dart';
 import 'package:talawa/models/chats/chat_message.dart';
@@ -75,6 +76,7 @@ import 'test_helpers.mocks.dart';
     MockSpec<AppTheme>(returnNullOnMissingStub: true),
     MockSpec<TaskService>(returnNullOnMissingStub: false),
     MockSpec<CreateEventViewModel>(returnNullOnMissingStub: true),
+    MockSpec<DirectChatViewModel>(returnNullOnMissingStub: true),
   ],
 )
 final User member1 = User(id: "testMem1");
@@ -551,6 +553,37 @@ CreateEventViewModel getAndRegisterCreateEventModel() {
   });
 
   locator.registerSingleton<CreateEventViewModel>(cachedViewModel);
+  return cachedViewModel;
+}
+
+DirectChatViewModel getAndRegisterDirectChatViewModel() {
+  _removeRegistrationIfExists<DirectChatViewModel>();
+  final cachedViewModel = MockDirectChatViewModel();
+  final formKey = GlobalKey<AnimatedListState>();
+  final ChatUser chatUser1 =
+      ChatUser(firstName: "XYZ", id: "XYZ", image: "XYZ");
+  final ChatUser chatUser2 =
+      ChatUser(firstName: "ABC", id: "ABC", image: "ABC");
+  final ChatMessage chatMessage1 =
+      ChatMessage("XYZ", chatUser1, "XYZ", chatUser2);
+  final Map<String, List<ChatMessage>> messages = {
+    "XYZ": [chatMessage1]
+  };
+  final ChatListTileDataModel chatListTileDataModel1 =
+      ChatListTileDataModel([chatUser1, chatUser2], "XYZ");
+
+  when(cachedViewModel.listKey).thenReturn(formKey);
+  when(cachedViewModel.chatState).thenReturn(ChatState.complete);
+  when(cachedViewModel.name).thenReturn("XYZ");
+  when(cachedViewModel.chats).thenReturn([chatListTileDataModel1]);
+  when(cachedViewModel.chatMessagesByUser).thenReturn(messages);
+
+  when(cachedViewModel.initialise()).thenAnswer((realInvocation) async {});
+  when(cachedViewModel.getChatMessages("XYZ"))
+      .thenAnswer((realInvocation) async {});
+  when(cachedViewModel.chatName("XYZ")).thenAnswer((realInvocation) {});
+
+  locator.registerSingleton<DirectChatViewModel>(cachedViewModel);
   return cachedViewModel;
 }
 

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -573,6 +573,7 @@ DirectChatViewModel getAndRegisterDirectChatViewModel() {
       ChatListTileDataModel([chatUser1, chatUser2], "XYZ");
 
   when(cachedViewModel.listKey).thenReturn(formKey);
+  // Default is the loaded state
   when(cachedViewModel.chatState).thenReturn(ChatState.complete);
   when(cachedViewModel.name).thenReturn("XYZ");
   when(cachedViewModel.chats).thenReturn([chatListTileDataModel1]);

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -4,47 +4,50 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
-import 'dart:io' as _i16;
+import 'dart:io' as _i17;
+import 'dart:ui' as _i9;
 
-import 'package:connectivity_plus/connectivity_plus.dart' as _i23;
+import 'package:connectivity_plus/connectivity_plus.dart' as _i24;
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart'
-    as _i24;
+    as _i25;
 import 'package:flutter/material.dart' as _i1;
 import 'package:graphql_flutter/graphql_flutter.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i2;
-import 'package:qr_code_scanner/src/qr_code_scanner.dart' as _i29;
-import 'package:qr_code_scanner/src/types/barcode.dart' as _i30;
-import 'package:qr_code_scanner/src/types/camera.dart' as _i31;
-import 'package:qr_code_scanner/src/types/features.dart' as _i10;
-import 'package:talawa/enums/enums.dart' as _i11;
-import 'package:talawa/models/chats/chat_list_tile_data_model.dart' as _i19;
-import 'package:talawa/models/chats/chat_message.dart' as _i20;
-import 'package:talawa/models/events/event_model.dart' as _i17;
+import 'package:qr_code_scanner/src/qr_code_scanner.dart' as _i30;
+import 'package:qr_code_scanner/src/types/barcode.dart' as _i31;
+import 'package:qr_code_scanner/src/types/camera.dart' as _i32;
+import 'package:qr_code_scanner/src/types/features.dart' as _i11;
+import 'package:talawa/enums/enums.dart' as _i12;
+import 'package:talawa/models/chats/chat_list_tile_data_model.dart' as _i20;
+import 'package:talawa/models/chats/chat_message.dart' as _i21;
+import 'package:talawa/models/events/event_model.dart' as _i18;
 import 'package:talawa/models/organization/org_info.dart' as _i5;
-import 'package:talawa/models/post/post_model.dart' as _i14;
-import 'package:talawa/models/task/task_model.dart' as _i35;
+import 'package:talawa/models/post/post_model.dart' as _i15;
+import 'package:talawa/models/task/task_model.dart' as _i36;
 import 'package:talawa/models/user/user_info.dart' as _i6;
-import 'package:talawa/services/chat_service.dart' as _i18;
-import 'package:talawa/services/comment_service.dart' as _i32;
+import 'package:talawa/services/chat_service.dart' as _i19;
+import 'package:talawa/services/comment_service.dart' as _i33;
 import 'package:talawa/services/database_mutation_functions.dart' as _i8;
-import 'package:talawa/services/event_service.dart' as _i9;
-import 'package:talawa/services/graphql_config.dart' as _i12;
+import 'package:talawa/services/event_service.dart' as _i10;
+import 'package:talawa/services/graphql_config.dart' as _i13;
 import 'package:talawa/services/navigation_service.dart' as _i7;
-import 'package:talawa/services/org_service.dart' as _i26;
-import 'package:talawa/services/post_service.dart' as _i13;
-import 'package:talawa/services/task_service.dart' as _i34;
+import 'package:talawa/services/org_service.dart' as _i27;
+import 'package:talawa/services/post_service.dart' as _i14;
+import 'package:talawa/services/task_service.dart' as _i35;
 import 'package:talawa/services/third_party_service/multi_media_pick_service.dart'
-    as _i15;
-import 'package:talawa/services/user_config.dart' as _i21;
-import 'package:talawa/utils/validators.dart' as _i28;
+    as _i16;
+import 'package:talawa/services/user_config.dart' as _i22;
+import 'package:talawa/utils/validators.dart' as _i29;
+import 'package:talawa/view_model/after_auth_view_models/chat_view_models/direct_chat_view_model.dart'
+    as _i38;
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/create_event_view_model.dart'
-    as _i36;
+    as _i37;
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart'
-    as _i27;
-import 'package:talawa/view_model/lang_view_model.dart' as _i22;
+    as _i28;
+import 'package:talawa/view_model/lang_view_model.dart' as _i23;
 import 'package:talawa/view_model/pre_auth_view_models/signup_details_view_model.dart'
-    as _i25;
-import 'package:talawa/view_model/theme_view_model.dart' as _i33;
+    as _i26;
+import 'package:talawa/view_model/theme_view_model.dart' as _i34;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -214,9 +217,8 @@ class _FakeDataBaseMutationFunctions_14 extends _i2.SmartFake
         );
 }
 
-class _FakeTextEditingController_15 extends _i2.SmartFake
-    implements _i1.TextEditingController {
-  _FakeTextEditingController_15(
+class _FakeLocale_15 extends _i2.SmartFake implements _i9.Locale {
+  _FakeLocale_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -225,8 +227,19 @@ class _FakeTextEditingController_15 extends _i2.SmartFake
         );
 }
 
-class _FakeFocusNode_16 extends _i2.SmartFake implements _i1.FocusNode {
-  _FakeFocusNode_16(
+class _FakeTextEditingController_16 extends _i2.SmartFake
+    implements _i1.TextEditingController {
+  _FakeTextEditingController_16(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFocusNode_17 extends _i2.SmartFake implements _i1.FocusNode {
+  _FakeFocusNode_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -239,8 +252,8 @@ class _FakeFocusNode_16 extends _i2.SmartFake implements _i1.FocusNode {
       super.toString();
 }
 
-class _FakeGraphQLError_17 extends _i2.SmartFake implements _i3.GraphQLError {
-  _FakeGraphQLError_17(
+class _FakeGraphQLError_18 extends _i2.SmartFake implements _i3.GraphQLError {
+  _FakeGraphQLError_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -249,8 +262,8 @@ class _FakeGraphQLError_17 extends _i2.SmartFake implements _i3.GraphQLError {
         );
 }
 
-class _FakeEventService_18 extends _i2.SmartFake implements _i9.EventService {
-  _FakeEventService_18(
+class _FakeEventService_19 extends _i2.SmartFake implements _i10.EventService {
+  _FakeEventService_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -259,9 +272,9 @@ class _FakeEventService_18 extends _i2.SmartFake implements _i9.EventService {
         );
 }
 
-class _FakeSystemFeatures_19 extends _i2.SmartFake
-    implements _i10.SystemFeatures {
-  _FakeSystemFeatures_19(
+class _FakeSystemFeatures_20 extends _i2.SmartFake
+    implements _i11.SystemFeatures {
+  _FakeSystemFeatures_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -270,8 +283,8 @@ class _FakeSystemFeatures_19 extends _i2.SmartFake
         );
 }
 
-class _FakeTimeOfDay_20 extends _i2.SmartFake implements _i1.TimeOfDay {
-  _FakeTimeOfDay_20(
+class _FakeTimeOfDay_21 extends _i2.SmartFake implements _i1.TimeOfDay {
+  _FakeTimeOfDay_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -280,8 +293,8 @@ class _FakeTimeOfDay_20 extends _i2.SmartFake implements _i1.TimeOfDay {
         );
 }
 
-class _FakeDateTime_21 extends _i2.SmartFake implements DateTime {
-  _FakeDateTime_21(
+class _FakeDateTime_22 extends _i2.SmartFake implements DateTime {
+  _FakeDateTime_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -406,7 +419,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
   @override
   void showTalawaErrorSnackBar(
     String? errorMessage,
-    _i11.MessageType? messageType, {
+    _i12.MessageType? messageType, {
     Duration? duration = const Duration(seconds: 2),
   }) =>
       super.noSuchMethod(
@@ -423,7 +436,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
   @override
   void showTalawaErrorDialog(
     String? errorMessage,
-    _i11.MessageType? messageType,
+    _i12.MessageType? messageType,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -448,7 +461,7 @@ class MockNavigationService extends _i2.Mock implements _i7.NavigationService {
 /// A class which mocks [GraphqlConfig].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGraphqlConfig extends _i2.Mock implements _i12.GraphqlConfig {
+class MockGraphqlConfig extends _i2.Mock implements _i13.GraphqlConfig {
   @override
   _i3.HttpLink get httpLink => (super.noSuchMethod(
         Invocation.getter(#httpLink),
@@ -783,17 +796,17 @@ class MockGraphQLClient extends _i2.Mock implements _i3.GraphQLClient {
 /// A class which mocks [PostService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPostService extends _i2.Mock implements _i13.PostService {
+class MockPostService extends _i2.Mock implements _i14.PostService {
   @override
-  _i4.Stream<List<_i14.Post>> get postStream => (super.noSuchMethod(
+  _i4.Stream<List<_i15.Post>> get postStream => (super.noSuchMethod(
         Invocation.getter(#postStream),
-        returnValue: _i4.Stream<List<_i14.Post>>.empty(),
-      ) as _i4.Stream<List<_i14.Post>>);
+        returnValue: _i4.Stream<List<_i15.Post>>.empty(),
+      ) as _i4.Stream<List<_i15.Post>>);
   @override
-  _i4.Stream<_i14.Post> get updatedPostStream => (super.noSuchMethod(
+  _i4.Stream<_i15.Post> get updatedPostStream => (super.noSuchMethod(
         Invocation.getter(#updatedPostStream),
-        returnValue: _i4.Stream<_i14.Post>.empty(),
-      ) as _i4.Stream<_i14.Post>);
+        returnValue: _i4.Stream<_i15.Post>.empty(),
+      ) as _i4.Stream<_i15.Post>);
   @override
   void setOrgStreamSubscription() => super.noSuchMethod(
         Invocation.method(
@@ -843,43 +856,43 @@ class MockPostService extends _i2.Mock implements _i13.PostService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockMultiMediaPickerService extends _i2.Mock
-    implements _i15.MultiMediaPickerService {
+    implements _i16.MultiMediaPickerService {
   @override
   _i4.Stream<dynamic> get fileStream => (super.noSuchMethod(
         Invocation.getter(#fileStream),
         returnValue: _i4.Stream<dynamic>.empty(),
       ) as _i4.Stream<dynamic>);
   @override
-  _i4.Future<_i16.File?> getPhotoFromGallery({bool? camera = false}) =>
+  _i4.Future<_i17.File?> getPhotoFromGallery({bool? camera = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPhotoFromGallery,
           [],
           {#camera: camera},
         ),
-        returnValue: _i4.Future<_i16.File?>.value(),
-      ) as _i4.Future<_i16.File?>);
+        returnValue: _i4.Future<_i17.File?>.value(),
+      ) as _i4.Future<_i17.File?>);
   @override
-  _i4.Future<_i16.File?> cropImage({required _i16.File? imageFile}) =>
+  _i4.Future<_i17.File?> cropImage({required _i17.File? imageFile}) =>
       (super.noSuchMethod(
         Invocation.method(
           #cropImage,
           [],
           {#imageFile: imageFile},
         ),
-        returnValue: _i4.Future<_i16.File?>.value(),
-      ) as _i4.Future<_i16.File?>);
+        returnValue: _i4.Future<_i17.File?>.value(),
+      ) as _i4.Future<_i17.File?>);
 }
 
 /// A class which mocks [EventService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEventService extends _i2.Mock implements _i9.EventService {
+class MockEventService extends _i2.Mock implements _i10.EventService {
   @override
-  _i4.Stream<_i17.Event> get eventStream => (super.noSuchMethod(
+  _i4.Stream<_i18.Event> get eventStream => (super.noSuchMethod(
         Invocation.getter(#eventStream),
-        returnValue: _i4.Stream<_i17.Event>.empty(),
-      ) as _i4.Stream<_i17.Event>);
+        returnValue: _i4.Stream<_i18.Event>.empty(),
+      ) as _i4.Stream<_i18.Event>);
   @override
   void setOrgStreamSubscription() => super.noSuchMethod(
         Invocation.method(
@@ -953,7 +966,7 @@ class MockEventService extends _i2.Mock implements _i9.EventService {
 /// A class which mocks [ChatService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockChatService extends _i2.Mock implements _i18.ChatService {
+class MockChatService extends _i2.Mock implements _i19.ChatService {
   @override
   _i4.Stream<_i3.QueryResult<Object?>> get chatStream => (super.noSuchMethod(
         Invocation.getter(#chatStream),
@@ -969,16 +982,16 @@ class MockChatService extends _i2.Mock implements _i18.ChatService {
         returnValueForMissingStub: null,
       );
   @override
-  _i4.Stream<_i19.ChatListTileDataModel> get chatListStream =>
+  _i4.Stream<_i20.ChatListTileDataModel> get chatListStream =>
       (super.noSuchMethod(
         Invocation.getter(#chatListStream),
-        returnValue: _i4.Stream<_i19.ChatListTileDataModel>.empty(),
-      ) as _i4.Stream<_i19.ChatListTileDataModel>);
+        returnValue: _i4.Stream<_i20.ChatListTileDataModel>.empty(),
+      ) as _i4.Stream<_i20.ChatListTileDataModel>);
   @override
-  _i4.Stream<_i20.ChatMessage> get chatMessagesStream => (super.noSuchMethod(
+  _i4.Stream<_i21.ChatMessage> get chatMessagesStream => (super.noSuchMethod(
         Invocation.getter(#chatMessagesStream),
-        returnValue: _i4.Stream<_i20.ChatMessage>.empty(),
-      ) as _i4.Stream<_i20.ChatMessage>);
+        returnValue: _i4.Stream<_i21.ChatMessage>.empty(),
+      ) as _i4.Stream<_i21.ChatMessage>);
   @override
   _i4.Future<void> sendMessageToDirectChat(
     String? chatId,
@@ -1019,7 +1032,7 @@ class MockChatService extends _i2.Mock implements _i18.ChatService {
 /// A class which mocks [UserConfig].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUserConfig extends _i2.Mock implements _i21.UserConfig {
+class MockUserConfig extends _i2.Mock implements _i22.UserConfig {
   @override
   _i4.Stream<_i5.OrgInfo> get currentOrgInfoStream => (super.noSuchMethod(
         Invocation.getter(#currentOrgInfoStream),
@@ -1160,7 +1173,7 @@ class MockUserConfig extends _i2.Mock implements _i21.UserConfig {
 /// A class which mocks [AppLanguage].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAppLanguage extends _i2.Mock implements _i22.AppLanguage {
+class MockAppLanguage extends _i2.Mock implements _i23.AppLanguage {
   @override
   bool get isTest => (super.noSuchMethod(
         Invocation.getter(#isTest),
@@ -1183,10 +1196,18 @@ class MockAppLanguage extends _i2.Mock implements _i22.AppLanguage {
         ),
       ) as _i8.DataBaseMutationFunctions);
   @override
-  _i11.ViewState get state => (super.noSuchMethod(
+  _i9.Locale get appLocal => (super.noSuchMethod(
+        Invocation.getter(#appLocal),
+        returnValue: _FakeLocale_15(
+          this,
+          Invocation.getter(#appLocal),
+        ),
+      ) as _i9.Locale);
+  @override
+  _i12.ViewState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i11.ViewState.idle,
-      ) as _i11.ViewState);
+        returnValue: _i12.ViewState.idle,
+      ) as _i12.ViewState);
   @override
   bool get isBusy => (super.noSuchMethod(
         Invocation.getter(#isBusy),
@@ -1216,7 +1237,7 @@ class MockAppLanguage extends _i2.Mock implements _i22.AppLanguage {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  _i4.Future<void> changeLanguage(dynamic type) => (super.noSuchMethod(
+  _i4.Future<void> changeLanguage(_i9.Locale? type) => (super.noSuchMethod(
         Invocation.method(
           #changeLanguage,
           [type],
@@ -1252,7 +1273,7 @@ class MockAppLanguage extends _i2.Mock implements _i22.AppLanguage {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  void setState(_i11.ViewState? viewState) => super.noSuchMethod(
+  void setState(_i12.ViewState? viewState) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [viewState],
@@ -1260,7 +1281,7 @@ class MockAppLanguage extends _i2.Mock implements _i22.AppLanguage {
         returnValueForMissingStub: null,
       );
   @override
-  void addListener(dynamic listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1268,7 +1289,7 @@ class MockAppLanguage extends _i2.Mock implements _i22.AppLanguage {
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(dynamic listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1296,30 +1317,30 @@ class MockAppLanguage extends _i2.Mock implements _i22.AppLanguage {
 /// A class which mocks [Connectivity].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockConnectivity extends _i2.Mock implements _i23.Connectivity {
+class MockConnectivity extends _i2.Mock implements _i24.Connectivity {
   @override
-  _i4.Stream<_i24.ConnectivityResult> get onConnectivityChanged =>
+  _i4.Stream<_i25.ConnectivityResult> get onConnectivityChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onConnectivityChanged),
-        returnValue: _i4.Stream<_i24.ConnectivityResult>.empty(),
-      ) as _i4.Stream<_i24.ConnectivityResult>);
+        returnValue: _i4.Stream<_i25.ConnectivityResult>.empty(),
+      ) as _i4.Stream<_i25.ConnectivityResult>);
   @override
-  _i4.Future<_i24.ConnectivityResult> checkConnectivity() =>
+  _i4.Future<_i25.ConnectivityResult> checkConnectivity() =>
       (super.noSuchMethod(
         Invocation.method(
           #checkConnectivity,
           [],
         ),
-        returnValue: _i4.Future<_i24.ConnectivityResult>.value(
-            _i24.ConnectivityResult.bluetooth),
-      ) as _i4.Future<_i24.ConnectivityResult>);
+        returnValue: _i4.Future<_i25.ConnectivityResult>.value(
+            _i25.ConnectivityResult.bluetooth),
+      ) as _i4.Future<_i25.ConnectivityResult>);
 }
 
 /// A class which mocks [SignupDetailsViewModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSignupDetailsViewModel extends _i2.Mock
-    implements _i25.SignupDetailsViewModel {
+    implements _i26.SignupDetailsViewModel {
   @override
   _i1.GlobalKey<_i1.FormState> get formKey => (super.noSuchMethod(
         Invocation.getter(#formKey),
@@ -1361,7 +1382,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get confirmPassword => (super.noSuchMethod(
         Invocation.getter(#confirmPassword),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#confirmPassword),
         ),
@@ -1378,7 +1399,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get firstName => (super.noSuchMethod(
         Invocation.getter(#firstName),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#firstName),
         ),
@@ -1394,7 +1415,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get lastName => (super.noSuchMethod(
         Invocation.getter(#lastName),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#lastName),
         ),
@@ -1410,7 +1431,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get password => (super.noSuchMethod(
         Invocation.getter(#password),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#password),
         ),
@@ -1426,7 +1447,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.TextEditingController get email => (super.noSuchMethod(
         Invocation.getter(#email),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#email),
         ),
@@ -1455,7 +1476,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
   @override
   _i1.FocusNode get confirmFocus => (super.noSuchMethod(
         Invocation.getter(#confirmFocus),
-        returnValue: _FakeFocusNode_16(
+        returnValue: _FakeFocusNode_17(
           this,
           Invocation.getter(#confirmFocus),
         ),
@@ -1482,10 +1503,10 @@ class MockSignupDetailsViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  _i11.ViewState get state => (super.noSuchMethod(
+  _i12.ViewState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i11.ViewState.idle,
-      ) as _i11.ViewState);
+        returnValue: _i12.ViewState.idle,
+      ) as _i12.ViewState);
   @override
   bool get isBusy => (super.noSuchMethod(
         Invocation.getter(#isBusy),
@@ -1502,7 +1523,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
         [org],
       ));
   @override
-  void setState(_i11.ViewState? viewState) => super.noSuchMethod(
+  void setState(_i12.ViewState? viewState) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [viewState],
@@ -1510,7 +1531,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void addListener(dynamic listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1518,7 +1539,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(dynamic listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1546,7 +1567,7 @@ class MockSignupDetailsViewModel extends _i2.Mock
 /// A class which mocks [Post].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPost extends _i2.Mock implements _i14.Post {
+class MockPost extends _i2.Mock implements _i15.Post {
   @override
   String get sId => (super.noSuchMethod(
         Invocation.getter(#sId),
@@ -1609,7 +1630,7 @@ class MockPost extends _i2.Mock implements _i14.Post {
         returnValueForMissingStub: null,
       );
   @override
-  set likedBy(List<_i14.LikedBy>? _likedBy) => super.noSuchMethod(
+  set likedBy(List<_i15.LikedBy>? _likedBy) => super.noSuchMethod(
         Invocation.setter(
           #likedBy,
           _likedBy,
@@ -1617,7 +1638,7 @@ class MockPost extends _i2.Mock implements _i14.Post {
         returnValueForMissingStub: null,
       );
   @override
-  set comments(List<_i14.Comments>? _comments) => super.noSuchMethod(
+  set comments(List<_i15.Comments>? _comments) => super.noSuchMethod(
         Invocation.setter(
           #comments,
           _comments,
@@ -1674,7 +1695,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
   @override
   _i3.GraphQLError get userNotFound => (super.noSuchMethod(
         Invocation.getter(#userNotFound),
-        returnValue: _FakeGraphQLError_17(
+        returnValue: _FakeGraphQLError_18(
           this,
           Invocation.getter(#userNotFound),
         ),
@@ -1690,7 +1711,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
   @override
   _i3.GraphQLError get userNotAuthenticated => (super.noSuchMethod(
         Invocation.getter(#userNotAuthenticated),
-        returnValue: _FakeGraphQLError_17(
+        returnValue: _FakeGraphQLError_18(
           this,
           Invocation.getter(#userNotAuthenticated),
         ),
@@ -1707,7 +1728,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
   @override
   _i3.GraphQLError get emailAccountPresent => (super.noSuchMethod(
         Invocation.getter(#emailAccountPresent),
-        returnValue: _FakeGraphQLError_17(
+        returnValue: _FakeGraphQLError_18(
           this,
           Invocation.getter(#emailAccountPresent),
         ),
@@ -1724,7 +1745,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
   @override
   _i3.GraphQLError get wrongCredentials => (super.noSuchMethod(
         Invocation.getter(#wrongCredentials),
-        returnValue: _FakeGraphQLError_17(
+        returnValue: _FakeGraphQLError_18(
           this,
           Invocation.getter(#wrongCredentials),
         ),
@@ -1741,7 +1762,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
   @override
   _i3.GraphQLError get organizationNotFound => (super.noSuchMethod(
         Invocation.getter(#organizationNotFound),
-        returnValue: _FakeGraphQLError_17(
+        returnValue: _FakeGraphQLError_18(
           this,
           Invocation.getter(#organizationNotFound),
         ),
@@ -1759,7 +1780,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
   _i3.GraphQLError get refreshAccessTokenExpiredException =>
       (super.noSuchMethod(
         Invocation.getter(#refreshAccessTokenExpiredException),
-        returnValue: _FakeGraphQLError_17(
+        returnValue: _FakeGraphQLError_18(
           this,
           Invocation.getter(#refreshAccessTokenExpiredException),
         ),
@@ -1777,7 +1798,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
   @override
   _i3.GraphQLError get memberRequestExist => (super.noSuchMethod(
         Invocation.getter(#memberRequestExist),
-        returnValue: _FakeGraphQLError_17(
+        returnValue: _FakeGraphQLError_18(
           this,
           Invocation.getter(#memberRequestExist),
         ),
@@ -1880,7 +1901,7 @@ class MockDataBaseMutationFunctions extends _i2.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockOrganizationService extends _i2.Mock
-    implements _i26.OrganizationService {
+    implements _i27.OrganizationService {
   @override
   _i4.Future<List<_i6.User>> getOrgMembersList(String? orgId) =>
       (super.noSuchMethod(
@@ -1896,20 +1917,20 @@ class MockOrganizationService extends _i2.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockExploreEventsViewModel extends _i2.Mock
-    implements _i27.ExploreEventsViewModel {
+    implements _i28.ExploreEventsViewModel {
   @override
-  List<_i17.Event> get events => (super.noSuchMethod(
+  List<_i18.Event> get events => (super.noSuchMethod(
         Invocation.getter(#events),
-        returnValue: <_i17.Event>[],
-      ) as List<_i17.Event>);
+        returnValue: <_i18.Event>[],
+      ) as List<_i18.Event>);
   @override
-  _i9.EventService get eventService => (super.noSuchMethod(
+  _i10.EventService get eventService => (super.noSuchMethod(
         Invocation.getter(#eventService),
-        returnValue: _FakeEventService_18(
+        returnValue: _FakeEventService_19(
           this,
           Invocation.getter(#eventService),
         ),
-      ) as _i9.EventService);
+      ) as _i10.EventService);
   @override
   String get emptyListMessage => (super.noSuchMethod(
         Invocation.getter(#emptyListMessage),
@@ -1921,10 +1942,10 @@ class MockExploreEventsViewModel extends _i2.Mock
         returnValue: '',
       ) as String);
   @override
-  _i11.ViewState get state => (super.noSuchMethod(
+  _i12.ViewState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i11.ViewState.idle,
-      ) as _i11.ViewState);
+        returnValue: _i12.ViewState.idle,
+      ) as _i12.ViewState);
   @override
   bool get isBusy => (super.noSuchMethod(
         Invocation.getter(#isBusy),
@@ -1963,7 +1984,7 @@ class MockExploreEventsViewModel extends _i2.Mock
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  _i4.Future<void> checkIfExistsAndAddNewEvent(_i17.Event? newEvent) =>
+  _i4.Future<void> checkIfExistsAndAddNewEvent(_i18.Event? newEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkIfExistsAndAddNewEvent,
@@ -1998,7 +2019,7 @@ class MockExploreEventsViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void setState(_i11.ViewState? viewState) => super.noSuchMethod(
+  void setState(_i12.ViewState? viewState) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [viewState],
@@ -2006,7 +2027,7 @@ class MockExploreEventsViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void addListener(dynamic listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -2014,7 +2035,7 @@ class MockExploreEventsViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(dynamic listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -2034,7 +2055,7 @@ class MockExploreEventsViewModel extends _i2.Mock
 /// A class which mocks [Validator].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockValidator extends _i2.Mock implements _i28.Validator {
+class MockValidator extends _i2.Mock implements _i29.Validator {
   @override
   _i4.Future<bool?> validateUrlExistence(String? url) => (super.noSuchMethod(
         Invocation.method(
@@ -2048,35 +2069,35 @@ class MockValidator extends _i2.Mock implements _i28.Validator {
 /// A class which mocks [QRViewController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockQRViewController extends _i2.Mock implements _i29.QRViewController {
+class MockQRViewController extends _i2.Mock implements _i30.QRViewController {
   @override
-  _i4.Stream<_i30.Barcode> get scannedDataStream => (super.noSuchMethod(
+  _i4.Stream<_i31.Barcode> get scannedDataStream => (super.noSuchMethod(
         Invocation.getter(#scannedDataStream),
-        returnValue: _i4.Stream<_i30.Barcode>.empty(),
-      ) as _i4.Stream<_i30.Barcode>);
+        returnValue: _i4.Stream<_i31.Barcode>.empty(),
+      ) as _i4.Stream<_i31.Barcode>);
   @override
   bool get hasPermissions => (super.noSuchMethod(
         Invocation.getter(#hasPermissions),
         returnValue: false,
       ) as bool);
   @override
-  _i4.Future<_i31.CameraFacing> getCameraInfo() => (super.noSuchMethod(
+  _i4.Future<_i32.CameraFacing> getCameraInfo() => (super.noSuchMethod(
         Invocation.method(
           #getCameraInfo,
           [],
         ),
         returnValue:
-            _i4.Future<_i31.CameraFacing>.value(_i31.CameraFacing.back),
-      ) as _i4.Future<_i31.CameraFacing>);
+            _i4.Future<_i32.CameraFacing>.value(_i32.CameraFacing.back),
+      ) as _i4.Future<_i32.CameraFacing>);
   @override
-  _i4.Future<_i31.CameraFacing> flipCamera() => (super.noSuchMethod(
+  _i4.Future<_i32.CameraFacing> flipCamera() => (super.noSuchMethod(
         Invocation.method(
           #flipCamera,
           [],
         ),
         returnValue:
-            _i4.Future<_i31.CameraFacing>.value(_i31.CameraFacing.back),
-      ) as _i4.Future<_i31.CameraFacing>);
+            _i4.Future<_i32.CameraFacing>.value(_i32.CameraFacing.back),
+      ) as _i4.Future<_i32.CameraFacing>);
   @override
   _i4.Future<bool?> getFlashStatus() => (super.noSuchMethod(
         Invocation.method(
@@ -2122,20 +2143,20 @@ class MockQRViewController extends _i2.Mock implements _i29.QRViewController {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  _i4.Future<_i10.SystemFeatures> getSystemFeatures() => (super.noSuchMethod(
+  _i4.Future<_i11.SystemFeatures> getSystemFeatures() => (super.noSuchMethod(
         Invocation.method(
           #getSystemFeatures,
           [],
         ),
         returnValue:
-            _i4.Future<_i10.SystemFeatures>.value(_FakeSystemFeatures_19(
+            _i4.Future<_i11.SystemFeatures>.value(_FakeSystemFeatures_20(
           this,
           Invocation.method(
             #getSystemFeatures,
             [],
           ),
         )),
-      ) as _i4.Future<_i10.SystemFeatures>);
+      ) as _i4.Future<_i11.SystemFeatures>);
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -2158,7 +2179,7 @@ class MockQRViewController extends _i2.Mock implements _i29.QRViewController {
 /// A class which mocks [CommentService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCommentService extends _i2.Mock implements _i32.CommentService {
+class MockCommentService extends _i2.Mock implements _i33.CommentService {
   @override
   _i4.Future<void> createComments(
     String? postId,
@@ -2188,7 +2209,7 @@ class MockCommentService extends _i2.Mock implements _i32.CommentService {
 /// A class which mocks [AppTheme].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAppTheme extends _i2.Mock implements _i33.AppTheme {
+class MockAppTheme extends _i2.Mock implements _i34.AppTheme {
   @override
   String get key => (super.noSuchMethod(
         Invocation.getter(#key),
@@ -2200,10 +2221,10 @@ class MockAppTheme extends _i2.Mock implements _i33.AppTheme {
         returnValue: false,
       ) as bool);
   @override
-  _i11.ViewState get state => (super.noSuchMethod(
+  _i12.ViewState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i11.ViewState.idle,
-      ) as _i11.ViewState);
+        returnValue: _i12.ViewState.idle,
+      ) as _i12.ViewState);
   @override
   bool get isBusy => (super.noSuchMethod(
         Invocation.getter(#isBusy),
@@ -2222,7 +2243,7 @@ class MockAppTheme extends _i2.Mock implements _i33.AppTheme {
         {#isOn: isOn},
       ));
   @override
-  void setState(_i11.ViewState? viewState) => super.noSuchMethod(
+  void setState(_i12.ViewState? viewState) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [viewState],
@@ -2230,7 +2251,7 @@ class MockAppTheme extends _i2.Mock implements _i33.AppTheme {
         returnValueForMissingStub: null,
       );
   @override
-  void addListener(dynamic listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -2238,7 +2259,7 @@ class MockAppTheme extends _i2.Mock implements _i33.AppTheme {
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(dynamic listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -2266,13 +2287,18 @@ class MockAppTheme extends _i2.Mock implements _i33.AppTheme {
 /// A class which mocks [TaskService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTaskService extends _i2.Mock implements _i34.TaskService {
+class MockTaskService extends _i2.Mock implements _i35.TaskService {
   MockTaskService() {
     _i2.throwOnMissingStub(this);
   }
 
   @override
-  set callbackNotifyListeners(dynamic _callbackNotifyListeners) =>
+  _i9.VoidCallback get callbackNotifyListeners => (super.noSuchMethod(
+        Invocation.getter(#callbackNotifyListeners),
+        returnValue: () {},
+      ) as _i9.VoidCallback);
+  @override
+  set callbackNotifyListeners(_i9.VoidCallback? _callbackNotifyListeners) =>
       super.noSuchMethod(
         Invocation.setter(
           #callbackNotifyListeners,
@@ -2281,10 +2307,10 @@ class MockTaskService extends _i2.Mock implements _i34.TaskService {
         returnValueForMissingStub: null,
       );
   @override
-  List<_i35.Task> get tasks => (super.noSuchMethod(
+  List<_i36.Task> get tasks => (super.noSuchMethod(
         Invocation.getter(#tasks),
-        returnValue: <_i35.Task>[],
-      ) as List<_i35.Task>);
+        returnValue: <_i36.Task>[],
+      ) as List<_i36.Task>);
   @override
   _i4.Future<void> getTasksForEvent(String? eventId) => (super.noSuchMethod(
         Invocation.method(
@@ -2365,11 +2391,11 @@ class MockTaskService extends _i2.Mock implements _i34.TaskService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCreateEventViewModel extends _i2.Mock
-    implements _i36.CreateEventViewModel {
+    implements _i37.CreateEventViewModel {
   @override
   _i1.TextEditingController get eventTitleTextController => (super.noSuchMethod(
         Invocation.getter(#eventTitleTextController),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#eventTitleTextController),
         ),
@@ -2388,7 +2414,7 @@ class MockCreateEventViewModel extends _i2.Mock
   _i1.TextEditingController get eventLocationTextController =>
       (super.noSuchMethod(
         Invocation.getter(#eventLocationTextController),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#eventLocationTextController),
         ),
@@ -2407,7 +2433,7 @@ class MockCreateEventViewModel extends _i2.Mock
   _i1.TextEditingController get eventDescriptionTextController =>
       (super.noSuchMethod(
         Invocation.getter(#eventDescriptionTextController),
-        returnValue: _FakeTextEditingController_15(
+        returnValue: _FakeTextEditingController_16(
           this,
           Invocation.getter(#eventDescriptionTextController),
         ),
@@ -2425,7 +2451,7 @@ class MockCreateEventViewModel extends _i2.Mock
   @override
   _i1.TimeOfDay get eventStartTime => (super.noSuchMethod(
         Invocation.getter(#eventStartTime),
-        returnValue: _FakeTimeOfDay_20(
+        returnValue: _FakeTimeOfDay_21(
           this,
           Invocation.getter(#eventStartTime),
         ),
@@ -2441,7 +2467,7 @@ class MockCreateEventViewModel extends _i2.Mock
   @override
   _i1.TimeOfDay get eventEndTime => (super.noSuchMethod(
         Invocation.getter(#eventEndTime),
-        returnValue: _FakeTimeOfDay_20(
+        returnValue: _FakeTimeOfDay_21(
           this,
           Invocation.getter(#eventEndTime),
         ),
@@ -2457,7 +2483,7 @@ class MockCreateEventViewModel extends _i2.Mock
   @override
   DateTime get eventStartDate => (super.noSuchMethod(
         Invocation.getter(#eventStartDate),
-        returnValue: _FakeDateTime_21(
+        returnValue: _FakeDateTime_22(
           this,
           Invocation.getter(#eventStartDate),
         ),
@@ -2473,7 +2499,7 @@ class MockCreateEventViewModel extends _i2.Mock
   @override
   DateTime get eventEndDate => (super.noSuchMethod(
         Invocation.getter(#eventEndDate),
-        returnValue: _FakeDateTime_21(
+        returnValue: _FakeDateTime_22(
           this,
           Invocation.getter(#eventEndDate),
         ),
@@ -2515,7 +2541,7 @@ class MockCreateEventViewModel extends _i2.Mock
   @override
   _i1.FocusNode get titleFocus => (super.noSuchMethod(
         Invocation.getter(#titleFocus),
-        returnValue: _FakeFocusNode_16(
+        returnValue: _FakeFocusNode_17(
           this,
           Invocation.getter(#titleFocus),
         ),
@@ -2531,7 +2557,7 @@ class MockCreateEventViewModel extends _i2.Mock
   @override
   _i1.FocusNode get locationFocus => (super.noSuchMethod(
         Invocation.getter(#locationFocus),
-        returnValue: _FakeFocusNode_16(
+        returnValue: _FakeFocusNode_17(
           this,
           Invocation.getter(#locationFocus),
         ),
@@ -2547,7 +2573,7 @@ class MockCreateEventViewModel extends _i2.Mock
   @override
   _i1.FocusNode get descriptionFocus => (super.noSuchMethod(
         Invocation.getter(#descriptionFocus),
-        returnValue: _FakeFocusNode_16(
+        returnValue: _FakeFocusNode_17(
           this,
           Invocation.getter(#descriptionFocus),
         ),
@@ -2631,10 +2657,10 @@ class MockCreateEventViewModel extends _i2.Mock
         returnValue: <String, bool>{},
       ) as Map<String, bool>);
   @override
-  _i11.ViewState get state => (super.noSuchMethod(
+  _i12.ViewState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i11.ViewState.idle,
-      ) as _i11.ViewState);
+        returnValue: _i12.ViewState.idle,
+      ) as _i12.ViewState);
   @override
   bool get isBusy => (super.noSuchMethod(
         Invocation.getter(#isBusy),
@@ -2709,7 +2735,7 @@ class MockCreateEventViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void setState(_i11.ViewState? viewState) => super.noSuchMethod(
+  void setState(_i12.ViewState? viewState) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [viewState],
@@ -2717,7 +2743,7 @@ class MockCreateEventViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void addListener(dynamic listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -2725,7 +2751,7 @@ class MockCreateEventViewModel extends _i2.Mock
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(dynamic listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -2737,6 +2763,158 @@ class MockCreateEventViewModel extends _i2.Mock
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [DirectChatViewModel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockDirectChatViewModel extends _i2.Mock
+    implements _i38.DirectChatViewModel {
+  @override
+  _i1.GlobalKey<_i1.AnimatedListState> get listKey => (super.noSuchMethod(
+        Invocation.getter(#listKey),
+        returnValue: _FakeGlobalKey_0<_i1.AnimatedListState>(
+          this,
+          Invocation.getter(#listKey),
+        ),
+      ) as _i1.GlobalKey<_i1.AnimatedListState>);
+  @override
+  _i12.ChatState get chatState => (super.noSuchMethod(
+        Invocation.getter(#chatState),
+        returnValue: _i12.ChatState.initial,
+      ) as _i12.ChatState);
+  @override
+  set chatState(_i12.ChatState? _chatState) => super.noSuchMethod(
+        Invocation.setter(
+          #chatState,
+          _chatState,
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  set name(String? _name) => super.noSuchMethod(
+        Invocation.setter(
+          #name,
+          _name,
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  List<_i20.ChatListTileDataModel> get chats => (super.noSuchMethod(
+        Invocation.getter(#chats),
+        returnValue: <_i20.ChatListTileDataModel>[],
+      ) as List<_i20.ChatListTileDataModel>);
+  @override
+  Map<String, List<_i21.ChatMessage>> get chatMessagesByUser =>
+      (super.noSuchMethod(
+        Invocation.getter(#chatMessagesByUser),
+        returnValue: <String, List<_i21.ChatMessage>>{},
+      ) as Map<String, List<_i21.ChatMessage>>);
+  @override
+  _i12.ViewState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _i12.ViewState.idle,
+      ) as _i12.ViewState);
+  @override
+  bool get isBusy => (super.noSuchMethod(
+        Invocation.getter(#isBusy),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+  @override
+  void refreshChats() => super.noSuchMethod(
+        Invocation.method(
+          #refreshChats,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  _i4.Future<void> initialise() => (super.noSuchMethod(
+        Invocation.method(
+          #initialise,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> getChatMessages(String? chatId) => (super.noSuchMethod(
+        Invocation.method(
+          #getChatMessages,
+          [chatId],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> sendMessageToDirectChat(
+    String? chatId,
+    String? messageContent,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sendMessageToDirectChat,
+          [
+            chatId,
+            messageContent,
+          ],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void chatName(dynamic chatId) => super.noSuchMethod(
+        Invocation.method(
+          #chatName,
+          [chatId],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void setState(_i12.ViewState? viewState) => super.noSuchMethod(
+        Invocation.method(
+          #setState,
+          [viewState],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/views/after_auth_screens/chat/chat_message_screen_test/chat_message_screen_test.dart
+++ b/test/views/after_auth_screens/chat/chat_message_screen_test/chat_message_screen_test.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:talawa/enums/enums.dart';
 import 'package:talawa/router.dart' as router;
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
 import 'package:talawa/views/after_auth_screens/chat/chat_message_screen.dart';
+import 'package:talawa/views/after_auth_screens/chat/widgets/chat_input_field.dart';
 import 'package:talawa/views/base_view.dart';
 
 import '../../../../helpers/test_helpers.dart';
@@ -54,4 +57,22 @@ void main() {
 
     expect(find.byType(Scaffold), findsOneWidget);
   });
+
+  testWidgets('Check if the Chat Input Field is in the widget tree',
+      (tester) async {
+    await showChatMessageScreen(tester);
+
+    expect(find.byType(ChatInputField), findsOneWidget);
+  });
+
+  testWidgets(
+    'Check if the circular progress indicator shows up on the loading state',
+    (tester) async {
+      when(directChatViewModel.chatState).thenReturn(ChatState.loading);
+      await tester.pumpWidget(createApp());
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    },
+  );
 }

--- a/test/views/after_auth_screens/chat/chat_message_screen_test/chat_message_screen_test.dart
+++ b/test/views/after_auth_screens/chat/chat_message_screen_test/chat_message_screen_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talawa/router.dart' as router;
+import 'package:talawa/services/navigation_service.dart';
+import 'package:talawa/services/size_config.dart';
+import 'package:talawa/utils/app_localization.dart';
+import 'package:talawa/view_model/lang_view_model.dart';
+import 'package:talawa/views/after_auth_screens/chat/chat_message_screen.dart';
+import 'package:talawa/views/base_view.dart';
+
+import '../../../../helpers/test_helpers.dart';
+import '../../../../helpers/test_locator.dart';
+
+final directChatViewModel = getAndRegisterDirectChatViewModel();
+
+Widget createApp() {
+  return BaseView<AppLanguage>(
+    onModelReady: (model) => model.initialize(),
+    builder: (context, langModel, child) {
+      return MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: [
+          const AppLocalizationsDelegate(isTest: true),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        home: ChatMessageScreen(chatId: "XYZ", model: directChatViewModel),
+        navigatorKey: locator<NavigationService>().navigatorKey,
+        onGenerateRoute: router.generateRoute,
+      );
+    },
+  );
+}
+
+Future<void> showChatMessageScreen(WidgetTester tester) async {
+  await tester.pumpWidget(createApp());
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  SizeConfig().test();
+  testSetupLocator();
+  registerServices();
+
+  testWidgets('Check if Chat Message Screen page shows up', (tester) async {
+    await showChatMessageScreen(tester);
+    expect(find.byType(Scaffold), findsOneWidget);
+  });
+
+  testWidgets('Check if Back page button is working', (tester) async {
+    await showChatMessageScreen(tester);
+    await tester.tap(find.byIcon(Icons.arrow_back));
+
+    expect(find.byType(Scaffold), findsOneWidget);
+  });
+}

--- a/test/widget_tests/widgets/task_schedule_test.dart
+++ b/test/widget_tests/widgets/task_schedule_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
 import 'package:talawa/models/events/event_model.dart';
@@ -17,7 +19,10 @@ import 'package:talawa/views/base_view.dart';
 import 'package:talawa/widgets/task_schedule.dart';
 
 import '../../helpers/test_helpers.dart';
+import '../../helpers/test_helpers.mocks.dart';
 import '../../helpers/test_locator.dart';
+
+final mockNavigationService = MockNavigationService();
 
 final task1 = Task(
   id: '123',
@@ -204,7 +209,9 @@ void main() {
     expect(find.byType(AlertDialog), findsOneWidget);
   });
 
-  testWidgets("Check if the Task Card's agenda is tapped", (tester) async {
+  testWidgets(
+      "Check calendarTapped when targetElement is CalendarElement.header",
+      (tester) async {
     await tester.pumpWidget(createTaskScheduleWidget());
     await tester.pump();
 
@@ -214,8 +221,9 @@ void main() {
     tester.allElements.forEach((element) {
       print(element);
     });
-    await tester.tap(find.text('February 2023'));
+    await tester.tap(find.text(DateFormat("MMMM y").format(DateTime.now())));
     await tester.pump();
+    verifyNever(mockNavigationService.pushDialog(const AlertDialog()));
   });
   testWidgets(
       'Check when the Task Card is pressed the close button is available',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR will:

- Introduce tests for the `lib/views/after_auth_screens/chat/chat_message_screen.dart` file.
- Fix a buggy test from `lib/widgets/task_schedule_test.dart`, which hard-codes the current month-year to find the widget(which failed today, since it's the start of the new month). 

**Issue Number:**

Fixes #1408 

**Did you add tests for your changes?**

Yes, this is a test related PR.

**Snapshots/Videos:**

Snapshot for the test coverage: 
![image](https://user-images.githubusercontent.com/55295613/222124134-985e9715-b8b5-4e0e-831e-029bb8d34a84.png)

**If relevant, did you update the documentation?**

N/A

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes