### PR TITLE
Fixes Snackbar clipping by adding an auto scroll and duration based on length of message

### DIFF
--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -120,13 +120,15 @@ class NavigationService {
 
   void showTalawaErrorSnackBar(
     String errorMessage,
-    MessageType messageType, {
-    Duration duration = const Duration(seconds: 2),
-  }) {
+    MessageType messageType,
+  ) {
+    final Duration duration = Duration(milliseconds: errorMessage.length * 80);
     ScaffoldMessenger.of(navigatorKey.currentContext!).showSnackBar(
       SnackBar(
         padding: EdgeInsets.zero,
+        duration: duration,
         content: TalawaErrorSnackBar(
+          duration: duration,
           messageType: messageType,
           errorMessage: errorMessage,
         ),

--- a/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
@@ -171,7 +171,6 @@ class SelectOrganizationViewModel extends BaseModel {
       navigationService.showTalawaErrorSnackBar(
         'Select one organization to continue',
         MessageType.warning,
-        duration: const Duration(milliseconds: 750),
       );
     }
   }

--- a/lib/widgets/talawa_error_snackbar.dart
+++ b/lib/widgets/talawa_error_snackbar.dart
@@ -1,11 +1,9 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
 import 'package:talawa/enums/enums.dart';
 
 import 'package:talawa/utils/app_localization.dart';
 
+/// Common Error Snack Bar for the whole talawa app.
 class TalawaErrorSnackBar extends StatelessWidget {
   const TalawaErrorSnackBar({
     super.key,
@@ -13,8 +11,14 @@ class TalawaErrorSnackBar extends StatelessWidget {
     required this.errorMessage,
     required this.messageType,
   });
+
+  /// Duration the snack bar is visible.
   final Duration duration;
+
+  /// error message for the talawaDialogBox.
   final String errorMessage;
+
+  /// enum for the type of error message.
   final MessageType messageType;
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/talawa_error_snackbar.dart
+++ b/lib/widgets/talawa_error_snackbar.dart
@@ -15,7 +15,7 @@ class TalawaErrorSnackBar extends StatelessWidget {
   /// Duration the snack bar is visible.
   final Duration duration;
 
-  /// error message for the talawaDialogBox.
+  /// error message for the talawa Snack Bar.
   final String errorMessage;
 
   /// enum for the type of error message.

--- a/lib/widgets/talawa_error_snackbar.dart
+++ b/lib/widgets/talawa_error_snackbar.dart
@@ -9,13 +9,25 @@ import 'package:talawa/utils/app_localization.dart';
 class TalawaErrorSnackBar extends StatelessWidget {
   const TalawaErrorSnackBar({
     super.key,
+    required this.duration,
     required this.errorMessage,
     required this.messageType,
   });
+  final Duration duration;
   final String errorMessage;
   final MessageType messageType;
   @override
   Widget build(BuildContext context) {
+    final ScrollController scrollController = ScrollController();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      scrollController.animateTo(
+        scrollController.position.maxScrollExtent,
+        duration: duration,
+        curve: Curves.linear,
+      );
+    });
+
     return Row(
       children: [
         Container(
@@ -59,6 +71,7 @@ class TalawaErrorSnackBar extends StatelessWidget {
           flex: 1,
           child: SingleChildScrollView(
             scrollDirection: Axis.horizontal,
+            controller: scrollController,
             child: Text(
               AppLocalizations.of(context)!.strictTranslate(errorMessage),
               style: const TextStyle(color: Colors.white),

--- a/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
+++ b/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
@@ -441,7 +441,6 @@ void main() {
         navigationService.showTalawaErrorSnackBar(
           'Select one organization to continue',
           MessageType.warning,
-          duration: const Duration(milliseconds: 750),
         ),
       );
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix: fixes the clipping thats seen in the login page by adding an auto scroll, with a dynamic duration based on the length of the message

**Issue Number:**
Fixes #2225

**Did you add tests for your changes?**
no

**Snapshots/Videos:**
Before:


https://github.com/PalisadoesFoundation/talawa/assets/72601105/a67f3621-75fc-442a-9f52-227ce7a831a3


After:


https://github.com/PalisadoesFoundation/talawa/assets/72601105/bd9ffc19-5d57-42a0-92a2-0a2b3fa45d47


**Summary**

This improves user experience as they wont be forced to manually scroll sideways, but can wish to do so if they require based on their preference

**Does this PR introduce a breaking change?**
no

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
yes
