### PR TITLE
Fix Exception occurred while cropping Image Bug

### DIFF
--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -33,7 +33,15 @@ class MultiMediaPickerService {
   late Stream<File> _fileStream;
   late ImagePicker _picker;
 
-  // Getters
+// Getters
+  /// Returns the stream of the file.
+  ///
+  /// params:
+  /// None
+  ///
+  /// returns:
+  /// * `Stream<File>`: A stream of file objects.
+  ///
   Stream<File> get fileStream => _fileStream;
 
   /// This function is used to pick the image from gallery or to click the image from user's camera.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  `bugfix `

**Issue Number:**

Fixes: #1681 ,#1569
This PR Closes #1681,#1569

**Did you add tests for your changes?**
Tested manually, there is no  big change.


**Snapshots/Videos:**
i will post an image of the path of the file returned after the `cropImage` function completes , **another image  to prove that #1569 was solved  too.**


**If relevant, did you update the documentation?**
no

<!--Add link to Talawa-Docs.-->

**Summary**

**Explain the **motivation** for making this change. What existing problem does the pull request solve?** 

The bug was preventing the user from uploading images with his posts, now after the change the user is able to interact with community and upload images with his/her posts make them more interactive and intresting.
The upload image is a feature which is well documented in the Talawa docs, with this change we will make our source code meet the docs at the point of `uploading images with posts`
**Does this PR introduce a breaking change?**
No.

**what was causing the BUG**
The `cropImage` Function was returning the image after the crop operation ends as a `File` and that is wrong cause it will damage the encoding of the image with respect to the cropImageFunction which should return `CroopedFile` not `File`.

![WhatsApp Image 2023-03-20 at 12 31 18 PM](https://user-images.githubusercontent.com/79102102/226314446-00bab3a8-f610-4bda-8dc0-e871d133b533.jpeg)
![1](https://user-images.githubusercontent.com/79102102/226210395-0546fff4-28e9-4e78-8823-79ae57af1077.png)


**FUN FACT**
issue #1569 which is labeled as a `featureRequest` was already implemented in the code base, but other developers think its not there because there was no image previewing, but the real problem was with encoding of the file returned.


 


 



