### PR TITLE
chore: Manual bump video_player to 2.6.0 closes #1712

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1677,10 +1677,10 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "58dc3d6ceb199b82e652ec27f16485e33167ef021fe4221a954ff1aa12b1a5c0"
+      sha256: "868a139229acb5018d22aded3eb9cb4767ff43a8216573c086b6c535a4957481"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.6.0"
   video_player_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,7 @@ dependencies:
   tutorial_coach_mark: ^1.2.6
   uni_links: ^0.5.1
   vibration: ^1.7.6
-  video_player: ^2.5.3
+  video_player: ^2.6.0
   visibility_detector: ^0.4.0+2
 
 


### PR DESCRIPTION


**What kind of change does this PR introduce?**

package update

**Issue Number:**

Fixes #1712 

**Did you add tests for your changes?**

NO

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

NO
Summary

updated package

Does this PR introduce a breaking change?

No
Other information

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?
Yes