### PR TITLE
Fixed 'notification.metrics.axis == widget.axis': is not true error in pinned_carousel_widget.dart

### DIFF
--- a/lib/widgets/pinned_carousel_widget.dart
+++ b/lib/widgets/pinned_carousel_widget.dart
@@ -159,6 +159,7 @@ class CustomCarouselScrollerState extends State<CustomCarouselScroller> {
         PageView(
           scrollDirection: Axis.horizontal,
           controller: controller,
+          physics: const BouncingScrollPhysics(),
           onPageChanged: (index) {
             setState(() {
               pindex = index;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #1800

**Did you add tests for your changes?**

 No. 

**Snapshots/Videos:**
<img width="1975" alt="Screen Shot 2023-05-03 at 2 08 03 PM" src="https://user-images.githubusercontent.com/35359329/236297442-8703a414-d633-4405-b1a5-79ad8e2ebdf4.png">
<img width="470" alt="Screen Shot 2023-05-03 at 2 08 14 PM" src="https://user-images.githubusercontent.com/35359329/236297456-98cac113-b4cb-49c0-b78d-166a2db5dae3.png">



**If relevant, did you update the documentation?**

No

**Summary**

(https://github.com/PalisadoesFoundation/talawa/issues/1800#issue-1691026661)

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes
