### PR TITLE
Talawa-Workflow-Markdown-files

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -95,11 +95,11 @@ jobs:
           flutter analyze
           dart analyze
           flutter pub global activate dartdoc
-          flutter pub global run dartdoc . --output docs/talawa
+          flutter pub global run dartdoc . --output talawa-mobile-docs --format md
       - uses: actions/upload-artifact@v1
         with:
-          name: docs
-          path: docs/talawa
+          name: talawa-mobile-docs
+          path: talawa-mobile-docs
       - name: Checking doc updated
         id: DocUpdated
         run: |
@@ -141,15 +141,17 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
       env:
-        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB_NEW }}    
+        API_TOKEN_GITHUB: ${{ secrets.TALAWA_DOCS_SYNC }}    
       with:
-        source_file: 'docs/talawa/'
-        destination_repo: 'PalisadoesFoundation/talawa-docs'
+        source_file: 'talawa-mobile-docs/'
+        destination_repo: 'Palisadoes-Foundation/talawa-docs'
         destination_branch: 'develop'
-        destination_folder: 'static'
+        destination_folder: 'docs'
         user_email: '${{env.email}}'
         user_name: '${{github.actor}}'
-        commit_message: 'Overwriting static/talawa from talawa-repo'
+        commit_message: 'Overwriting talawa-mobile-docs from talawa-repo'
+
+  
 
   Flutter-Testing:
     name: Testing codebase

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -141,10 +141,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
       env:
-        API_TOKEN_GITHUB: ${{ secrets.TALAWA_DOCS_SYNC }}    
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB_NEW }}    
       with:
         source_file: 'talawa-mobile-docs/'
-        destination_repo: 'Palisadoes-Foundation/talawa-docs'
+        destination_repo: 'PalisadoesFoundation/talawa-docs'
         destination_branch: 'develop'
         destination_folder: 'docs'
         user_email: '${{env.email}}'

--- a/talawa-mobile-docs/TalawaAdmin.md
+++ b/talawa-mobile-docs/TalawaAdmin.md
@@ -1,0 +1,1 @@
+file will be overwritten.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
To maintain design consistency in the Talawa Mobile Docs, we have shifted to auto Markdown files instead of auto HTML files here. The "talawa-mobile-docs" folder would now contain the files for Talawa Dart Docs

**Issue Number:**
Fixes #1965 

**Snapshots/Videos:**
![image](https://github.com/PalisadoesFoundation/talawa/assets/97171261/bc5727d9-5232-4a1b-9187-0899b7920dad)

**If relevant, did you update the documentation?**
No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
