### PR TITLE
Upgrade package tutorial_coach from 1.2.9 to 1.2.11

### DIFF
--- a/lib/view_model/main_screen_view_model.dart
+++ b/lib/view_model/main_screen_view_model.dart
@@ -365,7 +365,7 @@ class MainScreenViewModel extends BaseModel {
         }
         tourSkipped = true;
         onTabTapped(0);
-        return false;
+        return true;
       },
       onClickOverlay: (target) {
         onClickTarget(target);

--- a/lib/view_model/main_screen_view_model.dart
+++ b/lib/view_model/main_screen_view_model.dart
@@ -365,6 +365,7 @@ class MainScreenViewModel extends BaseModel {
         }
         tourSkipped = true;
         onTabTapped(0);
+        return false;
       },
       onClickOverlay: (target) {
         onClickTarget(target);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1621,10 +1621,10 @@ packages:
     dependency: "direct main"
     description:
       name: tutorial_coach_mark
-      sha256: ba60583d1b500111bf5040eb24330862b25162d926f72923b8e45c16621878b0
+      sha256: "1f1fd234790afb929dec7391a4d90aa54ffe8c8e4d278d9283df8e3f5ac5d63e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.9"
+    version: "1.2.11"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,7 @@ dependencies:
   syncfusion_flutter_calendar: 23.1.43
   syncfusion_flutter_datepicker: 23.1.44
   timelines: ^0.1.0
-  tutorial_coach_mark: ^1.2.9
+  tutorial_coach_mark: ^1.2.11
   uni_links: ^0.5.1
   vibration: ^1.8.3
   video_player: ^2.7.2


### PR DESCRIPTION
This change included the upgrading of tutorial_coach package from 1.2.9 to 1.2.11

Issue Number: https://github.com/PalisadoesFoundation/talawa/issues/2092

Fixed https://github.com/PalisadoesFoundation/talawa/issues/2092

Did you add tests for your changes?

No tests are required for this change as it only includes a package update.

If relevant, did you update the documentation?

Updation the documentation isnt required for this.

Summary

It upgrades tutorial_coach package from 1.2.9 to 1.2.11.

Does this PR introduce a breaking change?

No, this does not introduce any major changes to the codebase.

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes, i have followed the guidelines.
