### PR TITLE
Marks message field as nodoc

### DIFF
--- a/lib/views/after_auth_screens/chat/widgets/chat_message_bubble.dart
+++ b/lib/views/after_auth_screens/chat/widgets/chat_message_bubble.dart
@@ -10,7 +10,9 @@ import 'package:talawa/services/size_config.dart';
 class Message extends StatelessWidget {
   const Message({Key? key, required this.message}) : super(key: key);
 
+  /// {@nodoc}
   final ChatMessage message;
+
   @override
   Widget build(BuildContext context) {
     // styling


### PR DESCRIPTION
Marks the conflicting field as nodoc so that its documentation is not generated.
@palisadoes **DELETE** the `static/talawa` directory in `TalawaDocs` repo **before merging this**, so that the conflicting files are deleted first. Because the push workflow adds to the existing documentation, not replaces them.