### PR TITLE
Fix Exception occurred while cropping Image Bug

### DIFF
--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: talawa_api_doc
 // ignore_for_file: talawa_good_doc_comments
 // ignore_for_file: talawa_lint_rules
+// ignore_for_file: talawa_lint
 
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -2,7 +2,6 @@
 // ignore_for_file: talawa_good_doc_comments
 // ignore_for_file: talawa_lint_rules
 
-
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)
 Service usage: "add_post_view_model.dart"

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -79,6 +79,7 @@ class MultiMediaPickerService {
     }
     return null;
   }
+
   /// This function is used to crop an image using the ImageCropper library.
   ///
   /// params:

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: talawa_good_doc_comments
+
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)
 Service usage: "add_post_view_model.dart"

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -65,7 +65,7 @@ class MultiMediaPickerService {
             dialogTitle: 'Permission Denied',
             successText: 'SETTINGS',
             dialogSubTitle:
-            "Camera permission is required, to use this feature, give permission from app settings",
+                "Camera permission is required, to use this feature, give permission from app settings",
           ),
         );
       }

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: talawa_good_doc_comments
+// ignore_for_file: talawa_api_doc
 
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: talawa_api_doc
 // ignore_for_file: talawa_good_doc_comments
-// ignore_for_file: talawa_lint_rules
 
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -81,7 +81,7 @@ class MultiMediaPickerService {
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {
-      final CroppedFile? croppedImage = await ImageCropper().cropImage(
+      final File? croppedImage = await ImageCropper().cropImage(
         sourcePath: imageFile.path,
         aspectRatioPresets: [
           CropAspectRatioPreset.square,
@@ -101,7 +101,7 @@ class MultiMediaPickerService {
             minimumAspectRatio: 1.0,
           )
         ],
-      );
+      ) as File?;
       if (croppedImage != null) {
         return File(croppedImage.path);
       }

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_good_doc_comments
-// ignore_for_file: talawa_api_doc
-
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)
 Service usage: "add_post_view_model.dart"
@@ -31,23 +28,23 @@ class MultiMediaPickerService {
     _fileStream = _fileStreamController.stream.asBroadcastStream();
   }
 
-  //Local Variables
+  // Local Variables
   final StreamController<File> _fileStreamController = StreamController();
   late Stream<File> _fileStream;
   late ImagePicker _picker;
 
-  //Getters
-  Stream get fileStream => _fileStream;
+  // Getters
+  Stream<File> get fileStream => _fileStream;
 
   /// This function is used to pick the image from gallery or to click the image from user's camera.
   ///
   /// The function first asks for the permission to access the camera. If denied, it shows a custom dialog box.
   ///
   /// params:
-  /// * 'camera' : boolean value to check if the user has selected from camera or gallery
+  /// * `camera`: boolean value to check if the user has selected from camera or gallery
   ///
   /// returns:
-  /// * 'Future<File?>': image file
+  /// * `Future<File?>`: image file
   Future<File?> getPhotoFromGallery({bool camera = false}) async {
     // asking for user's camera access permission.
     try {
@@ -72,12 +69,12 @@ class MultiMediaPickerService {
             dialogTitle: 'Permission Denied',
             successText: 'SETTINGS',
             dialogSubTitle:
-                "Camera permission is required, to use this feature, give permission from app settings",
+                'Camera permission is required, to use this feature, give permission from app settings',
           ),
         );
       }
       print(
-        "MultiMediaPickerService : Exception occurred while choosing photo from the gallery $e",
+        'MultiMediaPickerService: Exception occurred while choosing photo from the gallery $e',
       );
     }
     return null;
@@ -86,14 +83,14 @@ class MultiMediaPickerService {
   /// This function is used to crop an image using the ImageCropper library.
   ///
   /// params:
-  /// * 'imageFile' : a required File object representing the image to be cropped.
+  /// * `imageFile`: a required File object representing the image to be cropped.
   ///
   /// returns:
-  /// * 'Future<File?>': a File object with the cropped image path, or null if an exception occurs.
+  /// * `Future<File?>`: a File object with the cropped image path, or null if an exception occurs.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {
-      final CroppedFile? image = await ImageCropper().cropImage(
+      final CroppedFile? croppedImage = await ImageCropper().cropImage(
         sourcePath: imageFile.path,
         aspectRatioPresets: [
           CropAspectRatioPreset.square,
@@ -114,8 +111,8 @@ class MultiMediaPickerService {
           )
         ],
       );
-      if (image != null) {
-        return File(image.path);
+      if (croppedImage != null) {
+        return File(croppedImage.path);
       }
     } catch (e) {
       print(

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -81,7 +81,7 @@ class MultiMediaPickerService {
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {
-      final File? croppedImage = await ImageCropper().cropImage(
+      final CroppedFile? croppedImage = await ImageCropper().cropImage(
         sourcePath: imageFile.path,
         aspectRatioPresets: [
           CropAspectRatioPreset.square,
@@ -101,7 +101,7 @@ class MultiMediaPickerService {
             minimumAspectRatio: 1.0,
           )
         ],
-      ) as File?;
+      );
       if (croppedImage != null) {
         return File(croppedImage.path);
       }

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,11 +1,6 @@
 // ignore_for_file: talawa_api_doc
 // ignore_for_file: talawa_good_doc_comments
 
-/* This is an abstraction service for picking up Photos/videos
-Library used: image_picker (https://pub.dev/packages/image_picker)
-Service usage: "add_post_view_model.dart"
-*/
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,5 +1,12 @@
 // ignore_for_file: talawa_api_doc
 // ignore_for_file: talawa_good_doc_comments
+// ignore_for_file: talawa_lint_rules
+
+
+/* This is an abstraction service for picking up Photos/videos
+Library used: image_picker (https://pub.dev/packages/image_picker)
+Service usage: "add_post_view_model.dart"
+*/
 
 import 'dart:async';
 import 'dart:io';

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: talawa_api_doc
 // ignore_for_file: talawa_good_doc_comments
+// ignore_for_file: talawa_lint_rules
 
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -77,7 +77,7 @@ class MultiMediaPickerService {
   }
 
   /// This function is used to crop the image selected by the user.
-  /// The function accepts a `File` type image and returns `File` type of cropped image.
+  /// The function accepts a `File` type image and returns `CroppedFile` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -81,7 +81,7 @@ class MultiMediaPickerService {
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {
-      final CroppedFile? croppedImage = await ImageCropper().cropImage(
+      final CroppedFile? image = await ImageCropper().cropImage(
         sourcePath: imageFile.path,
         aspectRatioPresets: [
           CropAspectRatioPreset.square,
@@ -102,8 +102,8 @@ class MultiMediaPickerService {
           )
         ],
       );
-      if (croppedImage != null) {
-        return File(croppedImage.path);
+      if (image != null) {
+        return File(image.path);
       }
     } catch (e) {
       print(

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -77,11 +77,11 @@ class MultiMediaPickerService {
   }
 
   /// This function is used to crop the image selected by the user.
-  /// The function accepts a `File` type image and returns `CroppedFile` type of cropped image.
+  /// The function accepts a `File` type image and returns `File` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {
-      final CroppedFile? croppedImage = await ImageCropper().cropImage(
+      final File? croppedImage = await ImageCropper().cropImage(
         sourcePath: imageFile.path,
         aspectRatioPresets: [
           CropAspectRatioPreset.square,
@@ -101,7 +101,7 @@ class MultiMediaPickerService {
             minimumAspectRatio: 1.0,
           )
         ],
-      ) as CroppedFile;
+      ) as File?;
       if (croppedImage != null) {
         return File(croppedImage.path);
       }

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -101,7 +101,7 @@ class MultiMediaPickerService {
             minimumAspectRatio: 1.0,
           )
         ],
-      );
+      ) as CroppedFile;
       if (croppedImage != null) {
         return File(croppedImage.path);
       }

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -77,7 +77,7 @@ class MultiMediaPickerService {
   }
 
   /// This function is used to crop the image selected by the user.
-  /// The function accepts a `File` type image and returns `File` type of cropped image.
+  /// The function accepts a `CroppedFile` type image and returns `CroppedFile` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)
 Service usage: "add_post_view_model.dart"
@@ -18,7 +15,8 @@ import 'package:talawa/locator.dart';
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/widgets/custom_alert_dialog.dart';
 
-/// This is a third party service which provide the service to select the image from
+/// This is a third party service which provide the service to select the image from.
+///
 /// gallery and then image can be cropped as well.
 ///
 /// Services include:
@@ -39,8 +37,14 @@ class MultiMediaPickerService {
   Stream get fileStream => _fileStream;
 
   /// This function is used to pick the image from gallery or to click the image from user's camera.
-  /// The function first ask for the permission to access the camera, if denied then returns a message in
-  /// custom Dialog Box. This function returns a File type for which `camera` variable is false by default.
+  ///
+  /// The function first asks for the permission to access the camera. If denied, it shows a custom dialog box.
+  ///
+  /// params:
+  /// * 'camera' : boolean value to check if the user has selected from camera or gallery
+  ///
+  /// returns:
+  /// * 'Future<File?>': image file
   Future<File?> getPhotoFromGallery({bool camera = false}) async {
     // asking for user's camera access permission.
     try {
@@ -75,9 +79,13 @@ class MultiMediaPickerService {
     }
     return null;
   }
-
-  /// This function is used to crop the image selected by the user.
-  /// The function accepts a `File` type image and returns `File` type of cropped image.
+  /// This function is used to crop an image using the ImageCropper library.
+  ///
+  /// params:
+  /// * 'imageFile' : a required File object representing the image to be cropped.
+  ///
+  /// returns:
+  /// * 'Future<File?>': a File object with the cropped image path, or null if an exception occurs.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -77,7 +77,7 @@ class MultiMediaPickerService {
   }
 
   /// This function is used to crop the image selected by the user.
-  /// The function accepts a `File` type image and returns `CroppedFile` type of cropped image.
+  /// This function accepts a `File` type image and returns `File` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -18,8 +18,7 @@ import 'package:talawa/locator.dart';
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/widgets/custom_alert_dialog.dart';
 
-/// This is a third party service which provide the service to select the image from.
-///
+/// This is a third party service which provide the service to select the image from
 /// gallery and then image can be cropped as well.
 ///
 /// Services include:
@@ -40,15 +39,8 @@ class MultiMediaPickerService {
   Stream get fileStream => _fileStream;
 
   /// This function is used to pick the image from gallery or to click the image from user's camera.
-  ///
   /// The function first ask for the permission to access the camera, if denied then returns a message in
   /// custom Dialog Box. This function returns a File type for which `camera` variable is false by default.
-  ///
-  /// params:
-  /// * 'camera' : boolean value to decide if to open camera or gallery
-  ///
-  /// returns:
-  /// * 'File': the imageFile after(selecting & cropping)
   Future<File?> getPhotoFromGallery({bool camera = false}) async {
     // asking for user's camera access permission.
     try {
@@ -73,7 +65,7 @@ class MultiMediaPickerService {
             dialogTitle: 'Permission Denied',
             successText: 'SETTINGS',
             dialogSubTitle:
-                "Camera permission is required, to use this feature, give permission from app settings",
+            "Camera permission is required, to use this feature, give permission from app settings",
           ),
         );
       }
@@ -84,15 +76,8 @@ class MultiMediaPickerService {
     return null;
   }
 
-  /// This function is used to crop the image selected by the user and it returns File.
-  ///
+  /// This function is used to crop the image selected by the user.
   /// The function accepts a `File` type image and returns `File` type of cropped image.
-  ///
-  /// params:
-  /// * 'imageFile' : the file to crop
-  ///
-  /// returns:
-  /// * 'File': the image file to view after cropping
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -65,7 +65,7 @@ class MultiMediaPickerService {
             dialogTitle: 'Permission Denied',
             successText: 'SETTINGS',
             dialogSubTitle:
-                "Camera permission is required, to use this feature, give permission from app settings",
+            "Camera permission is required, to use this feature, give permission from app settings",
           ),
         );
       }
@@ -77,7 +77,7 @@ class MultiMediaPickerService {
   }
 
   /// This function is used to crop the image selected by the user.
-  /// This function accepts a `File` type image and returns `File` type of cropped image.
+  /// The function accepts a `File` type image and returns `File` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: talawa_api_doc
 // ignore_for_file: talawa_good_doc_comments
-// ignore_for_file: talawa_lint_rules
-// ignore_for_file: talawa_lint
 
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -77,7 +77,7 @@ class MultiMediaPickerService {
   }
 
   /// This function is used to crop the image selected by the user.
-  /// The function accepts a `CroppedFile` type image and returns `CroppedFile` type of cropped image.
+  /// The function accepts a `File` type image and returns `File` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -18,7 +18,8 @@ import 'package:talawa/locator.dart';
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/widgets/custom_alert_dialog.dart';
 
-/// This is a third party service which provide the service to select the image from
+/// This is a third party service which provide the service to select the image from.
+///
 /// gallery and then image can be cropped as well.
 ///
 /// Services include:
@@ -39,6 +40,12 @@ class MultiMediaPickerService {
   Stream get fileStream => _fileStream;
 
   /// This function is used to pick the image from gallery or to click the image from user's camera.
+  ///
+  /// params:
+  /// * 'camera' : boolean value to decide if to open camera or gallery
+  ///
+  /// returns:
+  /// * 'File': the imageFile after(selecting & cropping)
   /// The function first ask for the permission to access the camera, if denied then returns a message in
   /// custom Dialog Box. This function returns a File type for which `camera` variable is false by default.
   Future<File?> getPhotoFromGallery({bool camera = false}) async {
@@ -76,7 +83,13 @@ class MultiMediaPickerService {
     return null;
   }
 
-  /// This function is used to crop the image selected by the user.
+  /// This function is used to crop the image selected by the user and it returns File.
+  ///
+  /// params:
+  /// * 'imageFile' : the file to crop
+  ///
+  /// returns:
+  /// * 'File': the image file to view after cropping
   /// The function accepts a `File` type image and returns `File` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.

--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -41,13 +41,14 @@ class MultiMediaPickerService {
 
   /// This function is used to pick the image from gallery or to click the image from user's camera.
   ///
+  /// The function first ask for the permission to access the camera, if denied then returns a message in
+  /// custom Dialog Box. This function returns a File type for which `camera` variable is false by default.
+  ///
   /// params:
   /// * 'camera' : boolean value to decide if to open camera or gallery
   ///
   /// returns:
   /// * 'File': the imageFile after(selecting & cropping)
-  /// The function first ask for the permission to access the camera, if denied then returns a message in
-  /// custom Dialog Box. This function returns a File type for which `camera` variable is false by default.
   Future<File?> getPhotoFromGallery({bool camera = false}) async {
     // asking for user's camera access permission.
     try {
@@ -85,12 +86,13 @@ class MultiMediaPickerService {
 
   /// This function is used to crop the image selected by the user and it returns File.
   ///
+  /// The function accepts a `File` type image and returns `File` type of cropped image.
+  ///
   /// params:
   /// * 'imageFile' : the file to crop
   ///
   /// returns:
   /// * 'File': the image file to view after cropping
-  /// The function accepts a `File` type image and returns `File` type of cropped image.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {

--- a/lib/views/after_auth_screens/events/explore_events.dart
+++ b/lib/views/after_auth_screens/events/explore_events.dart
@@ -211,6 +211,7 @@ class ExploreEvents extends StatelessWidget {
                 ),
           floatingActionButton: FloatingActionButton.extended(
             key: homeModel?.keySEAdd,
+            heroTag: "AddEventFab",
             backgroundColor: Theme.of(context).colorScheme.background,
             onPressed: () {
               navigationService.pushScreen(


### PR DESCRIPTION

**What kind of change does this PR introduce?**
  `bugfix `

**Issue Number:**

Fixes: #1681 ,#1569

**Did you add tests for your changes?**
Tested manually, there is no  big change.


**Snapshots/Videos:**
i will post an image of the path of the file returned after the `cropImage` function completes , **another image of me & my friends to prove that #1569 was solved  too.**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
no

<!--Add link to Talawa-Docs.-->

**Summary**

**Explain the **motivation** for making this change. What existing problem does the pull request solve?** 

The bug was preventing the user from uploading images with his posts, now after the change the user is able to interact with community and upload images with his/her posts make them more interactive and intresting.
The upload image is a feature which is well documented in the Talawa docs, with this change we will make our source code meet the docs at the point of `uploading images with posts`
**Does this PR introduce a breaking change?**
No.

**what was causing the BUG**
The `cropImage` Function was returning the image after the crop operation ends as a `File` and that is wrong cause it will damage the encoding of the image with respect to the cropImageFunction which should return `CroopedFile` not `File`.

**FUN FACT**
issue #1569 which is labeled as a `featureRequest` was already implemented in the code base, but other developers think its not there because there was no image previewing, but the real problem was with encoding of the file returned.

![1](https://user-images.githubusercontent.com/79102102/226210395-0546fff4-28e9-4e78-8823-79ae57af1077.png)
![WhatsApp Image 2023-03-19 at 11 17 13 PM](https://user-images.githubusercontent.com/79102102/226210397-20f360cd-921d-4926-a762-9bf84109a307.jpeg)


 



