### PR TITLE
ignoring the `avoid_dynamic_call_check` in the related files

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -78,5 +78,5 @@ linter:
     # MyObj obj = json_data['obj'] as MyObj;
     # ```
     
-    avoid_dynamic_calls: false
+    avoid_dynamic_calls: true
     

--- a/lib/models/post/post_model.dart
+++ b/lib/models/post/post_model.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_dynamic_calls
+
 import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/models/user/user_info.dart';
 

--- a/lib/plugins/talawa_plugin_provider.dart
+++ b/lib/plugins/talawa_plugin_provider.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'dart:async';

--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:talawa/locator.dart';

--- a/lib/services/database_mutation_functions.dart
+++ b/lib/services/database_mutation_functions.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'dart:async';

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_dynamic_calls
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/lib/services/org_service.dart
+++ b/lib/services/org_service.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:talawa/locator.dart';

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'dart:async';

--- a/lib/services/task_service.dart
+++ b/lib/services/task_service.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/painting.dart';

--- a/lib/services/user_config.dart
+++ b/lib/services/user_config.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'dart:async';

--- a/lib/view_model/after_auth_view_models/profile_view_models/profile_page_view_model.dart
+++ b/lib/view_model/after_auth_view_models/profile_view_models/profile_page_view_model.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:currency_picker/currency_picker.dart';

--- a/lib/view_model/main_screen_view_model.dart
+++ b/lib/view_model/main_screen_view_model.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/foundation.dart';

--- a/lib/view_model/pre_auth_view_models/login_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/login_view_model.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:firebase_messaging/firebase_messaging.dart';

--- a/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/cupertino.dart';

--- a/lib/view_model/pre_auth_view_models/signup_details_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/signup_details_view_model.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/lib/widgets/custom_alert_dialog.dart
+++ b/lib/widgets/custom_alert_dialog.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/lib/widgets/custom_list_tile.dart
+++ b/lib/widgets/custom_list_tile.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/lib/widgets/event_date_time_tile.dart
+++ b/lib/widgets/event_date_time_tile.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/lib/widgets/invite_child.dart
+++ b/lib/widgets/invite_child.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/lib/widgets/member_name_tile.dart
+++ b/lib/widgets/member_name_tile.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/lib/widgets/pinned_carousel_widget.dart
+++ b/lib/widgets/pinned_carousel_widget.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter/material.dart';

--- a/test/helpers/setup_firebase_mocks.dart
+++ b/test/helpers/setup_firebase_mocks.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 // ignore_for_file: return_of_invalid_type

--- a/test/view_model_tests/after_auth_view_model_tests/organization_feed_view_model_test.dart
+++ b/test/view_model_tests/after_auth_view_model_tests/organization_feed_view_model_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: talawa_api_doc
+// ignore_for_file: talawa_api_doc, avoid_dynamic_calls
 // ignore_for_file: talawa_good_doc_comments
 
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Issue Number:**

Corresponds to #1770 

**Did you add tests for your changes?**

NA

**Snapshots/Videos:**

NA

**If relevant, did you update the documentation?**

NA

**Summary**

To solve the #1721 issue in a systematic manner, we need to turn off the lining rules temporarily for the related files. Issue #1770 has been created to keep track of this change and to revert it back to normal once #1721  has been completely fixed.

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes
