### PR TITLE
FixImageCroppingBug

### DIFF
--- a/lib/services/third_party_service/multi_media_pick_service.dart
+++ b/lib/services/third_party_service/multi_media_pick_service.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 /* This is an abstraction service for picking up Photos/videos
 Library used: image_picker (https://pub.dev/packages/image_picker)
 Service usage: "add_post_view_model.dart"
@@ -18,7 +15,8 @@ import 'package:talawa/locator.dart';
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/widgets/custom_alert_dialog.dart';
 
-/// This is a third party service which provide the service to select the image from
+/// This is a third party service which provide the service to select the image from.
+///
 /// gallery and then image can be cropped as well.
 ///
 /// Services include:
@@ -30,17 +28,31 @@ class MultiMediaPickerService {
     _fileStream = _fileStreamController.stream.asBroadcastStream();
   }
 
-  //Local Variables
+  // Local Variables
   final StreamController<File> _fileStreamController = StreamController();
   late Stream<File> _fileStream;
   late ImagePicker _picker;
 
-  //Getters
-  Stream get fileStream => _fileStream;
+// Getters
+  /// Returns the stream of the file.
+  ///
+  /// params:
+  /// None
+  ///
+  /// returns:
+  /// * `Stream<File>`: A stream of file objects.
+  ///
+  Stream<File> get fileStream => _fileStream;
 
   /// This function is used to pick the image from gallery or to click the image from user's camera.
-  /// The function first ask for the permission to access the camera, if denied then returns a message in
-  /// custom Dialog Box. This function returns a File type for which `camera` variable is false by default.
+  ///
+  /// The function first asks for the permission to access the camera. If denied, it shows a custom dialog box.
+  ///
+  /// params:
+  /// * `camera`: boolean value to check if the user has selected from camera or gallery
+  ///
+  /// returns:
+  /// * `Future<File?>`: image file
   Future<File?> getPhotoFromGallery({bool camera = false}) async {
     // asking for user's camera access permission.
     try {
@@ -65,23 +77,28 @@ class MultiMediaPickerService {
             dialogTitle: 'Permission Denied',
             successText: 'SETTINGS',
             dialogSubTitle:
-                "Camera permission is required, to use this feature, give permission from app settings",
+                'Camera permission is required, to use this feature, give permission from app settings',
           ),
         );
       }
       print(
-        "MultiMediaPickerService : Exception occurred while choosing photo from the gallery $e",
+        'MultiMediaPickerService: Exception occurred while choosing photo from the gallery $e',
       );
     }
     return null;
   }
 
-  /// This function is used to crop the image selected by the user.
-  /// The function accepts a `File` type image and returns `File` type of cropped image.
+  /// This function is used to crop an image using the ImageCropper library.
+  ///
+  /// params:
+  /// * `imageFile`: a required File object representing the image to be cropped.
+  ///
+  /// returns:
+  /// * `Future<File?>`: a File object with the cropped image path, or null if an exception occurs.
   Future<File?> cropImage({required File imageFile}) async {
     // try, to crop the image and returns a File with cropped image path.
     try {
-      final File? croppedImage = await ImageCropper().cropImage(
+      final CroppedFile? croppedImage = await ImageCropper().cropImage(
         sourcePath: imageFile.path,
         aspectRatioPresets: [
           CropAspectRatioPreset.square,
@@ -101,7 +118,7 @@ class MultiMediaPickerService {
             minimumAspectRatio: 1.0,
           )
         ],
-      ) as File?;
+      );
       if (croppedImage != null) {
         return File(croppedImage.path);
       }

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -861,10 +861,10 @@ class MockPostService extends _i2.Mock implements _i14.PostService {
 class MockMultiMediaPickerService extends _i2.Mock
     implements _i16.MultiMediaPickerService {
   @override
-  _i4.Stream<dynamic> get fileStream => (super.noSuchMethod(
+  _i4.Stream<_i17.File> get fileStream => (super.noSuchMethod(
         Invocation.getter(#fileStream),
-        returnValue: _i4.Stream<dynamic>.empty(),
-      ) as _i4.Stream<dynamic>);
+        returnValue: _i4.Stream<_i17.File>.empty(),
+      ) as _i4.Stream<_i17.File>);
   @override
   _i4.Future<_i17.File?> getPhotoFromGallery({bool? camera = false}) =>
       (super.noSuchMethod(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  `bugfix `

**Issue Number:**

Fixes: #1681 ,#1569
This PR Closes #1681,#1569

**Did you add tests for your changes?**
Tested manually, there is no  big change.


**Snapshots/Videos:**
i will post an image of the path of the file returned after the `cropImage` function completes , **another image  to prove that #1569 was solved  too.**


**If relevant, did you update the documentation?**
no

<!--Add link to Talawa-Docs.-->

**Summary**

**Explain the **motivation** for making this change. What existing problem does the pull request solve?** 

The bug was preventing the user from uploading images with his posts, now after the change the user is able to interact with community and upload images with his/her posts make them more interactive and intresting.
The upload image is a feature which is well documented in the Talawa docs, with this change we will make our source code meet the docs at the point of `uploading images with posts`
**Does this PR introduce a breaking change?**
No.

**what was causing the BUG**
The `cropImage` Function was returning the image after the crop operation ends as a `File` and that is wrong cause it will damage the encoding of the image with respect to the cropImageFunction which should return `CroopedFile` not `File`.

![WhatsApp Image 2023-03-20 at 12 31 18 PM](https://user-images.githubusercontent.com/79102102/226314446-00bab3a8-f610-4bda-8dc0-e871d133b533.jpeg)
![1](https://user-images.githubusercontent.com/79102102/226210395-0546fff4-28e9-4e78-8823-79ae57af1077.png)


**FUN FACT**
issue #1569 which is labeled as a `featureRequest` was already implemented in the code base, but other developers think its not there because there was no image previewing, but the real problem was with encoding of the file returned.


 


 



