### PR TITLE
Fix Edit Event Routing

### DIFF
--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -45,7 +45,7 @@ class EventService {
   /// params:
   /// None
   /// returns:
-  /// `Stream<Event>`: returns the event stream
+  /// None
   Stream<Event> get eventStream => _eventStream;
 
   /// This function is used to set stream subscription for an organization.
@@ -62,6 +62,7 @@ class EventService {
   }
 
   /// This function is used to fetch all the events of an organization.
+  ///
   /// params:
   /// None
   /// returns:

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -1,11 +1,10 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:talawa/constants/routing_constants.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
+import 'package:talawa/models/mainscreen_navigation_args.dart';
 import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/services/database_mutation_functions.dart';
 import 'package:talawa/services/user_config.dart';
@@ -40,9 +39,16 @@ class EventService {
 
   final StreamController<Event> _eventStreamController =
       StreamController<Event>();
+
+  /// The event stream.
   Stream<Event> get eventStream => _eventStream;
 
   /// This function is used to set stream subscription for an organization.
+  ///
+  /// params:
+  /// None
+  /// returns:
+  /// None
   void setOrgStreamSubscription() {
     _currentOrganizationStreamSubscription =
         _userConfig.currentOrgInfoStream.listen((updatedOrganization) {
@@ -51,6 +57,10 @@ class EventService {
   }
 
   /// This function is used to fetch all the events of an organization.
+  /// params:
+  /// None
+  /// returns:
+  /// * `Future<void>` : void
   Future<void> getEvents() async {
     // refresh user's access token
     await _dbFunctions.refreshAccessToken(userConfig.currentUser.refreshToken!);
@@ -77,7 +87,9 @@ class EventService {
   /// This function is used to fetch all registrants of an event.
   ///
   /// params:
-  /// * [eventId] : id of an event
+  /// * `eventId` : id of an event.
+  /// returns:
+  /// * `Future<dynamic>` : Information about event registrants.
   Future<dynamic> fetchRegistrantsByEvent(String eventId) async {
     await _dbFunctions.refreshAccessToken(userConfig.currentUser.refreshToken!);
     final result = await _dbFunctions.gqlAuthQuery(
@@ -89,7 +101,9 @@ class EventService {
   /// This function is used to register user for an event.
   ///
   /// params:
-  /// * [eventId] : id of an event
+  /// * `eventId`: id of an event.
+  /// returns:
+  /// * `Future<dynamic>`: Information about the event registration.
   Future<dynamic> registerForAnEvent(String eventId) async {
     final tokenResult = await _dbFunctions
         .refreshAccessToken(userConfig.currentUser.refreshToken!);
@@ -105,7 +119,9 @@ class EventService {
   /// This function is used to delete the event.
   ///
   /// params:
-  /// * [eventId] : id of an event
+  /// * `eventId`: id of an event
+  /// returns:
+  /// * `Future<dynamic>`: Information about the event deletion
   Future<dynamic> deleteEvent(String eventId) async {
     navigationService.pushDialog(
       const CustomProgressDialog(key: Key('DeleteEventProgress')),
@@ -123,8 +139,10 @@ class EventService {
   /// This function is used to edit an event.
   ///
   /// params:
-  /// * [eventId] : id of an event
-  /// * [variables] : this will be `map` type and contain all the event details need to be update.
+  /// * `eventId` : id of an event
+  /// * `variables` : this will be `map` type and contain all the event details need to be update.
+  /// returns:
+  /// * `Future<void>` : void return
   Future<void> editEvent({
     required String eventId,
     required Map<String, dynamic> variables,
@@ -143,11 +161,20 @@ class EventService {
     );
     navigationService.pop();
     if (result != null) {
-      navigationService.removeAllAndPush('/mainScreen', '/');
+      navigationService.removeAllAndPush(
+        Routes.exploreEventsScreen,
+        Routes.mainScreen,
+        arguments: MainScreenArgs(mainScreenIndex: 0, fromSignUp: false),
+      );
     }
   }
 
   /// This function is used to cancel the stream subscription of an organization.
+  ///
+  /// params:
+  /// None
+  /// returns:
+  /// None
   void dispose() {
     _currentOrganizationStreamSubscription.cancel();
   }

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -45,7 +45,7 @@ class EventService {
   /// params:
   /// None
   /// returns:
-  /// `Stream<Event>`: returns the event stream
+  /// * `Stream<Event>`: returns the event stream
   Stream<Event> get eventStream => _eventStream;
 
   /// This function is used to set stream subscription for an organization.

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -45,7 +45,7 @@ class EventService {
   /// params:
   /// None
   /// returns:
-  /// None
+  /// `Stream<Event>`: returns the event stream
   Stream<Event> get eventStream => _eventStream;
 
   /// This function is used to set stream subscription for an organization.

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -41,6 +41,11 @@ class EventService {
       StreamController<Event>();
 
   /// The event stream.
+  ///
+  /// params:
+  /// None
+  /// returns:
+  /// `Stream<Event>`: returns the event stream
   Stream<Event> get eventStream => _eventStream;
 
   /// This function is used to set stream subscription for an organization.
@@ -60,7 +65,7 @@ class EventService {
   /// params:
   /// None
   /// returns:
-  /// * `Future<void>` : void
+  /// * `Future<void>`: void
   Future<void> getEvents() async {
     // refresh user's access token
     await _dbFunctions.refreshAccessToken(userConfig.currentUser.refreshToken!);
@@ -87,9 +92,9 @@ class EventService {
   /// This function is used to fetch all registrants of an event.
   ///
   /// params:
-  /// * `eventId` : id of an event.
+  /// * `eventId`: id of an event.
   /// returns:
-  /// * `Future<dynamic>` : Information about event registrants.
+  /// * `Future<dynamic>`: Information about event registrants.
   Future<dynamic> fetchRegistrantsByEvent(String eventId) async {
     await _dbFunctions.refreshAccessToken(userConfig.currentUser.refreshToken!);
     final result = await _dbFunctions.gqlAuthQuery(
@@ -139,10 +144,10 @@ class EventService {
   /// This function is used to edit an event.
   ///
   /// params:
-  /// * `eventId` : id of an event
-  /// * `variables` : this will be `map` type and contain all the event details need to be update.
+  /// * `eventId`: id of an event
+  /// * `variables`: this will be `map` type and contain all the event details need to be update.
   /// returns:
-  /// * `Future<void>` : void return
+  /// * `Future<void>`: void return
   Future<void> editEvent({
     required String eventId,
     required Map<String, dynamic> variables,

--- a/test/service_tests/event_service_test.dart
+++ b/test/service_tests/event_service_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mockito/mockito.dart';
+import 'package:talawa/services/database_mutation_functions.dart';
+import 'package:talawa/services/event_service.dart';
+import 'package:talawa/utils/event_queries.dart';
+import 'package:talawa/utils/task_queries.dart';
+
+import '../helpers/test_helpers.dart';
+import '../helpers/test_locator.dart';
+
+/// Tests event_service.dart.
+///
+/// params:
+/// None
+/// returns:
+/// None
+void main() {
+  testSetupLocator();
+
+  setUp(() {
+    registerServices();
+  });
+  group('Test EventService', () {
+    test('Test editEvent method', () async {
+      final dataBaseMutationFunctions = locator<DataBaseMutationFunctions>();
+      final query = TaskQueries.eventTasks('eventId');
+      final Map<String, dynamic> variables = <String, dynamic>{};
+      when(
+        dataBaseMutationFunctions.gqlAuthMutation(
+          EventQueries().updateEvent(eventId: 'eventId'),
+          variables: variables,
+        ),
+      ).thenAnswer(
+        (_) async => QueryResult(
+          options: QueryOptions(document: gql(query)),
+          data: {
+            'updateEvent': {
+              '_id': 'eventId',
+              'title': 'Test task',
+              'description': 'Test description'
+            }
+          },
+          source: QueryResultSource.network,
+        ),
+      );
+
+      final service = EventService();
+      await service.editEvent(
+        eventId: 'eventId',
+        variables: variables,
+      );
+
+      verify(
+        navigationService.pop(),
+      );
+    });
+  });
+}

--- a/test/widget_tests/widgets/task_form_test.dart
+++ b/test/widget_tests/widgets/task_form_test.dart
@@ -14,14 +14,34 @@ import 'package:talawa/widgets/task_form.dart';
 import '../../helpers/test_helpers.dart';
 import '../../helpers/test_locator.dart';
 
+/// OnSaveCallback class provides a simple call function to test callbacks.
+///
+/// Services include:
+/// * `call` : mock function to test callback
 class OnSaveCallback {
+  /// This is a mock function to test callback.
+  ///
+  /// params:
+  /// None
+  /// returns:
+  /// None
   void call() {}
 }
 
+/// MockOnSaveCallback class is the mocked version of OnSaveCallback.
+///
+/// Services include:
 class MockOnSaveCallback extends Mock implements OnSaveCallback {}
 
+/// The object created for MockOnSaveCallback.
 MockOnSaveCallback mockOnSaveCallback = MockOnSaveCallback();
 
+/// This function is used to return TaskFormWidget for testing.
+///
+/// params:
+/// None
+/// returns:
+/// * `Widget`: TaskForm Widget for testing.
 Widget createTaskFormWidget() {
   return BaseView<CreateTaskViewModel>(
     onModelReady: (model) {},
@@ -55,8 +75,12 @@ Widget createTaskFormWidget() {
   );
 }
 
-void callback() {}
-
+/// Tests task_form.dart.
+///
+/// params:
+/// None
+/// returns:
+/// None
 void main() {
   testSetupLocator();
   setUp(() {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR introduces the fix for the edit event flow. Currently, on pressing the "Done" button in the edit event page, we are shown a loader momentarily and are kept on the same page - with a `Null check operator used on a null value` in the background(due to the null arguments in the Main Screen route). After this PR, the users will be redirected to the events page.

**Issue Number:**

Fixes #1614 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

Before:

https://user-images.githubusercontent.com/55295613/223220112-7bdf5e0d-5e9d-4905-b407-ab9fe1d4aea2.mp4

After:

https://user-images.githubusercontent.com/55295613/223222224-55d18aca-5504-4c57-bbcd-186a13be7ec0.mp4

**If relevant, did you update the documentation?**

N/A

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes