### PR TITLE
iOS image upload crash fix

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -62,5 +62,7 @@
 		<string>sms</string>
 		<string>tel</string>
 		</array>
-	</dict>
+		<key>NSPhotoLibraryUsageDescription</key>
+		<string>Allow access to photo library</string>
+</dict>
 </plist>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #2368

**Summary**
In the create post page, when we try to click select the upload photo button the app crashes. This PR solves this issue by adding photo library permission in the info.plist file.
