### PR TITLE
Edit:Upgrade-flutter_svg from 2.0.8 to 2.0.9

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -551,10 +551,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: bfc7cc3c75fe1282e8ce2e056d8fd1533f1a6848b65c379b4a5e7a9b623d3371
+      sha256: d39e7f95621fc84376bc0f7d504f05c3a41488c562f4a8ad410569127507402c
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
     sdk: flutter
   flutter_reaction_button: ^2.0.1+2
   flutter_speed_dial: ^7.0.0
-  flutter_svg: ^2.0.8
+  flutter_svg: ^2.0.9
   font_awesome_flutter: ^10.6.0
   geocoding: ^2.1.1
   geolocator: ^10.1.0


### PR DESCRIPTION
This change included the upgrading of flutter_svg package from 2.0.8 to 2.0.9

Issue Number: #2093

Fixed https://github.com/PalisadoesFoundation/talawa/issues/2093

Did you add tests for your changes?

No tests are required for this change as it only includes a package update.

If relevant, did you update the documentation?

Updation the documentation isnt required for this.

Summary

It upgrades flutter_svg package from 2.0.8 to 2.0.9.

Does this PR introduce a breaking change?

No, this does not introduce any major changes to the codebase.

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes, i have followed the guidelines.