### PR TITLE
Irregular spacing between menu bar tiles and icon colors in settings screen fix.

### DIFF
--- a/lib/views/after_auth_screens/profile/profile_page.dart
+++ b/lib/views/after_auth_screens/profile/profile_page.dart
@@ -104,20 +104,22 @@ class ProfilePage extends StatelessWidget {
                         height: 20, //
                       ),
                       SizedBox(
-                        height: SizeConfig.screenHeight! * 0.63,
+                        height: SizeConfig.screenHeight! * 0.67,
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.start,
                           children: [
                             SizedBox(
-                              height: SizeConfig.screenHeight! * 0.05,
+                              height: SizeConfig.screenHeight! * 0.01,
                             ),
                             CustomListTile(
                               key: homeModel!.keySPAppSetting,
                               index: 0,
                               type: TileType.option,
                               option: Options(
-                                icon: const Icon(
+                                icon: Icon(
                                   Icons.phonelink_setup,
+                                  color:
+                                      Theme.of(context).colorScheme.secondary,
                                   size: 30,
                                 ),
                                 // title for App Settings.
@@ -141,8 +143,10 @@ class ProfilePage extends StatelessWidget {
                               index: 1,
                               type: TileType.option,
                               option: Options(
-                                icon: const Icon(
+                                icon: Icon(
                                   Icons.task_outlined,
+                                  color:
+                                      Theme.of(context).colorScheme.secondary,
                                   size: 30,
                                 ),
                                 // title for My Tasks tile
@@ -158,6 +162,9 @@ class ProfilePage extends StatelessWidget {
                               onTapOption: () {
                                 navigationService.pushScreen(Routes.userTasks);
                               },
+                            ),
+                            SizedBox(
+                              height: SizeConfig.screenHeight! * 0.05,
                             ),
                             // // Will be added later when we add the Help Section in Documentation.
                             // CustomListTile(

--- a/lib/views/after_auth_screens/profile/profile_page.dart
+++ b/lib/views/after_auth_screens/profile/profile_page.dart
@@ -201,7 +201,7 @@ class ProfilePage extends StatelessWidget {
                                         Icons.monetization_on,
                                         color: Theme.of(context)
                                             .colorScheme
-                                            .primary,
+                                            .secondary,
                                         size: 30,
                                       ),
                                       title: AppLocalizations.of(context)!


### PR DESCRIPTION
What kind of change does this PR introduce?
Bug Fixes for icons and overflow

Issue Number:
Closes #1608 

Have you read the [contributing guide]
Yes

Summary
The settings page was looking very irregular with inadequate spacing between some of its buttons and also the color of some icons was not reflecting the theme because the colors were hardcoded. So, used theme colors to change the icon colors. Also added adequate spacing between icons and made it consistent and stopped the overflowing of pixels in older phone models.

Screenshots
![image](https://user-images.githubusercontent.com/64556649/222879685-dd0cb4d1-c7cd-4931-91d0-424457ee5711.png)













