### PR TITLE
implement quick_fix for talawa_good_doc and enforce tab before None of params block

### DIFF
--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -78,7 +78,7 @@ final imagePicker = locator<ImagePicker>();
 /// This function registers the widgets/objects in "GetIt".
 ///
 /// **params**:
-///  None
+///   None
 ///
 /// **returns**:
 ///   None

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,7 +73,7 @@ late FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
 /// First function to initialize the application, invoked automatically.
 ///
 /// **params**:
-/// None
+///   None
 ///
 /// **returns**:
 /// * `Future<void>`: resolves if the application was successfully initialized.
@@ -201,7 +201,7 @@ class _MyAppState extends State<MyApp> {
   /// It allows to manage and interact with the application’s home screen quick actions.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None
@@ -333,7 +333,7 @@ class DemoViewModel extends BaseModel {
 /// Set up firebase instance, enbables messaging,listens to icoming messages.
 ///
 /// **params**:
-/// None
+///   None
 ///
 /// **returns**:
 /// * `Future<void>`: promise that will be fulfilled Firebase is setted up.

--- a/lib/models/post/post_model.dart
+++ b/lib/models/post/post_model.dart
@@ -78,7 +78,7 @@ class Post {
   /// this is to get duration of post.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `String`: date is returned in ago form.
@@ -117,7 +117,7 @@ class LikedBy {
   /// Convert dart object to json.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `Map<String, dynamic>`: json is returned.
@@ -151,7 +151,7 @@ class Comments {
   /// Convert dart object to json.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `Map<String, dynamic>`: json is returned.

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -51,7 +51,7 @@ class EventService {
   /// This function is used to set stream subscription for an organization.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None
@@ -65,7 +65,7 @@ class EventService {
   /// This function is used to fetch all the events of an organization.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `Future<void>`: void
@@ -184,7 +184,7 @@ class EventService {
   /// This function is used to cancel the stream subscription of an organization.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None

--- a/lib/utils/post_queries.dart
+++ b/lib/utils/post_queries.dart
@@ -43,7 +43,7 @@ class PostQueries {
   /// Add Like to a post.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `String`: The query related to addingLike
@@ -61,7 +61,7 @@ class PostQueries {
   /// Remove Like from a post.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `String`: The query related to removingLike
@@ -82,7 +82,7 @@ class PostQueries {
   /// Upload a post to database.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `String`: The query related to uploadingPost.

--- a/lib/view_model/after_auth_view_models/add_post_view_models/add_post_view_model.dart
+++ b/lib/view_model/after_auth_view_models/add_post_view_models/add_post_view_model.dart
@@ -72,7 +72,7 @@ class AddPostViewModel extends BaseModel {
   /// This function is usedto do initialisation of stuff in the view model.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None
@@ -110,7 +110,7 @@ class AddPostViewModel extends BaseModel {
   /// This function uploads the post finally, and navigate the success message or error message in Snack Bar.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `Future<void>`: Uploading post by contacting queries
@@ -146,7 +146,7 @@ class AddPostViewModel extends BaseModel {
   /// This function removes the image selected.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None

--- a/lib/view_model/after_auth_view_models/event_view_models/create_event_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/create_event_view_model.dart
@@ -116,7 +116,7 @@ class CreateEventViewModel extends BaseModel {
   /// Function To Initialize.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None
@@ -134,7 +134,7 @@ class CreateEventViewModel extends BaseModel {
   /// for creating an event and passes the required variables for the event.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `Future<void>`: Asynchronous function for creating event
@@ -224,7 +224,7 @@ class CreateEventViewModel extends BaseModel {
   /// This function remove the selected image.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None
@@ -236,7 +236,7 @@ class CreateEventViewModel extends BaseModel {
   /// This function fetch all the users in the current organization and return `List`.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   /// * `Future<List<User>>`: Current Organization Users List
@@ -258,7 +258,7 @@ class CreateEventViewModel extends BaseModel {
   /// This function build the user list.
   ///
   /// **params**:
-  /// None
+  ///   None
   ///
   /// **returns**:
   ///   None

--- a/talawa_lint/lib/helpers.dart
+++ b/talawa_lint/lib/helpers.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/syntactic_entity.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -138,3 +139,27 @@ bool isMethod(ClassMember m) => m is MethodDeclaration;
 bool isPrivate(Token? name) =>
     // ignore: avoid_bool_literals_in_conditional_expressions
     name != null ? Identifier.isPrivateName(name.lexeme) : false;
+
+class TalawaLintHelpers {
+  static bool isVoid(Declaration node) {
+    return ((node is FunctionDeclaration)
+            ? node.returnType?.type!.isVoid
+            : (node as MethodDeclaration).returnType?.type!.isVoid) ??
+        true;
+  }
+
+  static bool isImplicitReturn(Declaration node) {
+    return ((node is FunctionDeclaration)
+            ? node.declaredElement?.hasImplicitReturnType
+            : (node as MethodDeclaration)
+                .declaredElement
+                ?.hasImplicitReturnType) ??
+        false;
+  }
+
+  static DartType? returnType(Declaration node) {
+    return (node is FunctionDeclaration)
+        ? node.returnType?.type
+        : (node as MethodDeclaration).returnType?.type;
+  }
+}

--- a/talawa_lint/lib/talawa_api_doc/talawa_api_doc.dart
+++ b/talawa_lint/lib/talawa_api_doc/talawa_api_doc.dart
@@ -1,0 +1,76 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:talawa_lint/talawa_api_doc/talawa_api_doc_fixer.dart';
+import 'package:talawa_lint/talawa_api_doc/talawa_api_doc_visitor.dart';
+
+class TalawaApiDocLintRule extends DartLintRule {
+  const TalawaApiDocLintRule() : super(code: _code);
+
+  /// Metadata about the warning that will show-up in the IDE.
+  /// This is used for `// ignore: code` and enabling/disabling the lint
+  static const _code = LintCode(
+    name: 'talawa_api_doc',
+    problemMessage: 'Prefer documentation for fields.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    final visitor = TalawaApiDocVisitor(
+      this,
+      context,
+      reporter,
+    );
+
+    context.registry.addClassDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addClassTypeAlias(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addCompilationUnit(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addConstructorDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addEnumConstantDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addEnumDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addExtensionDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addFieldDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addFunctionDeclaration(
+      (node) => visitor.check(node),
+    );
+    context.registry.addFunctionTypeAlias(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addGenericTypeAlias(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addMixinDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addVariableDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addTopLevelVariableDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+  }
+
+  @override
+  List<Fix> getFixes() => [
+        TalawaAPIDocFixer(),
+      ];
+}

--- a/talawa_lint/lib/talawa_api_doc/talawa_api_doc.dart
+++ b/talawa_lint/lib/talawa_api_doc/talawa_api_doc.dart
@@ -10,7 +10,9 @@ class TalawaApiDocLintRule extends DartLintRule {
   /// This is used for `// ignore: code` and enabling/disabling the lint
   static const _code = LintCode(
     name: 'talawa_api_doc',
-    problemMessage: 'Prefer documentation for fields.',
+    problemMessage: 'No documentation found for this field.',
+    correctionMessage: "Add a valid documentation describing usecase.",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   @override

--- a/talawa_lint/lib/talawa_api_doc/talawa_api_doc_fixer.dart
+++ b/talawa_lint/lib/talawa_api_doc/talawa_api_doc_fixer.dart
@@ -1,0 +1,185 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/source/source_range.dart';
+import 'package:analyzer_plugin/utilities/change_builder/change_builder_dart.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:talawa_lint/helpers.dart';
+
+class TalawaAPIDocFixer extends DartFix {
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
+  ) {
+    context.registry.addVariableDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addClassDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addClassTypeAlias(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addConstructorDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addEnumConstantDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addEnumDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addExtensionDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addFieldDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addFunctionDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addMethodDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addFunctionTypeAlias(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addGenericTypeAlias(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addMixinDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+    context.registry.addTopLevelVariableDeclaration(
+      (node) => fix(node, reporter, analysisError),
+    );
+  }
+
+  void fix(
+    Declaration node,
+    ChangeReporter reporter,
+    AnalysisError analysisError,
+  ) {
+    // Verifying that the node and error offset match (collide)
+
+    if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+
+    // The [SourceRange] of the ClassDeclaration spans to the whole class
+    // and will intersect with everything inside it. This is a problem, as the
+    // error for it's fields will match to itself, and the fixes will be applied
+    // to the wrong place.
+
+    if (node is ClassDeclaration &&
+        !analysisError.sourceRange.intersects(
+          SourceRange(
+            node.offset,
+            node.leftBracket.offset - node.offset,
+          ),
+        )) return;
+
+    // The same issue exists for Functions and Methods. We can define functions
+    // inside functions, and the same overlap of [SourceRange] occurs due to that
+
+    if (node is FunctionDeclaration &&
+        !analysisError.sourceRange.intersects(
+          SourceRange(
+            node.offset,
+            (node.functionExpression.parameters?.end ??
+                    node.name.length + node.name.offset) -
+                node.offset,
+          ),
+        )) return;
+
+    if (node is MethodDeclaration &&
+        !analysisError.sourceRange.intersects(
+          SourceRange(
+            node.offset,
+            (node.parameters?.offset ?? node.name.length + node.name.offset) -
+                node.offset,
+          ),
+        )) return;
+
+    final changeBuilder = reporter.createChangeBuilder(
+      message: 'Insert Doc skeleton',
+      priority: 3,
+    );
+
+    changeBuilder.addDartFileEdit((builder) {
+      builder.addInsertion(node.offset, (builder) {
+        builder.write(
+          "/// a_line_ending_with_end_punctuation.\n"
+          "/// \n"
+          "/// more_info_if_required\n",
+        );
+
+        if (node is FunctionDeclaration || node is MethodDeclaration) {
+          fixFun(
+            node,
+            builder,
+          );
+        }
+      });
+    });
+  }
+
+  void fixFun(
+    Declaration node,
+    DartEditBuilder builder,
+  ) {
+    // Putting in these obvious checks because in the edge case when someone
+    // mistakenly calls this function on non-function type entities, the linter
+    // will simply crash without any plausible explanation.
+
+    if (!(node is FunctionDeclaration || node is MethodDeclaration)) {
+      return;
+    }
+
+    if (node is MethodDeclaration && (node.isGetter || node.isSetter)) {
+      return;
+    }
+
+    final fnInfo = StringBuffer();
+
+    fnInfo.write(
+      "/// \n"
+      "/// **params**:\n",
+    );
+
+    final paramList = (node is FunctionDeclaration)
+        ? (node.functionExpression.parameters)?.parameters
+        : (node as MethodDeclaration).parameters?.parameters;
+
+    if (paramList == null || paramList.isEmpty) {
+      fnInfo.write("///   None\n");
+    } else {
+      for (final param in paramList) {
+        fnInfo.write("/// * `${param.name}`: define_the_param\n");
+      }
+    }
+
+    fnInfo.write(
+      "/// \n"
+      "/// **returns**:\n",
+    );
+
+    final isImplicitReturn = TalawaLintHelpers.isImplicitReturn(node);
+    final isVoid = TalawaLintHelpers.isVoid(node);
+
+    final returnType = (node is FunctionDeclaration)
+        ? node.returnType
+        : (node as MethodDeclaration).returnType;
+
+    if (isImplicitReturn || returnType == null) {
+      fnInfo.write("/// * `undef`: type_the_return\n");
+    } else if (isVoid) {
+      fnInfo.write("///   None\n");
+    } else {
+      fnInfo.write("/// * `$returnType`: define_the_return\n");
+    }
+
+    builder.write(fnInfo.toString());
+  }
+}

--- a/talawa_lint/lib/talawa_api_doc/talawa_api_doc_visitor.dart
+++ b/talawa_lint/lib/talawa_api_doc/talawa_api_doc_visitor.dart
@@ -5,72 +5,8 @@ import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:talawa_lint/helpers.dart';
 
-class TalawaApiDocLintRule extends DartLintRule {
-  const TalawaApiDocLintRule() : super(code: _code);
-
-  /// Metadata about the warning that will show-up in the IDE.
-  /// This is used for `// ignore: code` and enabling/disabling the lint
-  static const _code = LintCode(
-    name: 'talawa_api_doc',
-    problemMessage: 'Prefer documentation for fields.',
-  );
-
-  @override
-  void run(
-    CustomLintResolver resolver,
-    ErrorReporter reporter,
-    CustomLintContext context,
-  ) {
-    final visitor = _Visitor(
-      this,
-      context,
-      reporter,
-    );
-
-    context.registry.addClassDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addClassTypeAlias(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addCompilationUnit(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addConstructorDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addEnumConstantDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addEnumDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addExtensionDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addFieldDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addFunctionDeclaration(
-      (node) => visitor.check(node),
-    );
-    context.registry.addFunctionTypeAlias(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addGenericTypeAlias(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addMixinDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addTopLevelVariableDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-  }
-}
-
-class _Visitor extends SimpleAstVisitor {
-  _Visitor(
+class TalawaApiDocVisitor extends SimpleAstVisitor {
+  TalawaApiDocVisitor(
     this.rule,
     this.context,
     this.reporter,
@@ -91,13 +27,16 @@ class _Visitor extends SimpleAstVisitor {
         !isOverridingMember(node) &&
         !extendsState) {
       final errorNode = getNodeToAnnotate(node);
+
       reporter.reportErrorForOffset(
         rule.code,
         errorNode.offset,
         errorNode.length,
       );
+
       return true;
     }
+
     return false;
   }
 

--- a/talawa_lint/lib/talawa_good_doc/talawa_good_doc.dart
+++ b/talawa_lint/lib/talawa_good_doc/talawa_good_doc.dart
@@ -9,8 +9,10 @@ class TalawaGoodDocComments extends DartLintRule {
   /// This is used for `// ignore: code` and enabling/disabling the lint
   static const _code = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong comment format.\n'
+    problemMessage: 'Wrong comment format.',
+    correctionMessage:
         'Use "/// ..." for public api and "// ..." for other cases.',
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   @override

--- a/talawa_lint/lib/talawa_good_doc/talawa_good_doc.dart
+++ b/talawa_lint/lib/talawa_good_doc/talawa_good_doc.dart
@@ -1,0 +1,71 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:talawa_lint/talawa_good_doc/talawa_good_doc_visitor.dart';
+
+class TalawaGoodDocComments extends DartLintRule {
+  const TalawaGoodDocComments() : super(code: _code);
+
+  /// Metadata about the warning that will show-up in the IDE.
+  /// This is used for `// ignore: code` and enabling/disabling the lint
+  static const _code = LintCode(
+    name: 'talawa_good_doc_comments',
+    problemMessage: 'Wrong comment format.\n'
+        'Use "/// ..." for public api and "// ..." for other cases.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    final visitor = TalawaGoodDocVisitor(
+      this,
+      context,
+      reporter,
+    );
+
+    context.registry.addClassDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addClassTypeAlias(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addCompilationUnit(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addConstructorDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addEnumConstantDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addEnumDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addExtensionDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addFieldDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addFunctionDeclaration(
+      visitor.check,
+    );
+    context.registry.addFunctionTypeAlias(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addGenericTypeAlias(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addMixinDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addTopLevelVariableDeclaration(
+      (node) => node.visitChildren(visitor),
+    );
+    context.registry.addComment(
+      (node) => node.visitChildren(visitor),
+    );
+  }
+}

--- a/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
+++ b/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
@@ -8,76 +8,8 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:talawa_lint/helpers.dart';
 import 'package:talawa_lint/talawa_lint_rules.dart';
 
-class TalawaGoodDocComments extends DartLintRule {
-  const TalawaGoodDocComments() : super(code: _code);
-
-  /// Metadata about the warning that will show-up in the IDE.
-  /// This is used for `// ignore: code` and enabling/disabling the lint
-  static const _code = LintCode(
-    name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong comment format.\n'
-        'Use "/// ..." for public api and "// ..." for other cases.',
-  );
-
-  @override
-  void run(
-    CustomLintResolver resolver,
-    ErrorReporter reporter,
-    CustomLintContext context,
-  ) {
-    final visitor = _Visitor(
-      this,
-      context,
-      reporter,
-    );
-
-    context.registry.addClassDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addClassTypeAlias(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addCompilationUnit(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addConstructorDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addEnumConstantDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addEnumDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addExtensionDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addFieldDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addFunctionDeclaration(
-      visitor.check,
-    );
-    context.registry.addFunctionTypeAlias(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addGenericTypeAlias(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addMixinDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addTopLevelVariableDeclaration(
-      (node) => node.visitChildren(visitor),
-    );
-    context.registry.addComment(
-      (node) => node.visitChildren(visitor),
-    );
-  }
-}
-
-class _Visitor extends SimpleAstVisitor {
-  _Visitor(
+class TalawaGoodDocVisitor extends SimpleAstVisitor {
+  TalawaGoodDocVisitor(
     this.rule,
     this.context,
     this.reporter,
@@ -101,8 +33,6 @@ class _Visitor extends SimpleAstVisitor {
   void visitCompilationUnit(CompilationUnit node) {
     final getters = <String, FunctionDeclaration>{};
     final setters = <FunctionDeclaration>[];
-
-    // Check functions.
 
     // Non-getters/setters.
     final functions = <FunctionDeclaration>[];
@@ -207,18 +137,18 @@ class _Visitor extends SimpleAstVisitor {
       return false;
     }
 
-    // Don't check for [setters] and [getters]
-
-    if (node is MethodDeclaration && (node.isGetter || node.isSetter)) {
-      return true;
-    }
-
     final doc = node.documentationComment!.tokens;
     if (!doc[0].lexeme.endsWith('.')) {
       reporter.reportErrorForToken(
         TalawaGoodDocLintRules.firstLineEndCode,
         doc[0],
       );
+    }
+
+    // Don't check for [setters] and [getters]
+    // TODO: Fix this completely
+    if (node is MethodDeclaration && (node.isGetter || node.isSetter)) {
+      return true;
     }
 
     if (doc.length == 1) {
@@ -294,9 +224,24 @@ class _Visitor extends SimpleAstVisitor {
       return false;
     }
 
+    final paramList = params?.parameterElements ?? [];
+
+    if (paramList.isEmpty) {
+      if (currentDocLine == doc.length) {
+        return false;
+      } else if (doc[currentDocLine].lexeme != "///   None") {
+        reporter.reportErrorForToken(
+          TalawaGoodDocLintRules.noParamNone,
+          doc[currentDocLine],
+        );
+        return false;
+      }
+
+      return true;
+    }
+
     // The currentParam we are checking for
     int currentParam = 0;
-    final paramList = params?.parameterElements ?? [];
 
     for (; currentDocLine < doc.length; currentDocLine++) {
       final line = doc[currentDocLine];
@@ -346,6 +291,10 @@ class _Visitor extends SimpleAstVisitor {
     List<Token> doc,
     Declaration rawNode,
   ) {
+    // Let the implicit_return_type warning be fixed first
+
+    if (TalawaLintHelpers.isImplicitReturn(rawNode)) return;
+
     int currentDocLine = 0;
     bool containsReturn = false;
 
@@ -353,7 +302,7 @@ class _Visitor extends SimpleAstVisitor {
         rawNode is FunctionDeclaration ? rawNode : rawNode as MethodDeclaration;
 
     for (; currentDocLine < doc.length; currentDocLine++) {
-      if (doc[currentDocLine].lexeme.startsWith('/// **returns**:')) {
+      if (doc[currentDocLine].lexeme.trim() == '/// **returns**:') {
         containsReturn = true;
         break;
       }
@@ -370,15 +319,7 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    bool isVoid = false;
-
-    if (node is FunctionDeclaration) {
-      final nodeReturnTypeLocal = node.returnType;
-      isVoid = nodeReturnTypeLocal?.type!.isVoid == true;
-    } else if (node is MethodDeclaration) {
-      final nodeReturnTypeLocal = node.returnType;
-      isVoid = nodeReturnTypeLocal?.type!.isVoid == true;
-    }
+    final isVoid = TalawaLintHelpers.isVoid(node);
 
     if (!containsReturn && !isVoid) {
       reporter.reportErrorForNode(
@@ -389,19 +330,12 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    if (isVoid && currentDocLine == doc.length) return;
+    // Uncomment below line if returns block is made optional for
+    // void types someday :)
 
-    // if (node.returnType!.type!.isVoid &&
-    //     doc[currentDocLine].lexeme != '/// returns: None') {
-    //   reporter.reportErrorForNode(
-    //     _wrongReturnsDoc,
-    //     node.documentationComment!,
-    //   );
+    // if (isVoid && currentDocLine == doc.length) return;
 
-    //   return;
-    // }
-
-    if (doc[currentDocLine].lexeme != '/// **returns**:') {
+    if (doc[currentDocLine].lexeme.trim() != '/// **returns**:') {
       reporter.reportErrorForNode(
         TalawaGoodDocLintRules.wrongReturnsDoc,
         node.documentationComment!,
@@ -440,16 +374,7 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    // ignore: prefer_typing_uninitialized_variables
-    late final returnType;
-
-    if (node is FunctionDeclaration) {
-      final nodeReturnTypeLocal = node.returnType;
-      returnType = nodeReturnTypeLocal?.type;
-    } else if (node is MethodDeclaration) {
-      final nodeReturnTypeLocal = node.returnType;
-      returnType = nodeReturnTypeLocal?.type;
-    }
+    final returnType = TalawaLintHelpers.returnType(node);
 
     // If return type is not [void] and doc doesn't end with [return_type] or
     // there are more lines to the doc

--- a/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
+++ b/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
@@ -387,7 +387,7 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
               returnTypeDocPattern.pattern,
             )) {
       reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.noEndWithNoneForVoid,
+        TalawaGoodDocLintRules.wrongReturnsDoc,
         node.documentationComment!,
       );
 

--- a/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
+++ b/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
@@ -308,22 +308,22 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
       }
     }
 
-    // Check if there is atleast one blank line above
+    final isVoid = TalawaLintHelpers.isVoid(node);
 
-    if (doc[currentDocLine - 1].lexeme.trim() != '///') {
+    if (!containsReturn) {
       reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.noBlankLineBWParamAndReturn,
+        TalawaGoodDocLintRules.doesNotContainReturn,
         node.documentationComment!,
       );
 
       return;
     }
 
-    final isVoid = TalawaLintHelpers.isVoid(node);
+    // Check if there is atleast one blank line above
 
-    if (!containsReturn && !isVoid) {
+    if (doc[currentDocLine - 1].lexeme.trim() != '///') {
       reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.doesNotContainReturn,
+        TalawaGoodDocLintRules.noBlankLineBWParamAndReturn,
         node.documentationComment!,
       );
 

--- a/talawa_lint/lib/talawa_lint.dart
+++ b/talawa_lint/lib/talawa_lint.dart
@@ -1,7 +1,7 @@
 // This is the entrypoint of our custom linter
 import 'package:custom_lint_builder/custom_lint_builder.dart';
-import 'package:talawa_lint/talawa_api_doc.dart';
-import 'package:talawa_lint/talawa_good_doc.dart';
+import 'package:talawa_lint/talawa_api_doc/talawa_api_doc.dart';
+import 'package:talawa_lint/talawa_good_doc/talawa_good_doc.dart';
 
 PluginBase createPlugin() => _ExampleLinter();
 

--- a/talawa_lint/lib/talawa_lint_rules.dart
+++ b/talawa_lint/lib/talawa_lint_rules.dart
@@ -5,50 +5,58 @@ class TalawaAPIDocLintRules {}
 class TalawaGoodDocLintRules {
   static const firstLineEndCode = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
-        "End first line of documentation with '.', '!' etc",
+    problemMessage: 'Wrong doc format.',
+    correctionMessage: "End first line of documentation with '.', '!' etc",
   );
 
   static const secondLineEmptyCode = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
+    problemMessage: 'Wrong doc format.',
+    correctionMessage:
         "Second line should be left empty to improve readability",
   );
 
   static const includeParamsKeywordCode = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
-        "Include `**params**:` keyword in function/method doc",
+    problemMessage: 'Wrong doc format.',
+    correctionMessage: "Include `**params**:` keyword in function/method doc",
+  );
+
+  static const noParamNone = LintCode(
+    name: 'talawa_good_doc_comments',
+    problemMessage: 'Wrong doc format.',
+    correctionMessage: "Empty param list should be documented as `///   None`",
   );
 
   static const startShouldFollowParam = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
-        "* should follow a param name",
+    problemMessage: 'Wrong doc format.',
+    correctionMessage: "* should follow a param name",
   );
 
   static const emptyParamDoc = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
-        "Param name should follow its documentation",
+    problemMessage: 'Wrong doc format.',
+    correctionMessage: "Param name should follow its documentation",
   );
 
   static const allParamsNotDocumented = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
-        "Some parameters are missing documentation",
+    problemMessage: 'Wrong doc format.',
+    correctionMessage: "Some parameters are missing documentation",
   );
 
   static const noBlankLineBWParamAndReturn = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
-        "Add a blank line between the end of 'params:' block\n"
+    problemMessage: 'Wrong doc format.',
+    correctionMessage: "Add a blank line between the end of 'params:' block\n"
         "and start of 'returns:' block.",
   );
 
   static const doesNotContainReturn = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
+    problemMessage: 'Wrong doc format.',
+    correctionMessage:
         "Documentation does not contain information about the return type,\n"
         "even though it is not `void`\n"
         "Add '**returns**:' block followed by the return doc.",
@@ -56,7 +64,8 @@ class TalawaGoodDocLintRules {
 
   static const wrongReturnsDoc = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
+    problemMessage: 'Wrong doc format.',
+    correctionMessage:
         "Documentation format of return type is in wrong format.\n"
         "For void type - '/// **returns**: \n///   None'\n"
         "For other types - '/// **returns**:' followed by types in new lines",
@@ -64,14 +73,16 @@ class TalawaGoodDocLintRules {
 
   static const noReturnDoc = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
+    problemMessage: 'Wrong doc format.',
+    correctionMessage:
         "'**returns**:' should immediately be followed by documentation about\n"
         "the return type",
   );
 
   static const noEndWithNoneForVoid = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.\n'
+    problemMessage: 'Wrong doc format.',
+    correctionMessage:
         "A function/method with [void] return type must end with\n"
         "`///   None`\n"
         "without extra lines.",

--- a/talawa_lint/lib/talawa_lint_rules.dart
+++ b/talawa_lint/lib/talawa_lint_rules.dart
@@ -8,6 +8,7 @@ class TalawaGoodDocLintRules {
     problemMessage:
         "First line of the documentation doesn't end with end punctuation.",
     correctionMessage: "End first line of documentation with '.', '!' etc",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const secondLineEmptyCode = LintCode(
@@ -15,18 +16,21 @@ class TalawaGoodDocLintRules {
     problemMessage: 'Second line of the doc is not empty.',
     correctionMessage:
         "Second line should be left empty to improve readability",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const includeParamsKeywordCode = LintCode(
     name: 'talawa_good_doc_comments',
     problemMessage: 'params block not found in the documentation.',
     correctionMessage: "Include `**params**:` keyword in function/method doc",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const noParamNone = LintCode(
     name: 'talawa_good_doc_comments',
     problemMessage: 'Wrong doc format.',
     correctionMessage: "Empty param list should be documented as `///   None`",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const startShouldFollowParam = LintCode(
@@ -34,12 +38,14 @@ class TalawaGoodDocLintRules {
     problemMessage: '* should follow a param name',
     correctionMessage: "Make sure you have added a param name after *, and it\n"
         "is in the same order as it appears in the function",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const emptyParamDoc = LintCode(
     name: 'talawa_good_doc_comments',
     problemMessage: 'No documentation is written for this parameter',
     correctionMessage: "Param name should follow its documentation",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const allParamsNotDocumented = LintCode(
@@ -47,6 +53,7 @@ class TalawaGoodDocLintRules {
     problemMessage: 'Some parameters are missing documentation',
     correctionMessage: "Please make sure that you have documented all\n"
         "of the parameters in the same order as they appear in the function.",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const noBlankLineBWParamAndReturn = LintCode(
@@ -54,6 +61,7 @@ class TalawaGoodDocLintRules {
     problemMessage: 'Wrong doc format.',
     correctionMessage: "Add a blank line between the end of 'params:' block\n"
         "and start of 'returns:' block.",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const doesNotContainReturn = LintCode(
@@ -62,6 +70,7 @@ class TalawaGoodDocLintRules {
     correctionMessage:
         "Documentation does not contain information about the return type.\n"
         "Add '**returns**:' block followed by the return doc.",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const wrongReturnsDoc = LintCode(
@@ -74,6 +83,7 @@ class TalawaGoodDocLintRules {
         "For other types - \n"
         "/// **returns**: \n"
         "/// * `return_type`: documentation of the return type.",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const noReturnDoc = LintCode(
@@ -82,6 +92,7 @@ class TalawaGoodDocLintRules {
     correctionMessage:
         "'**returns**:' should immediately be followed by documentation about\n"
         "the return type",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 
   static const noEndWithNoneForVoid = LintCode(
@@ -91,5 +102,6 @@ class TalawaGoodDocLintRules {
         "A function/method with [void] return type must end with\n"
         "`///   None`\n"
         "without extra lines.",
+    url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
   );
 }

--- a/talawa_lint/lib/talawa_lint_rules.dart
+++ b/talawa_lint/lib/talawa_lint_rules.dart
@@ -5,20 +5,21 @@ class TalawaAPIDocLintRules {}
 class TalawaGoodDocLintRules {
   static const firstLineEndCode = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.',
+    problemMessage:
+        "First line of the documentation doesn't end with end punctuation.",
     correctionMessage: "End first line of documentation with '.', '!' etc",
   );
 
   static const secondLineEmptyCode = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.',
+    problemMessage: 'Second line of the doc is not empty.',
     correctionMessage:
         "Second line should be left empty to improve readability",
   );
 
   static const includeParamsKeywordCode = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.',
+    problemMessage: 'params block not found in the documentation.',
     correctionMessage: "Include `**params**:` keyword in function/method doc",
   );
 
@@ -30,20 +31,23 @@ class TalawaGoodDocLintRules {
 
   static const startShouldFollowParam = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.',
-    correctionMessage: "* should follow a param name",
+    problemMessage: '* should follow a param name',
+    correctionMessage:
+        "Make sure you have added a param name after *, and it\n"
+        "is in the same order as it appears in the function",
   );
 
   static const emptyParamDoc = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.',
+    problemMessage: 'No documentation is written for this parameter',
     correctionMessage: "Param name should follow its documentation",
   );
 
   static const allParamsNotDocumented = LintCode(
     name: 'talawa_good_doc_comments',
-    problemMessage: 'Wrong doc format.',
-    correctionMessage: "Some parameters are missing documentation",
+    problemMessage: 'Some parameters are missing documentation',
+    correctionMessage: "Please make sure that you have documented all\n"
+        "of the parameters in the same order as they appear in the function.",
   );
 
   static const noBlankLineBWParamAndReturn = LintCode(

--- a/talawa_lint/lib/talawa_lint_rules.dart
+++ b/talawa_lint/lib/talawa_lint_rules.dart
@@ -57,8 +57,7 @@ class TalawaGoodDocLintRules {
     name: 'talawa_good_doc_comments',
     problemMessage: 'Wrong doc format.',
     correctionMessage:
-        "Documentation does not contain information about the return type,\n"
-        "even though it is not `void`\n"
+        "Documentation does not contain information about the return type.\n"
         "Add '**returns**:' block followed by the return doc.",
   );
 
@@ -68,7 +67,7 @@ class TalawaGoodDocLintRules {
     correctionMessage:
         "Documentation format of return type is in wrong format.\n"
         "For void type - '/// **returns**: \n///   None'\n"
-        "For other types - '/// **returns**:' followed by types in new lines",
+        "For other types - '/// **returns**:' followed by type in new lines",
   );
 
   static const noReturnDoc = LintCode(

--- a/talawa_lint/lib/talawa_lint_rules.dart
+++ b/talawa_lint/lib/talawa_lint_rules.dart
@@ -66,8 +66,11 @@ class TalawaGoodDocLintRules {
     problemMessage: 'Wrong doc format.',
     correctionMessage:
         "Documentation format of return type is in wrong format.\n"
-        "For void type - '/// **returns**: \n///   None'\n"
-        "For other types - '/// **returns**:' followed by type in new lines",
+        "For void type - \n"
+        "/// **returns**: \n///   None\n"
+        "For other types - \n"
+        "/// **returns**: \n"
+        "/// * `return_type`: documentation of the return type.",
   );
 
   static const noReturnDoc = LintCode(

--- a/talawa_lint/lib/talawa_lint_rules.dart
+++ b/talawa_lint/lib/talawa_lint_rules.dart
@@ -32,8 +32,7 @@ class TalawaGoodDocLintRules {
   static const startShouldFollowParam = LintCode(
     name: 'talawa_good_doc_comments',
     problemMessage: '* should follow a param name',
-    correctionMessage:
-        "Make sure you have added a param name after *, and it\n"
+    correctionMessage: "Make sure you have added a param name after *, and it\n"
         "is in the same order as it appears in the function",
   );
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

1. Adds quick_fix feature for the `talawa_api_doc` custom lint rule. Now a template can be inserted with a few clicks to document the code easily.
2. Enforces a `tab` space before the `None` of empty param list.
3. Adds URL to `Talawa Docs` in the error message itself.

**Issue Number:**

Part of: #1646 

**Snapshots/Videos:**

https://user-images.githubusercontent.com/62198564/230409919-8f9c1ee2-a34b-4a01-9f1d-3bdff6736a4e.mp4

