### PR TITLE
chrore: Bump image_cropper from 3.0.1 to 3.0.2 closes  #1725

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -793,10 +793,10 @@ packages:
     dependency: "direct main"
     description:
       name: image_cropper
-      sha256: "85324928ee8a8be35a529446435ca53067865b9353c8681983472eeec66d780f"
+      sha256: e08311fcf0cdba367715a5036aec8d8e9b3ab84479909dc2156dd5bf872edefb
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   image_cropper_for_web:
     dependency: transitive
     description:
@@ -1677,10 +1677,10 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "58dc3d6ceb199b82e652ec27f16485e33167ef021fe4221a954ff1aa12b1a5c0"
+      sha256: "868a139229acb5018d22aded3eb9cb4767ff43a8216573c086b6c535a4957481"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.6.0"
   video_player_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   graphql_flutter: ^5.1.2
   hive: ^2.2.3
   http: ^0.13.3
-  image_cropper: ^3.0.1
+  image_cropper: ^3.0.2
   image_picker: ^0.8.7
   intl: ^0.17.0
   json_annotation: ^4.7.0
@@ -72,7 +72,7 @@ dependencies:
   tutorial_coach_mark: ^1.2.6
   uni_links: ^0.5.1
   vibration: ^1.7.6
-  video_player: ^2.5.3
+  video_player: ^2.6.0
   visibility_detector: ^0.4.0+2
 
 


### PR DESCRIPTION
What kind of change does this PR introduce?

Chores: Dependency updates

Fixes https://github.com/PalisadoesFoundation/talawa/issues/1725

Did you add tests for your changes?

NO

Snapshots/Videos:

N/A

If relevant, did you update the documentation?

NO

Summary

updated package

Does this PR introduce a breaking change?

No
Other information

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?
Yes