### PR TITLE
Update TextEditing Controller for handling hashtags while making post

### DIFF
--- a/lib/view_model/after_auth_view_models/add_post_view_models/add_post_view_model.dart
+++ b/lib/view_model/after_auth_view_models/add_post_view_models/add_post_view_model.dart
@@ -12,6 +12,7 @@ import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/third_party_service/multi_media_pick_service.dart';
 import 'package:talawa/services/user_config.dart';
 import 'package:talawa/view_model/base_view_model.dart';
+import 'package:talawa/widgets/post_text_field.dart';
 
 /// AddPostViewModel class have different functions that are used
 /// to interact with the model to add a new post in the organization.
@@ -24,13 +25,17 @@ class AddPostViewModel extends BaseModel {
   late File? _imageFile;
   late User _currentUser;
   late OrgInfo _selectedOrg;
-  final TextEditingController _controller = TextEditingController();
+  final PostTextController _controller = PostTextController();
+  final List<String> _fetchedhashtags = [];
+  late bool _showHashtagList;
 
   // Getters
   File? get imageFile => _imageFile;
   String get userName => _currentUser.firstName! + _currentUser.lastName!;
   String get orgName => _selectedOrg.name!;
-  TextEditingController get controller => _controller;
+  PostTextController get controller => _controller;
+  List<String> get fetchedhashtags => [..._fetchedhashtags];
+  bool get showHashtagList => _showHashtagList;
 
   // initialisation
   void initialise() {
@@ -39,6 +44,7 @@ class AddPostViewModel extends BaseModel {
     _selectedOrg = locator<UserConfig>().currentOrg;
     _imageFile = null;
     _multiMediaPickerService = locator<MultiMediaPickerService>();
+    _showHashtagList = false;
   }
 
   /// This function is used to get the image from gallery.
@@ -68,6 +74,102 @@ class AddPostViewModel extends BaseModel {
   /// This function removes the image selected.
   void removeImage() {
     _imageFile = null;
+    notifyListeners();
+  }
+
+  /// This function will return the start and end index of the current tag where the pointer/
+  /// cursor is currently placed
+  MapEntry<int, int> _getCurrentString() {
+    final text = _controller.text;
+    final cursorPosition = _controller.selection;
+    final cursorIndex = cursorPosition.baseOffset - 1;
+
+    int left = 0;
+    int right = 0;
+
+    int temp = cursorIndex;
+    while (temp > 0) {
+      if (text[temp] == ' ' || text[temp] == '\n') {
+        left = temp + 1;
+        break;
+      }
+      temp--;
+    }
+    if (temp == 0) {
+      left = 0;
+    }
+    temp = cursorIndex;
+
+    while (temp < text.length) {
+      if (text[temp] == ' ' || text[temp] == '\n') {
+        right = temp;
+        break;
+      }
+      temp++;
+    }
+    if (temp == text.length) {
+      right = text.length;
+    }
+    return MapEntry(left, right);
+  }
+
+  /// This function is used to fetch the hashtags from server based on the prefix.
+  /// params:
+  /// * [prefix] : prefix of the hashtags
+  List<String> _fetchTags(String prefix) {
+    // function that will make a request for trending tags and add it to provide user
+    return [];
+  }
+
+  /// This function is used to add the tag in the post(textField) on tapping the one of the tag from suggestions
+  /// and is responsible to reposition the cursor at the end of the string
+  /// params:
+  /// * [tag] : String value of the tag
+  void onTagClick(String tag) {
+    final list = _controller.text.split(' ');
+
+    final vals = _getCurrentString();
+    final currString = _controller.text.substring(vals.key, vals.value);
+
+    final index = list.indexOf(currString);
+
+    if (index != -1) {
+      list[index] = "#$tag";
+    } else {
+      list.add("#$tag");
+    }
+
+    _controller.text = list.join(' ');
+
+    _controller.selection = TextSelection.fromPosition(
+      TextPosition(
+        offset:
+            (index == -1) ? _controller.text.length : vals.key + tag.length + 1,
+      ),
+    );
+
+    _showHashtagList = false;
+
+    notifyListeners();
+  }
+
+  /// This function is responsible to detect weather the tag is being added to the string currently
+  /// and is responsible to reposition the cursor at the end of the string
+  void handleTextChange(_) {
+    final vals = _getCurrentString();
+    final currText = _controller.text.substring(vals.key, vals.value);
+
+    if (currText == '#' || currText.startsWith('#')) {
+      _fetchedhashtags.clear();
+      if (currText.length > 1) {
+        print("In here");
+        _fetchedhashtags.addAll(_fetchTags(currText.substring(1)));
+      }
+      _showHashtagList = true;
+    } else {
+      _showHashtagList = false;
+    }
+
     notifyListeners();
   }
 }

--- a/lib/views/after_auth_screens/add_post_page.dart
+++ b/lib/views/after_auth_screens/add_post_page.dart
@@ -106,6 +106,7 @@ class AddPost extends StatelessWidget {
                 child: TextField(
                   controller: model.controller,
                   maxLines: null,
+                  onChanged: model.handleTextChange,
                   // input field to write the description of the post.
                   decoration: InputDecoration(
                     border: InputBorder.none,
@@ -119,6 +120,21 @@ class AddPost extends StatelessWidget {
                   ),
                 ),
               ),
+              if (model.showHashtagList)
+                SizedBox(
+                  height: 200,
+                  child: ListView(
+                    children: List.generate(
+                      model.fetchedhashtags.length,
+                      (index) => ListTile(
+                        title: Text("#${model.fetchedhashtags[index]}"),
+                        onTap: () => model.onTagClick(
+                          model.fetchedhashtags[index],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
               // if the image for the post is added then render button to remove it.
               model.imageFile != null
                   // ignore: sized_box_for_whitespace

--- a/lib/views/after_auth_screens/add_post_page.dart
+++ b/lib/views/after_auth_screens/add_post_page.dart
@@ -89,15 +89,6 @@ class AddPost extends StatelessWidget {
                     onPressed: () {},
                     icon: const Icon(Icons.file_upload),
                   ),
-                  // button to add hastags to the post.
-                  TextButton(
-                    key: const Key('add_post_text_btn2'),
-                    onPressed: () {},
-                    child: Text(
-                      '# ${AppLocalizations.of(context)!.strictTranslate("Add hashtag")}',
-                      style: Theme.of(context).textTheme.titleLarge,
-                    ),
-                  ),
                 ],
               ),
               const Divider(),

--- a/lib/widgets/post_text_field.dart
+++ b/lib/widgets/post_text_field.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+/// PostTextController is customized to highlight the the tags that are present in the text.
+class PostTextController extends TextEditingController {
+  PostTextController({
+    String? text,
+  }) : super(text: text);
+
+  /// Setting this will notify all the listeners of this [TextEditingController]
+  /// that they need to update (it calls [notifyListeners]).
+  @override
+  set text(String newText) {
+    value = value.copyWith(
+      text: newText,
+      selection: const TextSelection.collapsed(offset: -1),
+      composing: TextRange.empty,
+    );
+  }
+
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    final List<TextSpan> children = [];
+    final matches = <String>{};
+    final List<Map<String, List<int>>> matchIndex = [];
+    final RegExp allRegex = RegExp(r"\B#[a-zA-Z0-9]+\b");
+
+    text.splitMapJoin(
+      allRegex,
+      onNonMatch: (String span) {
+        children.add(TextSpan(text: span, style: style));
+        return span;
+      },
+      onMatch: (Match m) {
+        matches.add(m[0]!);
+
+        children.add(
+          TextSpan(
+            text: m[0],
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.secondary,
+            ),
+          ),
+        );
+
+        final resultMatchIndex = matchValueIndex(m);
+        if (resultMatchIndex != null) {
+          matchIndex.add(resultMatchIndex);
+        }
+
+        return '';
+      },
+    );
+
+    return TextSpan(style: style, children: children);
+  }
+
+  Map<String, List<int>>? matchValueIndex(Match match) {
+    final matchValue = match[0]?.replaceFirstMapped('#', (match) => '');
+    if (matchValue != null) {
+      final firstMatchChar = match.start + 1;
+      final lastMatchChar = match.end - 1;
+      final compactMatch = {
+        matchValue: [firstMatchChar, lastMatchChar]
+      };
+      return compactMatch;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION


**What kind of change does this PR introduce?**
Feature 
Made adding hashtags in post easier, rather than having to add the hashtags separetely, user can now add them in the post as well, just by adding "#" followed by the keyword, just like twitter/linkedIn.

**Issue Number:**

Fixes #1583 <!--Add related issue number here.-->

**Did you add tests for your changes?**

No

**Snapshots/Videos:**
[Checkout this video](https://drive.google.com/file/d/12Z0LMAcutjvQGVN5ABPKk-iQSVPpft1Y/view?usp=share_link)

**Summary**

Initially there was a seperate Add Hashtag button in the Add Post screen, users needed to add the hashtags to the post seperately, but with these changes and updated TextEditingContoller users can add the hashtags in the body of the post itself. Users can also get the suggestion of the hashtags based on the prefix they have already added.

**Does this PR introduce a breaking change?**
No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes 
