### PR TITLE
Upgrade flutter_local_notifications from 14.1.0 to 14.1.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1337,10 +1337,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "16d3fb6b3692ad244a695c0183fca18cf81fd4b821664394a781de42386bf022"
+      sha256: "396f85b8afc6865182610c0a2fc470853d56499f75f7499e2a73a9f0539d23d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -482,10 +482,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "12f8abacca8bf29c042ec50c554f967da4c6f88ec99fc215e0325e5b43a25188"
+      sha256: "812791d43ccfc1b443a0d39fa02a206fc228c597e28ff9337e09e3ca8d370391"
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.0"
+    version: "14.1.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   flutter_braintree: ^3.0.0
   flutter_cache_manager: ^3.3.0
-  flutter_local_notifications: ^14.0.0
+  flutter_local_notifications: ^14.1.1
   flutter_localizations:
     sdk: flutter
   flutter_speed_dial: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dependencies:
   qr_code_scanner: ^1.0.0
   qr_flutter: 4.0.0
   quick_actions: ^1.0.1
-  shared_preferences: ^2.1.0
+  shared_preferences: ^2.1.2
   shimmer: ^3.0.0
   social_share: ^2.2.1
   syncfusion_flutter_calendar: 20.4.54


### PR DESCRIPTION
What kind of change does this PR introduce?

Upgrade flutter_local_notifications from 14.1.0 to 14.1.1

Issue Number:

Fixes #1881 

Summary

Just updated the flutter_local_notifications version as required for resolving issue #1881 

Does this PR introduce a breaking change?

No

Have you read the [contributing guide]?

Yes