### PR TITLE
Push workflow updated

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -115,17 +115,40 @@ jobs:
         run: |
           echo "commit_id=$(echo $(git rev-parse HEAD))" >> $GITHUB_ENV
           echo "email=$(echo $(git log --pretty=format:"%ae" $commit_id))" >> $GITHUB_ENV
-      - uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.TALAWA_DOCS_SYNC }}
-        with:
-          source_file: 'docs/talawa/'
-          destination_repo: 'PalisadoesFoundation/talawa-docs'
-          destination_branch: 'develop'
-          destination_folder: 'static'
-          user_email: '${{env.email}}'
-          user_name: '${{github.actor}}'
-          commit_message: 'Updating talawa documentation as new PR merged into talawa:automated-docs'
+      - name: Handle untracked files
+        if: steps.DocUpdated.outputs.updateDoc
+        run: |
+          git config --global user.name "${{github.actor}}"
+          git config --global user.email "${{env.email}}"
+          git add .
+      - name: Update Doc
+        if: steps.DocUpdated.outputs.updateDoc
+        run: |
+          Green='0;32'
+          NoColor='\033[0m'
+          git config --global user.name "${{github.actor}}"
+          git config --global user.email "${{env.email}}"
+          git commit -a -m "Updated docs"
+          git push
+          echo -e "🚀${Green} Hurrah! doc updated${NoColor}"
+          
+  Copy-docs-to-talawa-docs:
+    runs-on: ubuntu-latest
+    needs: Update-Documentation
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.TALAWA_DOCS_SYNC }}    
+      with:
+        source_file: 'docs/talawa/'
+        destination_repo: 'Palisadoes/talawa-docs'
+        destination_branch: 'develop'
+        destination_folder: 'static'
+        user_email: '${{env.email}}'
+        user_name: '${{github.actor}}'
+        commit_message: 'Overwriting static/talawa from talawa-repo'
+        overwrite: true
 
   Flutter-Testing:
     name: Testing codebase


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR fixes the problem of automated workflow that only allows for one of the two locations to receive updates, leading to confusion and disrupting the smooth flow of automatic documentation.

**Issue Number:**
Fixes #1907 

**Summary**
Both the folders now get updated

**Does this PR introduce a breaking change?**
No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
