### PR TITLE
Fixed DateFormat Parse error in Edit Event 

### DIFF
--- a/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
@@ -47,12 +47,12 @@ class EditEventViewModel extends BaseModel {
     eventDescriptionTextController.text = _event.description!;
     isPublicSwitch = _event.isPublic!;
     isRegisterableSwitch = _event.isRegisterable!;
-    eventStartDate = DateFormat().add_yMd().parse(_event.startDate!);
-    eventEndDate = DateFormat().add_yMd().parse(_event.endDate!);
+    eventStartDate = DateFormat('yyyy-MM-dd').parse(_event.startDate!);
+    eventEndDate = DateFormat('yyyy-MM-dd').parse(_event.endDate!);
     eventStartTime =
-        TimeOfDay.fromDateTime(DateFormat("h:mm a").parse(_event.startTime!));
+        TimeOfDay.fromDateTime(DateFormat("HH:mm:ss").parse(_event.startTime!));
     eventEndTime =
-        TimeOfDay.fromDateTime(DateFormat("h:mm a").parse(_event.endTime!));
+        TimeOfDay.fromDateTime(DateFormat("HH:mm:ss").parse(_event.endTime!));
   }
 
   /// This function is used to update an event.

--- a/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:talawa/locator.dart';
@@ -8,39 +5,81 @@ import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/services/event_service.dart';
 import 'package:talawa/view_model/base_view_model.dart';
 
-/// EditEventViewModel class have methods to interact with model in
-/// the context of editing the event in the organization.
+/// `EditEventViewModel` is a class that extends `BaseModel`.
 ///
-/// Methods include:
-/// * `updateEvent` : to update an event.
+/// It provides methods and properties to manage the state and behavior of the Edit Event view.
+/// This includes text controllers for event details, focus nodes for form fields, and methods to initialize and update events.
+///
+/// The class uses the `EventService` to perform operations related to events.
 class EditEventViewModel extends BaseModel {
   late Event _event;
+
+  /// Controller for the title of the event.
   TextEditingController eventTitleTextController = TextEditingController();
+
+  /// Controller for the location of the event.
   TextEditingController eventLocationTextController = TextEditingController();
+
+  /// Controller for the description of the event.
   TextEditingController eventDescriptionTextController =
       TextEditingController();
+
+  /// Start time of the event.
   TimeOfDay eventStartTime = TimeOfDay.now();
+
+  /// End time of the event.
   TimeOfDay eventEndTime = TimeOfDay.now();
+
+  /// Start date of the event.
   DateTime eventStartDate = DateTime.now();
+
+  /// End date of the event.
   DateTime eventEndDate = DateTime.now();
+
+  /// Switch to toggle the event's public status.
   bool isPublicSwitch = true;
+
+  /// Switch to toggle the event's registerable status.
   bool isRegisterableSwitch = false;
+
+  /// Focus node for the title of the event.
   FocusNode titleFocus = FocusNode();
+
+  /// Focus node for the location of the event.
   FocusNode locationFocus = FocusNode();
+
+  /// Focus node for the description of the event.
   FocusNode descriptionFocus = FocusNode();
 
+  /// Key for the form.
   final formKey = GlobalKey<FormState>();
 
   final _eventService = locator<EventService>();
+
+  /// Autovalidate mode for the form.
   AutovalidateMode validate = AutovalidateMode.disabled;
 
-  // initialiser, invoke `_fillEditForm` function.
+  /// This function initializes the controller with the data.
+  ///
+  /// **params**:
+  /// * `event`: The event to initialize the controller with.
+  ///
+  /// **returns**:
+  ///   None
+
   void initialize(Event event) {
     _event = event;
     _fillEditForm();
   }
 
-  /// This function initialises the controller with the data.
+  /// This function fills the edit form with the event details.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  ///   None
+
   void _fillEditForm() {
     eventTitleTextController.text = _event.title!;
     eventLocationTextController.text = _event.location!;
@@ -55,8 +94,14 @@ class EditEventViewModel extends BaseModel {
         TimeOfDay.fromDateTime(DateFormat("HH:mm:ss").parse(_event.endTime!));
   }
 
-  /// This function is used to update an event.
-  /// The function uses `editEvent` function provided by `eventService` service.
+  /// This function updates the event with the new data.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  ///   None
+
   Future<void> updateEvent() async {
     titleFocus.unfocus();
     locationFocus.unfocus();

--- a/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
+++ b/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
@@ -14,10 +14,10 @@ import '../../../helpers/test_helpers.dart';
 final testEvent = Event(
   id: '1',
   title: 'test',
-  startDate: '01/30/2022', // mm/dd/yyyy
-  endDate: '01/30/2022',
-  startTime: '06:40 PM',
-  endTime: '07:40 PM',
+  startDate: '2024-01-30', // yyyy-MM-dd
+  endDate: '2024-01-30',
+  startTime: '06:40:00',
+  endTime: '06:40:00',
   location: 'ABC',
   description: 'test',
   creator: User(
@@ -47,15 +47,18 @@ void main() {
       expect(model.eventDescriptionTextController.text, 'test');
       expect(model.isPublicSwitch, true);
       expect(model.isRegisterableSwitch, true);
-      expect(model.eventStartDate, DateFormat().add_yMd().parse('01/30/2022'));
-      expect(model.eventEndDate, DateFormat().add_yMd().parse('01/30/2022'));
+      expect(
+        model.eventStartDate,
+        DateFormat('yyyy-MM-dd').parse('2024-01-30'),
+      );
+      expect(model.eventEndDate, DateFormat('yyyy-MM-dd').parse('2024-01-30'));
       expect(
         model.eventStartTime,
-        TimeOfDay.fromDateTime(DateFormat('h:mm a').parse('06:40 PM')),
+        TimeOfDay.fromDateTime(DateFormat("HH:mm:ss").parse("06:40:00")),
       );
       expect(
         model.eventEndTime,
-        TimeOfDay.fromDateTime(DateFormat('h:mm a').parse('07:40 PM')),
+        TimeOfDay.fromDateTime(DateFormat("HH:mm:ss").parse("06:40:00")),
       );
     });
     testWidgets('Check if updateEvent() is working fine', (tester) async {

--- a/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
+++ b/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
@@ -8,10 +8,26 @@ import 'package:talawa/view_model/after_auth_view_models/event_view_models/edit_
 
 import '../../../helpers/test_helpers.dart';
 
+/// [testEvent] is a mock event used for testing the `EditEventViewModel`.
+///
+/// It represents a typical event with the following properties:
+/// * `id`: A unique identifier for the event.
+/// * `title`: The title of the event.
+/// * `startDate` and `endDate`: The start and end dates of the event, in 'yyyy-MM-dd' format.
+/// * `startTime` and `endTime`: The start and end times of the event, in 'HH:mm:ss' format.
+/// * `location`: The location of the event.
+/// * `description`: A description of the event.
+/// * `creator`: The user who created the event.
+/// * `isPublic`: A boolean indicating whether the event is public.
+/// * `isRegisterable`: A boolean indicating whether users can register for the event.
+/// * `organization`: The organization that the event belongs to.
+///
+/// This mock event is used in the `EditEventViewModel Test` group to test the initialization and updating of events.
+
 final testEvent = Event(
   id: '1',
   title: 'test',
-  startDate: '2024-01-30', // yyyy-MM-dd
+  startDate: '2024-01-30',
   endDate: '2024-01-30',
   startTime: '06:40:00',
   endTime: '06:40:00',
@@ -30,6 +46,15 @@ final testEvent = Event(
   organization: OrgInfo(id: 'XYZ'),
 );
 
+/// Main.
+///
+/// more_info_if_required
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+///   None
 void main() {
   setUp(() {
     registerServices();

--- a/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
+++ b/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';

--- a/test/widget_tests/after_auth_screens/events/edit_event_page_test.dart
+++ b/test/widget_tests/after_auth_screens/events/edit_event_page_test.dart
@@ -46,14 +46,14 @@ Widget editEventScreen({
             event: Event(
               id: '1',
               admins: [],
-              startDate: DateFormat('yMd').format(
+              startDate: DateFormat('yyyy-MM-dd').format(
                 DateTime(2021, 1, 1),
               ),
-              endDate: DateFormat('yMd').format(
+              endDate: DateFormat('yyyy-MM-dd').format(
                 DateTime(2022, 1, 1),
               ),
-              startTime: DateFormat('h:mm a').format(DateTime(2021, 1, 1)),
-              endTime: DateFormat('h:mm a').format(DateTime(2022, 1, 1)),
+              startTime: DateFormat('HH:mm:ss').format(DateTime(2021, 1, 1)),
+              endTime: DateFormat('HH:mm:ss').format(DateTime(2022, 1, 1)),
               isRegisterable: true,
               isPublic: true,
               isRegistered: true,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #2464 

**Did you add tests for your changes?**

Yes (Updated related tests)

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa/assets/109027247/9d68256d-25ef-4098-8e12-ddba79bbe401

**Summary**

- In `edit_event_view_model` error was caused due to date/time format mismatch. Fixed it by expecting appropriate Date/Time format.
- Updated test cases for `edit_event_page` & `edit_event_model` accordingly.
- Added Documentation for modified files

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes 
