### PR TITLE
FixMultipleHerosWithSameTagBug

### DIFF
--- a/lib/views/after_auth_screens/events/explore_events.dart
+++ b/lib/views/after_auth_screens/events/explore_events.dart
@@ -211,6 +211,7 @@ class ExploreEvents extends StatelessWidget {
                 ),
           floatingActionButton: FloatingActionButton.extended(
             key: homeModel?.keySEAdd,
+            heroTag: "AddEventFab",
             backgroundColor: Theme.of(context).colorScheme.background,
             onPressed: () {
               navigationService.pushScreen(


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

`bugfix
`
**Issue Number:#1663**

**Did you add tests for your changes?**

I have tested the application manually after adding the `heroTag` attribute

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
no, i have just added a missing attribute to a widget

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This error was appearing in the debug console, everyone working on this project was wondering about the cause of this bug, on the technical side you mustn't have many **floating action buttons** with the same  hero tag, which will make the flutter not able to identify the FAB buttons, its like the `global keys` for widgets .
**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
no breaking change.

