### PR TITLE
converted private orgs to userRegistrationRequired orgs

### DIFF
--- a/lib/models/organization/org_info.dart
+++ b/lib/models/organization/org_info.dart
@@ -14,7 +14,7 @@ class OrgInfo {
     this.description,
     this.id,
     this.image,
-    this.isPublic,
+    this.userRegistrationRequired,
     this.name,
   });
 
@@ -34,7 +34,9 @@ class OrgInfo {
       name: json['name'] != null ? json['name'] as String? : null,
       description:
           json['description'] != null ? json['description'] as String? : null,
-      isPublic: json['isPublic'] != null ? json['isPublic'] as bool? : null,
+      userRegistrationRequired: json['userRegistrationRequired'] != null
+          ? json['userRegistrationRequired'] as bool?
+          : null,
       creatorInfo: json['creator'] != null
           ? User.fromJson(
               json['creator'] as Map<String, dynamic>,
@@ -112,9 +114,9 @@ class OrgInfo {
   @HiveField(5)
   String? description;
 
-  /// The org visibility.
+  /// The org registration is required.
   @HiveField(6)
-  bool? isPublic;
+  bool? userRegistrationRequired;
 
   /// The org creatorInfo.
   @HiveField(7)

--- a/lib/models/organization/org_info.g.dart
+++ b/lib/models/organization/org_info.g.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'org_info.dart';
@@ -26,7 +23,7 @@ class OrgInfoAdapter extends TypeAdapter<OrgInfo> {
       description: fields[5] as String?,
       id: fields[1] as String?,
       image: fields[0] as String?,
-      isPublic: fields[6] as bool?,
+      userRegistrationRequired: fields[6] as bool?,
       name: fields[2] as String?,
     );
   }
@@ -48,7 +45,7 @@ class OrgInfoAdapter extends TypeAdapter<OrgInfo> {
       ..writeByte(5)
       ..write(obj.description)
       ..writeByte(6)
-      ..write(obj.isPublic)
+      ..write(obj.userRegistrationRequired)
       ..writeByte(7)
       ..write(obj.creatorInfo);
   }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -43,7 +43,7 @@ import 'package:talawa/views/pre_auth_screens/select_language.dart';
 import 'package:talawa/views/pre_auth_screens/select_organization.dart';
 import 'package:talawa/views/pre_auth_screens/set_url.dart';
 import 'package:talawa/views/pre_auth_screens/signup_details.dart';
-import 'package:talawa/views/pre_auth_screens/waiting_to_join_private_org.dart';
+import 'package:talawa/views/pre_auth_screens/waiting_screen.dart';
 
 /// The MaterialApp provides us with a property called generateRoute where.
 ///

--- a/lib/utils/queries.dart
+++ b/lib/utils/queries.dart
@@ -35,7 +35,7 @@ class Queries {
                   name
                   image
                   description
-                  isPublic
+                  userRegistrationRequired
                   creator{
                     _id
                     firstName
@@ -48,7 +48,7 @@ class Queries {
                   name
                   image
                   description
-                  isPublic
+                  userRegistrationRequired
                   creator{
                     _id
                     firstName
@@ -62,7 +62,7 @@ class Queries {
                     name
                     image
                     description
-                    isPublic
+                    userRegistrationRequired
                     creator{
                       _id
                       firstName
@@ -106,7 +106,7 @@ class Queries {
                 name
                 image
                 description
-                isPublic
+                userRegistrationRequired
                 creator{
                   _id
                   firstName
@@ -119,7 +119,7 @@ class Queries {
                 name
                 image
                 description
-                isPublic
+                userRegistrationRequired
                 creator{
                   _id
                   firstName
@@ -133,7 +133,7 @@ class Queries {
                   name
                   image
                   description
-                  isPublic
+                  userRegistrationRequired
                   creator{
                     _id
                     firstName
@@ -207,7 +207,7 @@ class Queries {
         _id
         name
         image
-        isPublic
+        userRegistrationRequired
         creator{
           firstName
           lastName
@@ -229,7 +229,7 @@ class Queries {
         where:{
           name_starts_with: \$nameStartsWith,
           visibleInSearch: true,
-          isPublic: true,
+          userRegistrationRequired: true,
         }
         first: \$first,
         skip: \$skip,
@@ -239,7 +239,7 @@ class Queries {
         _id
         name
         image
-        isPublic
+        userRegistrationRequired
         creator{
           firstName
           lastName
@@ -266,7 +266,7 @@ class Queries {
             name
             image
             description
-            isPublic
+            userRegistrationRequired
             creator{
               _id
               firstName
@@ -297,7 +297,7 @@ class Queries {
               name
               image
               description
-              isPublic
+              userRegistrationRequired
               creator{
                 _id
                 firstName
@@ -324,7 +324,7 @@ class Queries {
               name
               image
               description
-              isPublic
+              userRegistrationRequired
               creator{
                 _id
                 firstName
@@ -338,7 +338,7 @@ class Queries {
               name
               image
               description
-              isPublic
+              userRegistrationRequired
               creator{
                 _id
                 firstName
@@ -351,7 +351,7 @@ class Queries {
                 _id
                 name
                 image
-                isPublic
+                userRegistrationRequired
                 creator{
                   _id
                   firstName
@@ -420,7 +420,7 @@ class Queries {
         _id
         name
         image
-        isPublic
+        userRegistrationRequired
         creator{
           firstName
           lastName
@@ -480,7 +480,7 @@ class Queries {
           _id
         }
         description
-        isPublic
+        userRegistrationRequired
         creator{
           _id
           firstName

--- a/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
@@ -123,9 +123,8 @@ class SelectOrganizationViewModel extends BaseModel {
         selectedOrganization = item;
         notifyListeners();
         onTapJoin();
-        // print(selectedOrganization.isPublic);
 
-        if (!selectedOrganization.isPublic!) {
+        if (selectedOrganization.userRegistrationRequired!) {
           navigationService.pushScreen(
             Routes.requestAccess,
             arguments: selectedOrganization,
@@ -186,8 +185,8 @@ class SelectOrganizationViewModel extends BaseModel {
   /// **returns**:
   /// * `Future<void>`: None
   Future<void> onTapJoin() async {
-    // if `selectedOrganization` is public.
-    if (selectedOrganization.isPublic == true) {
+    // if `selectedOrganization` registrations is not required.
+    if (selectedOrganization.userRegistrationRequired == false) {
       try {
         // run the graph QL mutation
         final QueryResult result = await databaseFunctions.gqlAuthMutation(

--- a/lib/view_model/pre_auth_view_models/signup_details_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/signup_details_view_model.dart
@@ -142,8 +142,8 @@ class SignupDetailsViewModel extends BaseModel {
           final bool tokenRefreshed = await graphqlConfig.getToken() as bool;
           // if user successfully saved and access token is also generated.
           if (userSaved && tokenRefreshed) {
-            // if the selected organization is public.
-            if (selectedOrganization.isPublic!) {
+            // if the selected organization userRegistration not required.
+            if (!selectedOrganization.userRegistrationRequired!) {
               try {
                 final QueryResult result =
                     await databaseFunctions.gqlAuthMutation(

--- a/lib/views/pre_auth_screens/waiting_screen.dart
+++ b/lib/views/pre_auth_screens/waiting_screen.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
 import 'package:talawa/enums/enums.dart';
 import 'package:talawa/services/size_config.dart';
@@ -12,7 +9,7 @@ import 'package:talawa/widgets/raised_round_edge_button.dart';
 import 'package:talawa/widgets/rich_text.dart';
 import 'package:talawa/widgets/signup_progress_indicator.dart';
 
-/// This class returns a widget which shows the request sent by the user to join a userRegistrationRequired organization.
+/// Displays a screen instructing the user to wait for approval.
 class WaitingPage extends StatelessWidget {
   const WaitingPage({super.key});
 

--- a/lib/views/pre_auth_screens/waiting_screen.dart
+++ b/lib/views/pre_auth_screens/waiting_screen.dart
@@ -12,7 +12,7 @@ import 'package:talawa/widgets/raised_round_edge_button.dart';
 import 'package:talawa/widgets/rich_text.dart';
 import 'package:talawa/widgets/signup_progress_indicator.dart';
 
-/// This class returns a widget which shows the request sent by the user to join a private organization.
+/// This class returns a widget which shows the request sent by the user to join a userRegistrationRequired organization.
 class WaitingPage extends StatelessWidget {
   const WaitingPage({super.key});
 

--- a/lib/widgets/custom_list_tile.dart
+++ b/lib/widgets/custom_list_tile.dart
@@ -110,8 +110,10 @@ class CustomListTile extends StatelessWidget {
                 child: type != TileType.user
                     ? type == TileType.org
                         ? Icon(
-                            orgInfo!.isPublic! ? Icons.lock_open : Icons.lock,
-                            color: orgInfo!.isPublic!
+                            !orgInfo!.userRegistrationRequired!
+                                ? Icons.lock_open
+                                : Icons.lock,
+                            color: !orgInfo!.userRegistrationRequired!
                                 ? const Color(0xFF34AD64)
                                 : const Color(0xffFABC57),
                           )

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -111,7 +111,7 @@ final fakeOrgInfo = OrgInfo(
     firstName: "ravidi",
     lastName: "shaikh",
   ),
-  isPublic: false,
+  userRegistrationRequired: true,
 );
 
 void _removeRegistrationIfExists<T extends Object>() {
@@ -363,13 +363,13 @@ UserConfig getAndRegisterUserConfig() {
         OrgInfo(
           id: '3',
           name: 'test org 3',
-          isPublic: true,
+          userRegistrationRequired: false,
           creatorInfo: User(firstName: 'test', lastName: '1'),
         ),
         OrgInfo(
           id: '4',
           name: 'test org 4',
-          isPublic: false,
+          userRegistrationRequired: true,
           creatorInfo: User(firstName: 'test', lastName: '2'),
         ),
         OrgInfo(
@@ -381,13 +381,13 @@ UserConfig getAndRegisterUserConfig() {
         OrgInfo(
           id: '1',
           name: 'test org',
-          isPublic: false,
+          userRegistrationRequired: true,
           creatorInfo: User(firstName: 'test', lastName: 'test'),
         ),
         OrgInfo(
           id: '2',
           name: 'test org',
-          isPublic: false,
+          userRegistrationRequired: true,
           creatorInfo: User(firstName: 'test', lastName: 'test'),
         ),
       ],

--- a/test/model_tests/organization/org_info_test.dart
+++ b/test/model_tests/organization/org_info_test.dart
@@ -16,7 +16,7 @@ void main() {
       'image': 'image_url',
       'name': 'Name',
       'description': 'Description',
-      'isPublic': true,
+      'userRegistrationRequired': false,
       'creator': userJson,
       'members': [userJson],
       'admins': [userJson],
@@ -26,7 +26,7 @@ void main() {
       'image': 'image_url',
       'name': 'Name',
       'description': 'Description',
-      'isPublic': true,
+      'userRegistrationRequired': false,
       'creator': userJson,
       'members': [userJson],
       'admins': [userJson],
@@ -39,7 +39,7 @@ void main() {
       expect(result.image, 'image_url');
       expect(result.name, 'Name');
       expect(result.description, 'Description');
-      expect(result.isPublic, true);
+      expect(result.userRegistrationRequired, false);
       expect(result.creatorInfo!.authToken, ' ');
       expect(result.creatorInfo!.refreshToken, ' ');
       expect(result.creatorInfo!.id, 'user_id');
@@ -64,7 +64,7 @@ void main() {
       expect(result.image, 'image_url');
       expect(result.name, 'Name');
       expect(result.description, 'Description');
-      expect(result.isPublic, true);
+      expect(result.userRegistrationRequired, false);
       expect(result.creatorInfo!.authToken, ' ');
       expect(result.creatorInfo!.refreshToken, ' ');
       expect(result.creatorInfo!.id, 'user_id');
@@ -92,7 +92,7 @@ void main() {
         expect(result.image, 'image_url');
         expect(result.name, 'Name');
         expect(result.description, 'Description');
-        expect(result.isPublic, true);
+        expect(result.userRegistrationRequired, false);
         expect(result.creatorInfo!.authToken, ' ');
         expect(result.creatorInfo!.refreshToken, ' ');
         expect(result.creatorInfo!.id, 'user_id');
@@ -124,7 +124,7 @@ void main() {
       expect(res[0].image, 'image_url');
       expect(res[0].name, 'Name');
       expect(res[0].description, 'Description');
-      expect(res[0].isPublic, true);
+      expect(res[0].userRegistrationRequired, false);
       expect(res[0].creatorInfo!.authToken, ' ');
       expect(res[0].creatorInfo!.refreshToken, ' ');
       expect(res[0].creatorInfo!.id, 'user_id');
@@ -141,7 +141,7 @@ void main() {
       expect(res[1].image, 'image_url');
       expect(res[1].name, 'Name');
       expect(res[1].description, 'Description');
-      expect(res[1].isPublic, true);
+      expect(res[1].userRegistrationRequired, false);
       expect(res[1].creatorInfo!.authToken, ' ');
       expect(res[1].creatorInfo!.refreshToken, ' ');
       expect(res[1].creatorInfo!.id, 'user_id');
@@ -158,7 +158,7 @@ void main() {
       expect(res[2].image, 'image_url');
       expect(res[2].name, 'Name');
       expect(res[2].description, 'Description');
-      expect(res[2].isPublic, true);
+      expect(res[2].userRegistrationRequired, false);
       expect(res[2].creatorInfo!.authToken, ' ');
       expect(res[2].creatorInfo!.refreshToken, ' ');
       expect(res[2].creatorInfo!.id, 'user_id');

--- a/test/model_tests/user/user_info_test.dart
+++ b/test/model_tests/user/user_info_test.dart
@@ -11,14 +11,14 @@ import 'package:talawa/models/user/user_info.dart';
 final encodedOrg = {
   "name": 'test_org',
   "image": 'https://testimg.com',
-  "isPublic": false,
+  "userRegistrationRequired": true,
 };
 
 /// Updated Organization.
 final updatedOrg = OrgInfo.fromJson({
   "name": 'test_org_updated',
   "image": 'https://testimg_updated.com',
-  "isPublic": true,
+  "userRegistrationRequired": false,
 });
 
 /// Membership Request Organization.
@@ -136,7 +136,7 @@ void main() {
       expect(userInfo.joinedOrganizations!.length, 2);
       expect(userInfo.joinedOrganizations![0].name, 'test_org');
       expect(userInfo.joinedOrganizations![0].image, 'https://testimg.com');
-      expect(userInfo.joinedOrganizations![0].isPublic, false);
+      expect(userInfo.joinedOrganizations![0].userRegistrationRequired, true);
 
       userInfo.updateJoinedOrg([updatedOrg, updatedOrg, updatedOrg]);
 
@@ -146,7 +146,7 @@ void main() {
         userInfo.joinedOrganizations![0].image,
         'https://testimg_updated.com',
       );
-      expect(userInfo.joinedOrganizations![0].isPublic, true);
+      expect(userInfo.joinedOrganizations![0].userRegistrationRequired, false);
     });
 
     test('Check if the method updateCreatedOrg works', () async {
@@ -155,7 +155,7 @@ void main() {
       expect(userInfo.createdOrganizations!.length, 2);
       expect(userInfo.createdOrganizations![0].name, 'test_org');
       expect(userInfo.createdOrganizations![0].image, 'https://testimg.com');
-      expect(userInfo.createdOrganizations![0].isPublic, false);
+      expect(userInfo.createdOrganizations![0].userRegistrationRequired, true);
 
       userInfo.updateCreatedOrg([updatedOrg, updatedOrg, updatedOrg]);
 
@@ -165,7 +165,7 @@ void main() {
         userInfo.createdOrganizations![0].image,
         'https://testimg_updated.com',
       );
-      expect(userInfo.createdOrganizations![0].isPublic, true);
+      expect(userInfo.createdOrganizations![0].userRegistrationRequired, false);
     });
 
     test('Check if the method updateMemberRequestOrg works', () async {
@@ -174,7 +174,7 @@ void main() {
       expect(userInfo.membershipRequests!.length, 2);
       expect(userInfo.membershipRequests![0].name, 'test_org');
       expect(userInfo.membershipRequests![0].image, 'https://testimg.com');
-      expect(userInfo.membershipRequests![0].isPublic, false);
+      expect(userInfo.membershipRequests![0].userRegistrationRequired, true);
 
       userInfo.updateMemberRequestOrg([updatedOrg, updatedOrg, updatedOrg]);
 
@@ -184,7 +184,7 @@ void main() {
         userInfo.membershipRequests![3].image,
         'https://testimg_updated.com',
       );
-      expect(userInfo.membershipRequests![3].isPublic, true);
+      expect(userInfo.membershipRequests![3].userRegistrationRequired, false);
     });
 
     test('Check if the method updateAdminFor works', () async {
@@ -193,14 +193,14 @@ void main() {
       expect(userInfo.adminFor!.length, 2);
       expect(userInfo.adminFor![0].name, 'test_org');
       expect(userInfo.adminFor![0].image, 'https://testimg.com');
-      expect(userInfo.adminFor![0].isPublic, false);
+      expect(userInfo.adminFor![0].userRegistrationRequired, true);
 
       userInfo.updateAdminFor([updatedOrg, updatedOrg, updatedOrg]);
 
       expect(userInfo.adminFor!.length, 3);
       expect(userInfo.adminFor![0].name, 'test_org_updated');
       expect(userInfo.adminFor![0].image, 'https://testimg_updated.com');
-      expect(userInfo.adminFor![0].isPublic, true);
+      expect(userInfo.adminFor![0].userRegistrationRequired, false);
     });
 
     test('Check if Hive storage works', () async {

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -41,7 +41,7 @@ import 'package:talawa/views/pre_auth_screens/change_password.dart';
 import 'package:talawa/views/pre_auth_screens/select_language.dart';
 import 'package:talawa/views/pre_auth_screens/select_organization.dart';
 import 'package:talawa/views/pre_auth_screens/set_url.dart';
-import 'package:talawa/views/pre_auth_screens/waiting_to_join_private_org.dart';
+import 'package:talawa/views/pre_auth_screens/waiting_screen.dart';
 
 class MockBuildContext extends Mock implements BuildContext {}
 

--- a/test/service_tests/database_mutations_function_test.dart
+++ b/test/service_tests/database_mutations_function_test.dart
@@ -58,7 +58,7 @@ void main() async {
     'image': 'sampleimg',
     'id': 'XYZ',
     'name': 'Sample1',
-    'isPublic': true,
+    'userRegistrationRequired': false,
     'creator': {'firstName': 'Shivam', 'lastName': 'Gupta'},
   });
 
@@ -145,7 +145,7 @@ void main() async {
                 'id': 'XYZ',
                 'image': 'sampleimg',
                 'name': 'Sample1',
-                'isPublic': true,
+                'userRegistrationRequired': false,
                 'creator': {'firstName': 'Shivam', 'lastName': 'Gupta'},
               },
             ],
@@ -159,7 +159,7 @@ void main() async {
       expect(org.id, testOrg.id);
       expect(org.name, testOrg.name);
       expect(org.image, testOrg.image);
-      expect(org.isPublic, testOrg.isPublic);
+      expect(org.userRegistrationRequired, testOrg.userRegistrationRequired);
       expect(org.creatorInfo!.firstName, testOrg.creatorInfo!.firstName);
     });
 
@@ -374,7 +374,7 @@ void main() async {
                 'id': 'XYZ',
                 'image': 'sampleimg',
                 'name': 'Sample1',
-                'isPublic': true,
+                'userRegistrationRequired': false,
                 'creator': {'firstName': 'Shivam', 'lastName': 'Gupta'},
               },
             ],
@@ -391,7 +391,7 @@ void main() async {
       expect(org.id, testOrg.id);
       expect(org.name, testOrg.name);
       expect(org.image, testOrg.image);
-      expect(org.isPublic, testOrg.isPublic);
+      expect(org.userRegistrationRequired, testOrg.userRegistrationRequired);
       expect(org.creatorInfo!.firstName, testOrg.creatorInfo!.firstName);
     });
 
@@ -501,7 +501,7 @@ void main() async {
                 'id': 'XYZ',
                 'image': 'sampleimg',
                 'name': 'Sample1',
-                'isPublic': true,
+                'userRegistrationRequired': false,
                 'creator': {'firstName': 'Shivam', 'lastName': 'Gupta'},
               },
             ],
@@ -518,7 +518,7 @@ void main() async {
       expect(org.id, testOrg.id);
       expect(org.name, testOrg.name);
       expect(org.image, testOrg.image);
-      expect(org.isPublic, testOrg.isPublic);
+      expect(org.userRegistrationRequired, testOrg.userRegistrationRequired);
       expect(org.creatorInfo!.firstName, testOrg.creatorInfo!.firstName);
     });
 
@@ -629,7 +629,7 @@ void main() async {
                 'id': 'XYZ',
                 'image': 'sampleimg',
                 'name': 'Sample1',
-                'isPublic': true,
+                'userRegistrationRequired': false,
                 'creator': {'firstName': 'Shivam', 'lastName': 'Gupta'},
               },
             ],
@@ -646,7 +646,7 @@ void main() async {
       expect(org.id, testOrg.id);
       expect(org.name, testOrg.name);
       expect(org.image, testOrg.image);
-      expect(org.isPublic, testOrg.isPublic);
+      expect(org.userRegistrationRequired, testOrg.userRegistrationRequired);
       expect(org.creatorInfo!.firstName, testOrg.creatorInfo!.firstName);
     });
 
@@ -664,7 +664,7 @@ void main() async {
                 'id': 'XYZ',
                 'image': 'sampleimg',
                 'name': 'Sample1',
-                'isPublic': true,
+                'userRegistrationRequired': false,
                 'creator': {'firstName': 'Shivam', 'lastName': 'Gupta'},
               },
             ],
@@ -681,7 +681,7 @@ void main() async {
       expect(org.id, testOrg.id);
       expect(org.name, testOrg.name);
       expect(org.image, testOrg.image);
-      expect(org.isPublic, testOrg.isPublic);
+      expect(org.userRegistrationRequired, testOrg.userRegistrationRequired);
       expect(org.creatorInfo!.firstName, testOrg.creatorInfo!.firstName);
     });
 

--- a/test/service_tests/org_service_test.dart
+++ b/test/service_tests/org_service_test.dart
@@ -31,7 +31,7 @@ void main() {
           _id
         }
         description
-        isPublic
+        userRegistrationRequired
         creator{
           _id
           firstName

--- a/test/view_model_tests/access_request_view_model_test.dart
+++ b/test/view_model_tests/access_request_view_model_test.dart
@@ -53,7 +53,7 @@ void main() {
                   'name': 'Organization Name',
                   'image': null,
                   'description': null,
-                  'isPublic': false,
+                  'userRegistrationRequired': true,
                   'creator': {
                     'firstName': 'ravidi',
                     'lastName': 'shaikh',
@@ -106,7 +106,7 @@ void main() {
                   'name': 'Organization Name',
                   'image': null,
                   'description': null,
-                  'isPublic': false,
+                  'userRegistrationRequired': true,
                   'creator': {
                     'firstName': 'ravidi',
                     'lastName': 'shaikh',

--- a/test/view_model_tests/custom_drawer_view_model_test.dart
+++ b/test/view_model_tests/custom_drawer_view_model_test.dart
@@ -166,7 +166,7 @@ void main() {
       final OrgInfo fakeOrg = OrgInfo(
         id: '5',
         name: 'fake org 1',
-        isPublic: false,
+        userRegistrationRequired: true,
         creatorInfo: User(firstName: 'fake', lastName: 'user'),
       );
       //check if the mocked org is present or not

--- a/test/view_model_tests/pre_auth_view_models/login_view_model_test.dart
+++ b/test/view_model_tests/pre_auth_view_models/login_view_model_test.dart
@@ -162,7 +162,7 @@ class MockUserConfig extends Mock implements UserConfig {
                 OrgInfo(
                   id: '3',
                   name: 'test org 3',
-                  isPublic: true,
+                  userRegistrationRequired: false,
                   creatorInfo: User(firstName: 'test', lastName: '1'),
                 ),
               ],

--- a/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
+++ b/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
@@ -79,7 +79,7 @@ void main() {
     org = OrgInfo(
       id: '3',
       name: 'test org 3',
-      isPublic: true,
+      userRegistrationRequired: false,
       creatorInfo: User(firstName: 'test', lastName: '1'),
     );
     locator.registerSingleton(Queries());
@@ -272,7 +272,8 @@ void main() {
 
       expect(selectOrganizationViewModel.selectedOrganization, org);
     });
-    testWidgets('Test for successful selectOrg function when org is private',
+    testWidgets(
+        'Test for successful selectOrg function when org requires userRegistration',
         (WidgetTester tester) async {
       locator.registerSingleton<UserConfig>(_MockUserConfig());
       final selectOrganizationViewModel = SelectOrganizationViewModel();
@@ -282,7 +283,7 @@ void main() {
           qrKey: selectOrganizationViewModel.qrKey,
         ),
       );
-      org.isPublic = false;
+      org.userRegistrationRequired = true;
       selectOrganizationViewModel.selectedOrganization = org;
 
       when(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)))
@@ -537,7 +538,7 @@ void main() {
     });
 
     /// we no longer have the tap button to join a org
-    // testWidgets('Test for successful onTapJoin function when isPublic is false',
+    // testWidgets('Test for successful onTapJoin function when userRegistrationRequired is false',
     //     (WidgetTester tester) async {
     //   locator.registerSingleton<UserConfig>(_MockUserConfig());
     //   final selectOrganizationViewModel = SelectOrganizationViewModel();
@@ -548,7 +549,7 @@ void main() {
     //     ),
     //   );
     //
-    //   org.isPublic = false;
+    //   org.userRegistrationRequired = false;
     //   selectOrganizationViewModel.selectedOrganization = org;
     //   _user = User(joinedOrganizations: []);
     //
@@ -583,7 +584,7 @@ void main() {
     //   );
     // });
     // testWidgets(
-    //     'Test for successful onTapJoin function when isPublic is false and joined orgnazation is not empty',
+    //     'Test for successful onTapJoin function when userRegistrationRequired is false and joined orgnazation is not empty',
     //     (WidgetTester tester) async {
     //   locator.registerSingleton<UserConfig>(_MockUserConfig());
     //   final selectOrganizationViewModel = SelectOrganizationViewModel();
@@ -594,7 +595,7 @@ void main() {
     //     ),
     //   );
     //
-    //   org.isPublic = false;
+    //   org.userRegistrationRequired = false;
     //   selectOrganizationViewModel.selectedOrganization = org;
     //   _user = User(joinedOrganizations: [org]);
     //
@@ -630,7 +631,7 @@ void main() {
     //   );
     // });
     // testWidgets(
-    //     'Test for successful onTapJoin function when isPublic is false and result is null',
+    //     'Test for successful onTapJoin function when userRegistrationRequired is false and result is null',
     //     (WidgetTester tester) async {
     //   locator.registerSingleton<UserConfig>(_MockUserConfig());
     //   final selectOrganizationViewModel = SelectOrganizationViewModel();
@@ -641,7 +642,7 @@ void main() {
     //     ),
     //   );
     //
-    //   org.isPublic = false;
+    //   org.userRegistrationRequired = false;
     //   selectOrganizationViewModel.selectedOrganization = org;
     //
     //   when(
@@ -672,7 +673,7 @@ void main() {
     //   );
     // });
     testWidgets(
-        'Test for successful onTapJoin function when isPublic is true and throws exception',
+        'Test for successful onTapJoin function when userRegistrationRequired is false and throws exception',
         (WidgetTester tester) async {
       locator.registerSingleton<UserConfig>(_MockUserConfig());
       final selectOrganizationViewModel = SelectOrganizationViewModel();
@@ -699,7 +700,7 @@ void main() {
       verify(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)));
     });
     // testWidgets(
-    //     'Test for successful onTapJoin function when isPublic is false and throws exception',
+    //     'Test for successful onTapJoin function when userRegistrationRequired is false and throws exception',
     //     (WidgetTester tester) async {
     //   locator.registerSingleton<UserConfig>(_MockUserConfig());
     //   final selectOrganizationViewModel = SelectOrganizationViewModel();
@@ -709,7 +710,7 @@ void main() {
     //       qrKey: selectOrganizationViewModel.qrKey,
     //     ),
     //   );
-    //   org.isPublic = false;
+    //   org.userRegistrationRequired = false;
     //
     //   selectOrganizationViewModel.selectedOrganization = org;
     //

--- a/test/view_model_tests/pre_auth_view_models/signup_details_view_model_test.dart
+++ b/test/view_model_tests/pre_auth_view_models/signup_details_view_model_test.dart
@@ -18,7 +18,7 @@ import '../../helpers/test_helpers.dart';
 
 bool empty = true;
 bool userSaved = true;
-bool isPublic = true;
+bool userRegistrationRequired = false;
 final data = {
   'signUp': {
     'user': {
@@ -51,7 +51,7 @@ class SignUpMock extends StatelessWidget {
 OrgInfo get org => OrgInfo(
       id: '3',
       name: 'test org 3',
-      isPublic: isPublic,
+      userRegistrationRequired: userRegistrationRequired,
       creatorInfo: User(firstName: 'test', lastName: '1'),
     );
 
@@ -62,7 +62,7 @@ void main() {
     await locator.unregister<UserConfig>();
     userSaved = true;
     empty = true;
-    isPublic = true;
+    userRegistrationRequired = false;
   });
   tearDown(() async {
     await locator.unregister<Queries>();
@@ -286,9 +286,9 @@ void main() {
       );
     });
     testWidgets(
-        'Check if signup() is working fine when selected organization is not public',
+        'Check if signup() is working fine when selected organization requires userRegistration',
         (tester) async {
-      isPublic = false;
+      userRegistrationRequired = true;
       locator.registerSingleton<UserConfig>(MockUserConfig());
 
       final model = SignupDetailsViewModel();
@@ -465,7 +465,7 @@ void main() {
     testWidgets(
         'Check if signup() is working fine when process of send membership request throws exception',
         (tester) async {
-      isPublic = false;
+      userRegistrationRequired = true;
       locator.registerSingleton<UserConfig>(MockUserConfig());
 
       final model = SignupDetailsViewModel();

--- a/test/views/after_auth_screens/join_org_after_auth_test/join_organisation_after_auth_test.dart
+++ b/test/views/after_auth_screens/join_org_after_auth_test/join_organisation_after_auth_test.dart
@@ -236,7 +236,7 @@ void main() {
           firstName: "ravidi",
           lastName: "shaikh",
         ),
-        isPublic: false,
+        userRegistrationRequired: true,
       );
       final orgTwo = OrgInfo(
         name: "org_two",
@@ -244,7 +244,7 @@ void main() {
           firstName: "ravidi",
           lastName: "shaikh",
         ),
-        isPublic: false,
+        userRegistrationRequired: true,
       );
 
       final selectOrgInfoVM = locator.get<SelectOrganizationViewModel>();

--- a/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
+++ b/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
@@ -55,7 +55,6 @@ Widget createOrganizationFeedScreen({
 // late OrganizationFeedViewModel _organizationFeedViewModel;
 
 Widget createOrganizationFeedScreen2({
-  bool isPublic = true,
   bool viewOnMap = true,
   required MainScreenViewModel homeModel,
 }) {

--- a/test/widget_tests/after_auth_screens/feed/pinned_post_screen_test.dart
+++ b/test/widget_tests/after_auth_screens/feed/pinned_post_screen_test.dart
@@ -34,7 +34,7 @@ Widget createApp() {
         final OrgInfo org = OrgInfo(
           id: '2',
           name: 'test org',
-          isPublic: true,
+          userRegistrationRequired: false,
           creatorInfo: User(firstName: 'test', lastName: 'test'),
         );
         print(org);

--- a/test/widget_tests/pre_auth_screens/signup_details_test.dart
+++ b/test/widget_tests/pre_auth_screens/signup_details_test.dart
@@ -27,7 +27,7 @@ Widget createApp() {
         final OrgInfo org = OrgInfo(
           id: '2',
           name: 'test org',
-          isPublic: true,
+          userRegistrationRequired: false,
           creatorInfo: User(firstName: 'test', lastName: 'test'),
         );
 

--- a/test/widget_tests/pre_auth_screens/waiting_page_test.dart
+++ b/test/widget_tests/pre_auth_screens/waiting_page_test.dart
@@ -16,7 +16,7 @@ import 'package:talawa/router.dart' as router;
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
-import 'package:talawa/views/pre_auth_screens/waiting_to_join_private_org.dart';
+import 'package:talawa/views/pre_auth_screens/waiting_screen.dart';
 import 'package:talawa/widgets/raised_round_edge_button.dart';
 import 'package:talawa/widgets/rich_text.dart';
 

--- a/test/widget_tests/widgets/custom_list_tile_test.dart
+++ b/test/widget_tests/widgets/custom_list_tile_test.dart
@@ -90,7 +90,7 @@ void main() {
       bool executed = false;
       _orgInfo = OrgInfo(
         name: 'Test Name',
-        isPublic: true,
+        userRegistrationRequired: false,
         creatorInfo: User(
           firstName: 'Test firstname',
           lastName: 'Test lastname',
@@ -144,7 +144,7 @@ void main() {
         (WidgetTester tester) async {
       _orgInfo = OrgInfo(
         name: 'Test Name',
-        isPublic: false,
+        userRegistrationRequired: true,
         creatorInfo: User(
           firstName: 'Test firstname',
           lastName: 'Test lastname',
@@ -237,7 +237,7 @@ void main() {
 
       // expect(userSizedBoxFallback, findsOneWidget);
 
-      // Testing SizedBox for users fallback for isPublic info
+      // Testing SizedBox for users fallback for userRegistrationRequired info
       // final userSizedBoxFallback1 = find
       //     .descendant(
       //       of: find.byType(Expanded).at(1),


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR converts all the support & references of `private organizations` to `userRegistrationRequired organizations`.

**Issue Number:**

Fixes #2287 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

The motive of this PR is to transform all the references and code of `private` organizatioins to `userRegistrationRequired` organizations.
The above transformation is achieved by replacing the `isPublic` attribute of `Organisation` model with `userRegistrationRequired` attribute in entire code base and making respective change to the logic.

**Does this PR introduce a breaking change?**

No

**Other information**



**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes