### PR TITLE
Disable auto notes

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -71,15 +71,6 @@ jobs:
 #         run: echo "$GITHUB_CONTEXT"
 #       - name: Echo the GitHub context for troubleshooting
 #         run: echo "${{ toJSON(github) }}"
-      # - name: Granting permission to documentationcheck.py
-      #   run: chmod +x ./.github/workflows/documentationcheck.py
-      # - name: execute py script
-      #   # For more information on the GitHub context used for the "--repository" flag used by this script visit:
-      #   # https://docs.github.com/en/actions/learn-github-actions/contexts
-      #   run: |
-      #     git branch
-      #     pip install GitPython
-      #     python ./.github/workflows/documentationcheck.py --repository ${{github.repository}} --merge_branch_name ${{github.ref_name}}
 
   Update-Documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -124,16 +124,6 @@ jobs:
         run: |
           echo "commit_id=$(echo $(git rev-parse HEAD))" >> $GITHUB_ENV
           echo "email=$(echo $(git log --pretty=format:"%ae" $commit_id))" >> $GITHUB_ENV
-      #- name: Update Doc
-        #if: steps.DocUpdated.outputs.updateDoc
-        #run: |
-          #Green='0;32'
-          #NoColor='\033[0m'
-          #git config --global user.name "${{github.actor}}"
-          #git config --global user.email "${{env.email}}"
-          #git commit -a -m "Updated docs"
-          #git push
-          #echo -e "🚀${Green} Hurrah! doc updated${NoColor}"
       - uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.TALAWA_DOCS_SYNC }}
@@ -145,23 +135,6 @@ jobs:
           user_email: '${{env.email}}'
           user_name: '${{github.actor}}'
           commit_message: 'Updating talawa documentation as new PR merged into talawa:automated-docs'
-          
-  #Copy-docs-to-talawa-docs:
-    #runs-on: ubuntu-latest
-    #needs: Update-Documentation
-    #steps:
-    #- uses: actions/checkout@v3
-    #- uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
-      #env:
-        #API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      #with:
-        #source_file: 'docs/talawa/'
-        #destination_repo: 'PalisadoesFoundation/talawa-docs'
-        #destination_branch: 'develop'
-        #destination_folder: 'static/talawa'
-        #user_email: '${{env.email}}'
-        #user_name: '${{github.actor}}'
-        #commit_message: 'Updating talawa documentation as new PR merged into talawa:automated-docs'
 
   Flutter-Testing:
     name: Testing codebase
@@ -224,7 +197,7 @@ jobs:
           name: "Automated Android Release"
           artifacts: "./build/app/outputs/flutter-apk/app-release.apk"
           allowUpdates: "true"
-          generateReleaseNotes: true
+          generateReleaseNotes: false
           tag: "automated"
           body: |
             This is an automated release, triggered by a recent push. 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Disables auto-generation of release notes and removes unnecessary clutter from `push.yml`

**Issue Number:**

As discussed [here](https://github.com/PalisadoesFoundation/talawa/pull/1779#issuecomment-1511390287)

**Snapshots/Videos:**

When merged, the new generated release notes will be clean and clutter free like this

![](https://user-images.githubusercontent.com/62198564/232029484-d7821993-56f9-4748-9d65-be41d6f63d22.png)

**If relevant, did you update the documentation?**

Already done.
