### PR TITLE
Enhancing UX for adding content

### DIFF
--- a/lib/constants/routing_constants.dart
+++ b/lib/constants/routing_constants.dart
@@ -100,6 +100,6 @@ class Routes {
   /// static variable to access pinnedpostscreen.
   static const String pinnedPostScreen = '/pinnedpostscreen';
 
-  /// static variable.
+  /// static variable to access addPostScreen.
   static const String addPostScreen = '/addpostscreen';
 }

--- a/lib/constants/routing_constants.dart
+++ b/lib/constants/routing_constants.dart
@@ -99,4 +99,7 @@ class Routes {
 
   /// static variable to access pinnedpostscreen.
   static const String pinnedPostScreen = '/pinnedpostscreen';
+
+  /// static variable.
+  static const String addPostScreen = '/addpostscreen';
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -10,6 +10,7 @@ import 'package:talawa/models/task/task_model.dart';
 import 'package:talawa/splash_screen.dart';
 import 'package:talawa/view_model/after_auth_view_models/chat_view_models/direct_chat_view_model.dart';
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/create_event_view_model.dart';
+import 'package:talawa/views/after_auth_screens/add_post_page.dart';
 import 'package:talawa/views/after_auth_screens/app_settings/app_settings_page.dart';
 import 'package:talawa/views/after_auth_screens/chat/chat_message_screen.dart';
 import 'package:talawa/views/after_auth_screens/chat/select_contact.dart';
@@ -302,11 +303,17 @@ Route<dynamic> generateRoute(RouteSettings settings) {
           task: task,
         ),
       );
-    // Returns the DemoPageView Widget by default
     case Routes.selectContact:
       return MaterialPageRoute(
         builder: (context) => const SelectContact(key: Key('selectContact')),
       );
+    case Routes.addPostScreen:
+      return MaterialPageRoute(
+        builder: (context) => const AddPost(
+          key: Key('addpostscreen'),
+        ),
+      );
+    // Returns the DemoPageView Widget by default
     default:
       return MaterialPageRoute(
         builder: (context) => const DemoPageView(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -310,7 +310,7 @@ Route<dynamic> generateRoute(RouteSettings settings) {
     case Routes.addPostScreen:
       return MaterialPageRoute(
         builder: (context) => const AddPost(
-          key: Key('addpostscreen'),
+          key: Key('addPostScreen'),
         ),
       );
     // Returns the DemoPageView Widget by default

--- a/lib/view_model/main_screen_view_model.dart
+++ b/lib/view_model/main_screen_view_model.dart
@@ -7,7 +7,6 @@ import 'package:talawa/plugins/fetch_plugin_list.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
 import 'package:talawa/view_model/base_view_model.dart';
-import 'package:talawa/views/after_auth_screens/add_post_page.dart';
 // import 'package:talawa/views/after_auth_screens/chat/chat_list_screen.dart';
 import 'package:talawa/views/after_auth_screens/events/explore_events.dart';
 import 'package:talawa/views/after_auth_screens/feed/organization_feed.dart';
@@ -232,13 +231,6 @@ class MainScreenViewModel extends BaseModel {
         ),
         label: AppLocalizations.of(context)!.strictTranslate('Events'),
       ),
-      BottomNavigationBarItem(
-        icon: Icon(
-          Icons.add_box,
-          key: keyBNPost,
-        ),
-        label: AppLocalizations.of(context)!.strictTranslate('Add'),
-      ),
 
       /// Makes chat inaccessible for the user
       //TODO: add chat functionality
@@ -267,13 +259,6 @@ class MainScreenViewModel extends BaseModel {
         key: const Key('ExploreEvents'),
         homeModel: this,
       ),
-      AddPost(
-        key: const Key('AddPost'),
-        drawerKey: MainScreenViewModel.scaffoldKey,
-      ),
-      // const ChatPage(
-      //   key: Key('Chats'),
-      // ),
       ProfilePage(
         key: keySPEditProfile,
         homeModel: this,

--- a/lib/views/after_auth_screens/add_post_page.dart
+++ b/lib/views/after_auth_screens/add_post_page.dart
@@ -39,8 +39,13 @@ class AddPost extends StatelessWidget {
           //TODO: showing the null pointer exception
           key: const Key('add_post_icon_button1'),
           color: Theme.of(context).iconTheme.color,
-          icon: const Icon(Icons.menu),
-          onPressed: () => drawerKey!.currentState!.openDrawer(),
+          icon: const Icon(
+            Icons.arrow_back,
+            size: 36,
+          ),
+          onPressed: () {
+            navigationService.pop();
+          },
         ),
         // button to upload the post.
         actions: [
@@ -48,6 +53,7 @@ class AddPost extends StatelessWidget {
             key: const Key('add_post_text_btn1'),
             onPressed: () {
               model.uploadPost();
+              navigationService.pop();
               // convertImageToBase64(sampleBase64Image);
             },
             child: Text(

--- a/lib/views/after_auth_screens/feed/organization_feed.dart
+++ b/lib/views/after_auth_screens/feed/organization_feed.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:talawa/locator.dart';
 import 'package:talawa/view_model/after_auth_view_models/feed_view_models/organization_feed_view_model.dart';
 import 'package:talawa/view_model/main_screen_view_model.dart';
 import 'package:talawa/views/base_view.dart';
@@ -26,6 +27,19 @@ class OrganizationFeed extends StatelessWidget {
       builder: (context, model, child) {
         print(model.posts);
         return Scaffold(
+          floatingActionButton: FloatingActionButton(
+            shape: const CircleBorder(side: BorderSide.none),
+            key: const Key('floating_action_btn'),
+            backgroundColor: Colors.green,
+            onPressed: () {
+              navigationService.pushScreen('/addpostscreen');
+            },
+            child: const Icon(
+              Icons.add,
+              size: 35,
+              color: Colors.white,
+            ),
+          ),
           appBar: AppBar(
             // AppBar returns a widget for the header of the page.
             backgroundColor: Colors.green,

--- a/lib/views/after_auth_screens/feed/organization_feed.dart
+++ b/lib/views/after_auth_screens/feed/organization_feed.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:talawa/locator.dart';
+import 'package:talawa/services/size_config.dart';
 import 'package:talawa/view_model/after_auth_view_models/feed_view_models/organization_feed_view_model.dart';
 import 'package:talawa/view_model/main_screen_view_model.dart';
 import 'package:talawa/views/base_view.dart';
@@ -33,9 +34,9 @@ class OrganizationFeed extends StatelessWidget {
             onPressed: () {
               navigationService.pushScreen('/addpostscreen');
             },
-            child: const Icon(
+            child: Icon(
               Icons.add,
-              size: 35,
+              size: SizeConfig.screenHeight! * 0.045,
               color: Colors.white,
             ),
           ),

--- a/lib/views/after_auth_screens/feed/organization_feed.dart
+++ b/lib/views/after_auth_screens/feed/organization_feed.dart
@@ -25,7 +25,6 @@ class OrganizationFeed extends StatelessWidget {
     return BaseView<OrganizationFeedViewModel>(
       onModelReady: (model) => model.initialise(isTest: forTest),
       builder: (context, model, child) {
-        print(model.posts);
         return Scaffold(
           floatingActionButton: FloatingActionButton(
             shape: const CircleBorder(side: BorderSide.none),

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -15,6 +15,7 @@ import 'package:talawa/models/user/user_info.dart';
 import 'package:talawa/router.dart';
 import 'package:talawa/splash_screen.dart';
 import 'package:talawa/view_model/after_auth_view_models/chat_view_models/direct_chat_view_model.dart';
+import 'package:talawa/views/after_auth_screens/add_post_page.dart';
 import 'package:talawa/views/after_auth_screens/app_settings/app_settings_page.dart';
 import 'package:talawa/views/after_auth_screens/chat/chat_message_screen.dart';
 import 'package:talawa/views/after_auth_screens/chat/select_contact.dart';
@@ -335,6 +336,17 @@ void main() {
         final builder = route.builder;
         final widget = builder(MockBuildContext());
         expect(widget, isA<SelectContact>());
+      }
+    });
+
+    testWidgets('Test for addPostpage route', (WidgetTester tester) async {
+      final route =
+          generateRoute(const RouteSettings(name: Routes.addPostScreen));
+      expect(route, isA<MaterialPageRoute>());
+      if (route is MaterialPageRoute) {
+        final builder = route.builder;
+        final widget = builder(MockBuildContext());
+        expect(widget, isA<AddPost>());
       }
     });
 

--- a/test/widget_tests/after_auth_screens/add_post_page_test.dart
+++ b/test/widget_tests/after_auth_screens/add_post_page_test.dart
@@ -62,6 +62,16 @@ void main() {
   });
 
   group('createAddPostScreen Test', () {
+    testWidgets('check if back button in app bar works', (tester) async {
+      await tester.pumpWidget(createAddPostScreen());
+      await tester.pump();
+      final backButtonFinder = find.byKey(const Key('add_post_icon_button1'));
+      expect(backButtonFinder, findsOneWidget);
+      await tester.tap(backButtonFinder);
+      await tester.pump();
+      verify(navigationService.pop()).called(1);
+    });
+
     testWidgets('check if createAddPostScreen shows up', (tester) async {
       await tester.pumpWidget(createAddPostScreen());
       await tester.pump();

--- a/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
+++ b/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
@@ -168,4 +168,15 @@ void main() {
     await tester.pumpWidget(createOrganizationFeedScreen2(homeModel: model));
     await tester.pumpAndSettle(const Duration(seconds: 1));
   });
+  testWidgets('check if floating action button is visible and functional',
+      (tester) async {
+    final model = locator<MainScreenViewModel>();
+    await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
+    await tester.pump();
+    final fabFinder = find.byKey(const Key('floating_action_btn'));
+    expect(fabFinder, findsOneWidget);
+    await tester.tap(fabFinder);
+    await tester.pump();
+    verify(navigationService.pushScreen('/addpostscreen')).called(1);
+  });
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Enhancing UX for adding content so that no longer add sign button are there in a particular screen of the App.

**Issue Number:**

Fixes #2191 

**Did you add tests for your changes?**

Yes 

**Snapshots/Videos:**
![Screenshot_1701688091](https://github.com/PalisadoesFoundation/talawa/assets/103507835/189abbeb-fd15-44b7-88b1-b29210be188d)


**Summary**

Currently there are more than one add/plus sign button on some screen of the app to add content this affects the user experience of the App. I added Floating Action Button(FAB) on the feed screen of the app so that there wouldn't be more than one add/plus button on any screen of the app.

This FAB navigates us to the add post page screen to make new posts, took reference from X/Twitter app for making new tweets.


**Have you read the [contributing guide] (https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes