### PR TITLE
Fix Navigation: On clicking change language it navigates to home screen.

### DIFF
--- a/lib/views/pre_auth_screens/set_url.dart
+++ b/lib/views/pre_auth_screens/set_url.dart
@@ -188,7 +188,7 @@ class _SetUrlState extends State<SetUrl> {
                         key: const Key('ChangeLanguage'),
                         onTap: () {
                           navigationService
-                                          .pushScreen(Routes.languageSelectionRoute);
+                              .pushScreen(Routes.languageSelectionRoute);
                         },
                         child: Padding(
                           padding: EdgeInsets.only(

--- a/lib/views/pre_auth_screens/set_url.dart
+++ b/lib/views/pre_auth_screens/set_url.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:talawa/constants/routing_constants.dart';
 import 'package:talawa/custom_painters/language_icon.dart';
 import 'package:talawa/custom_painters/talawa_logo.dart';
 import 'package:talawa/locator.dart';
@@ -186,7 +187,8 @@ class _SetUrlState extends State<SetUrl> {
                       GestureDetector(
                         key: const Key('ChangeLanguage'),
                         onTap: () {
-                          navigationService.pop();
+                          navigationService
+                                          .pushScreen(Routes.languageSelectionRoute);
                         },
                         child: Padding(
                           padding: EdgeInsets.only(


### PR DESCRIPTION
**What kind of change does this PR introduce?**

-> Fixed the navigation, where app used to navigate back to the home page instead of the Select Language page on clicking the Select Language button.

**Issue Number:**

-> fixes #2394

**Did you add tests for your changes?**

-> No

**Does this PR introduce a breaking change?**

-> No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

-> Yes

Snapshots/Videos:

https://github.com/PalisadoesFoundation/talawa/assets/113767354/9ada2e8b-2691-4597-a8ca-8c78c018903d


