### PR TITLE
Scrolling Functionality for Event Details Page

### DIFF
--- a/lib/views/after_auth_screens/events/event_info_body.dart
+++ b/lib/views/after_auth_screens/events/event_info_body.dart
@@ -255,7 +255,6 @@ class EventInfoBody extends StatelessWidget {
               //then renders all the attendees in ListView.
               ListView.builder(
                 padding: EdgeInsets.zero,
-                physics: const NeverScrollableScrollPhysics(),
                 shrinkWrap: true,
                 itemCount: model.registrants.length,
                 itemBuilder: (BuildContext context, int index) {

--- a/lib/views/after_auth_screens/events/event_info_body.dart
+++ b/lib/views/after_auth_screens/events/event_info_body.dart
@@ -221,17 +221,12 @@ class EventInfoBody extends StatelessWidget {
             SizedBox(
               height: SizeConfig.screenHeight! * 0.013,
             ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  AppLocalizations.of(context)!.strictTranslate("Attendees"),
-                  style: Theme.of(context)
-                      .textTheme
-                      .headlineSmall!
-                      .copyWith(fontSize: 16),
-                ),
-              ],
+            Text(
+              AppLocalizations.of(context)!.strictTranslate("Attendees"),
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall!
+                  .copyWith(fontSize: 16),
             ),
             Divider(
               color: Theme.of(context).colorScheme.onBackground,

--- a/lib/views/after_auth_screens/events/event_info_body.dart
+++ b/lib/views/after_auth_screens/events/event_info_body.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:talawa/constants/routing_constants.dart';

--- a/lib/views/after_auth_screens/events/event_info_body.dart
+++ b/lib/views/after_auth_screens/events/event_info_body.dart
@@ -231,13 +231,6 @@ class EventInfoBody extends StatelessWidget {
                       .headlineSmall!
                       .copyWith(fontSize: 16),
                 ),
-                Text(
-                  AppLocalizations.of(context)!.strictTranslate('See all'),
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodySmall!
-                      .copyWith(color: const Color(0xff4285F4)),
-                ),
               ],
             ),
             Divider(


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR will allow the users to scroll through the event details page. Previously, there was no scrolling functionality for event details page but now the "see all" option has been removed and user can see all the attendees by scrolling down.

**Issue Number:**

Fixes #1601 

**Snapshots/Videos:**

![image](https://user-images.githubusercontent.com/75278584/230715245-f0561c00-2b06-47c3-af28-28ffbb48fc14.png)

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes