### PR TITLE
chores: Manual Bump shared_preferences to 2.0.20 closes #1714

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1289,10 +1289,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: ee6257848f822b8481691f20c3e6d2bfee2e9eccb2a3d249907fcfb198c55b41
+      sha256: "78528fd87d0d08ffd3e69551173c026e8eacc7b7079c82eb6a77413957b7e394"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.18"
+    version: "2.0.20"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   qr_code_scanner: ^1.0.0
   qr_flutter: ^4.0.0
   quick_actions: ^1.0.1
-  shared_preferences: ^2.0.17
+  shared_preferences: ^2.0.20
   shimmer: ^2.0.0
   social_share: ^2.2.1
   syncfusion_flutter_calendar: ^20.4.54


### PR DESCRIPTION
What kind of change does this PR introduce?

Chores: Dependency updates

Fixes https://github.com/PalisadoesFoundation/talawa/issues/1714

Did you add tests for your changes?

NO

Snapshots/Videos:

N/A

If relevant, did you update the documentation?

NO

Summary

updated package

Does this PR introduce a breaking change?

No
Other information

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?
Yes