### PR TITLE
Update shared_preferences from 2.1.0 to 2.1.2 #1893

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1337,10 +1337,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "16d3fb6b3692ad244a695c0183fca18cf81fd4b821664394a781de42386bf022"
+      sha256: "396f85b8afc6865182610c0a2fc470853d56499f75f7499e2a73a9f0539d23d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dependencies:
   qr_code_scanner: ^1.0.0
   qr_flutter: 4.0.0
   quick_actions: ^1.0.1
-  shared_preferences: ^2.1.0
+  shared_preferences: ^2.1.2
   shimmer: ^3.0.0
   social_share: ^2.2.1
   syncfusion_flutter_calendar: 20.4.54


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Updates  shared_preferences from 2.1.0 to 2.1.2

**Issue Number:**

Fixes #1893 

**Summary**

Just updated the shared preferences version as required for resolving issue #1893 

**Does this PR introduce a breaking change?**

No

**more info**

The issue stated to update shared_preferences form 2.1.1 to 2.1.2 but actually the shared_preferneces version currently used in develop branch is 2.1.0, so had to change from 2.1.0 to 2.1.2

**Have you read the [contributing guide]?**

Yes