### PR TITLE
Fixes #1831: Update lint from 2.0.1 to 2.0.20.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1677,10 +1677,10 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "868a139229acb5018d22aded3eb9cb4767ff43a8216573c086b6c535a4957481"
+      sha256: de95f0e9405f29b5582573d4166132e71f83b3158aac14e8ee5767a54f4f1fbd
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.6.1"
   video_player_android:
     dependency: transitive
     description:
@@ -1701,10 +1701,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: "72ba04ad0eff76123c6d782ac46621cb8be476a89c33c89173fce982b6ec049b"
+      sha256: a8c4dcae2a7a6e7cc1d7f9808294d968eca1993af34a98e95b9bdfa959bec684
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.1.0"
   video_player_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ dependencies:
   tutorial_coach_mark: ^1.2.8
   uni_links: ^0.5.1
   vibration: ^1.7.6
-  video_player: ^2.6.0
+  video_player: ^2.6.1
   visibility_detector: ^0.4.0+2
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dev_dependencies:
     sdk: flutter
   hive_generator: ^2.0.0
   json_serializable: ^6.6.1
-  lint: ^2.0.1
+  lint: ^2.0.20
   mocktail_image_network: ^0.3.1
   talawa_lint:
     path: talawa_lint/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dev_dependencies:
     sdk: flutter
   hive_generator: ^2.0.0
   json_serializable: ^6.6.1
-  lint: ^2.0.20
+  lint: ^2.0.20 
   mocktail_image_network: ^0.3.1
   talawa_lint:
     path: talawa_lint/


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Bugfix; updates the version number of the lint dependency 

**Issue Number:**

Fixes #1831 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

**If relevant, did you update the documentation?**

No

**Summary**
The lint package for Dart has been updated to 2.0.20 whose deprecated version (2.0.1) is being used in the code causing a version mismatch problem, so updating the package version solves those problems.

**Does this PR introduce a breaking change?**

No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes
