### PR TITLE
Add test for Edit Task Page to validate onSave callback.

### DIFF
--- a/test/helpers/test_locator.dart
+++ b/test/helpers/test_locator.dart
@@ -21,6 +21,7 @@ import 'package:talawa/view_model/after_auth_view_models/event_view_models/explo
 import 'package:talawa/view_model/after_auth_view_models/feed_view_models/organization_feed_view_model.dart';
 import 'package:talawa/view_model/after_auth_view_models/profile_view_models/edit_profile_view_model.dart';
 import 'package:talawa/view_model/after_auth_view_models/profile_view_models/profile_page_view_model.dart';
+import 'package:talawa/view_model/after_auth_view_models/task_view_models/create_task_view_model.dart';
 import 'package:talawa/view_model/after_auth_view_models/task_view_models/explore_tasks_view_model.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
 import 'package:talawa/view_model/main_screen_view_model.dart';
@@ -92,6 +93,7 @@ void testSetupLocator() {
   locator.registerFactory(() => ProfilePageViewModel());
   locator.registerFactory(() => EditProfilePageViewModel());
   locator.registerFactory(() => CreateEventViewModel());
+  locator.registerFactory(() => CreateTaskViewModel());
   locator.registerFactory(() => EditEventViewModel());
   locator.registerFactory(() => AddPostViewModel());
   locator.registerFactory(() => EventInfoViewModel());

--- a/test/widget_tests/after_auth_screens/tasks/edit_task_page_test.dart
+++ b/test/widget_tests/after_auth_screens/tasks/edit_task_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:talawa/constants/custom_theme.dart';
 import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/models/task/task_model.dart';
 import 'package:talawa/models/user/user_info.dart';
@@ -12,14 +13,19 @@ import 'package:talawa/widgets/task_form.dart';
 import '../../../helpers/test_helpers.dart';
 
 Widget createEditTaskPage() => MaterialApp(
+      locale: const Locale('en'),
       localizationsDelegates: [
-        AppLocalizations.delegate,
+        const AppLocalizationsDelegate(isTest: true),
         GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
       ],
+      themeMode: ThemeMode.light,
+      theme: TalawaTheme.lightTheme,
       home: EditTaskPage(
         task: Task(
           id: '1',
           title: 'title',
+          description: 'description',
           event: Event(),
           creator: User(),
           createdAt: '123456',
@@ -28,14 +34,31 @@ Widget createEditTaskPage() => MaterialApp(
     );
 
 void main() {
-  setUp(() {
+  setUpAll(() {
     SizeConfig().test();
     registerServices();
     registerViewModels();
   });
-  testWidgets('EditTaskPage UI Test', (tester) async {
-    await tester.pumpWidget(createEditTaskPage());
-    await tester.pump();
-    expect(find.byType(TaskForm), findsOneWidget);
+
+  group("Functionality tests", () {
+    testWidgets('Check onSave functionality for TaskForm', (tester) async {
+      await tester.pumpWidget(createEditTaskPage());
+      await tester.pump();
+      await tester.tap(find.byType(TextButton));
+      expect(find.byType(TaskForm), findsOneWidget);
+    });
+  });
+
+  group("UI Tests", () {
+    testWidgets('EditTaskPage UI Test', (tester) async {
+      await tester.pumpWidget(createEditTaskPage());
+      await tester.pump();
+      expect(find.byType(TaskForm), findsOneWidget);
+    });
+  });
+
+  tearDownAll(() {
+    unregisterServices();
+    unregisterViewModels();
   });
 }

--- a/test/widget_tests/widgets/task_form_test.dart
+++ b/test/widget_tests/widgets/task_form_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:talawa/router.dart' as router;
+import 'package:talawa/services/navigation_service.dart';
+import 'package:talawa/services/size_config.dart';
+import 'package:talawa/utils/app_localization.dart';
+import 'package:talawa/view_model/after_auth_view_models/task_view_models/create_task_view_model.dart';
+import 'package:talawa/views/base_view.dart';
+import 'package:talawa/widgets/event_date_time_tile.dart';
+import 'package:talawa/widgets/task_form.dart';
+
+import '../../helpers/test_helpers.dart';
+import '../../helpers/test_locator.dart';
+
+class OnSaveCallback {
+  void call() {}
+}
+
+class MockOnSaveCallback extends Mock implements OnSaveCallback {}
+
+MockOnSaveCallback mockOnSaveCallback = MockOnSaveCallback();
+
+Widget createTaskFormWidget() {
+  return BaseView<CreateTaskViewModel>(
+    onModelReady: (model) {},
+    builder: (context, model, child) {
+      return MaterialApp(
+        key: const Key('Root'),
+        navigatorKey: locator<NavigationService>().navigatorKey,
+        navigatorObservers: [],
+        locale: const Locale('en'),
+        supportedLocales: [
+          const Locale('en', 'US'),
+        ],
+        localizationsDelegates: [
+          const AppLocalizationsDelegate(isTest: true),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: TaskForm(
+            onSave: () async {
+              mockOnSaveCallback.call();
+              return true;
+            },
+            title: "TITLE",
+            actionText: "ACTION",
+          ),
+        ),
+        onGenerateRoute: router.generateRoute,
+      );
+    },
+  );
+}
+
+void callback() {}
+
+void main() {
+  testSetupLocator();
+  setUp(() {
+    registerServices();
+    locator<SizeConfig>().test();
+  });
+
+  tearDown(() {
+    unregisterServices();
+  });
+
+  group('Test datetime callbacks', () {
+    testWidgets(
+      "Check DateTimeTile setTime and setDate callback",
+      (tester) async {
+        await tester.pumpWidget(createTaskFormWidget());
+        await tester.pumpAndSettle();
+        final dateTimeTile = find.byType(DateTimeTile);
+        final datePicker = find.byKey(const Key("EventDateTimeTileDate"));
+        final timePicker = find.byKey(const Key("EventDateTimeTileTime"));
+
+        expect(dateTimeTile, findsOneWidget);
+        expect(datePicker, findsOneWidget);
+        expect(timePicker, findsOneWidget);
+
+        await tester.tap(timePicker);
+        await tester.pumpAndSettle();
+        expect(find.text("OK"), findsOneWidget);
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(timePicker);
+        await tester.pumpAndSettle();
+        expect(find.text("OK"), findsOneWidget);
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+      },
+    );
+  });
+
+  group("Widget Tests for TaskForm", () {
+    testWidgets("Check if TaskForm shows up", (tester) async {
+      await tester.pumpWidget(createTaskFormWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TaskForm), findsOneWidget);
+    });
+
+    testWidgets("Check if all children show up correctly", (tester) async {
+      await tester.pumpWidget(createTaskFormWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Scaffold), findsWidgets);
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(Scrollbar), findsOneWidget);
+      expect(find.byType(TitleField), findsOneWidget);
+      expect(find.byType(DescriptionField), findsOneWidget);
+    });
+
+    testWidgets("Check if all update button work", (tester) async {
+      await tester.pumpWidget(createTaskFormWidget());
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TitleField), "title");
+      await tester.enterText(find.byType(DescriptionField), "description");
+      await tester.tap(find.byType(TextButton));
+
+      verify(mockOnSaveCallback.call());
+    });
+  });
+}

--- a/test/widget_tests/widgets/task_schedule_test.dart
+++ b/test/widget_tests/widgets/task_schedule_test.dart
@@ -315,7 +315,6 @@ void main() {
     expect(find.byType(AlertDialog), findsNothing);
   });
   testWidgets('Check AlertDialog edit button iss working', (tester) async {
-    locator.registerFactory(() => CreateTaskViewModel());
     await tester.pumpWidget(createTaskCardWidget());
     // await tester
     await tester.pump();

--- a/test/widget_tests/widgets/task_schedule_test.dart
+++ b/test/widget_tests/widgets/task_schedule_test.dart
@@ -12,7 +12,6 @@ import 'package:talawa/router.dart' as router;
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
-import 'package:talawa/view_model/after_auth_view_models/task_view_models/create_task_view_model.dart';
 import 'package:talawa/view_model/after_auth_view_models/task_view_models/explore_tasks_view_model.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
 import 'package:talawa/views/base_view.dart';


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Introduces a new test for `lib/views/after_auth_screens/tasks/edit_task_page.dart` to test the `onSave()` callback.

- Introduces tests for `task_form.dart`.

**Issue Number:**

Fixes #1401 and #1397

**Did you add tests for your changes?**

Yes, this is a test related PR.

**Snapshots/Videos:**

![image](https://user-images.githubusercontent.com/55295613/222951453-c42fc6f9-8d79-4710-9a24-edffcdb33867.png)

**If relevant, did you update the documentation?**

N/A

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes