### PR TITLE
Use new env secrets in push workflow to make docs work again.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -79,6 +79,7 @@ jobs:
 
   Update-Documentation:
     runs-on: ubuntu-latest
+    environment: docs
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -131,10 +132,10 @@ jobs:
           #echo -e "🚀${Green} Hurrah! doc updated${NoColor}"
       - uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          API_TOKEN_GITHUB: ${{ secrets.TALAWA_DOCS_SYNC }}
         with:
           source_file: 'docs/talawa/'
-          destination_repo: 'PalisadoesFoundation/talawa-docs'
+          destination_repo: 'literalEval/talawa-docs'
           destination_branch: 'develop'
           destination_folder: 'static/talawa'
           user_email: '${{env.email}}'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -79,7 +79,7 @@ jobs:
 
   Update-Documentation:
     runs-on: ubuntu-latest
-    environment: docs
+    environment: TALAWA_ENVIRONMENT
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -135,7 +135,7 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.TALAWA_DOCS_SYNC }}
         with:
           source_file: 'docs/talawa/'
-          destination_repo: 'literalEval/talawa-docs'
+          destination_repo: 'PalisadoesFoundation/talawa-docs'
           destination_branch: 'develop'
           destination_folder: 'static/talawa'
           user_email: '${{env.email}}'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Uses newly generated env secrets in order to make automatic docs updation in `Talawa Docs` work again.

**Issue Number:**

Fixes #1768 
