### PR TITLE
Fix issues in loading Attendees 

### DIFF
--- a/lib/demo_server_data/events_demo_data.dart
+++ b/lib/demo_server_data/events_demo_data.dart
@@ -1,14 +1,29 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
+/// 'eventsDemoData' is a list of events that are used to display the events in the app.
+///
+/// Each event has the following properties:
+/// - title: The title of the event.
+/// - description: The description of the event.
+/// - location: The location of the event.
+/// - recurring: Whether the event is recurring or not.
+/// - allDay: Whether the event is an all-day event or not.
+/// - startDate: The start date of the event.
+/// - endDate: The end date of the event.
+/// - startTime: The start time of the event.
+/// - endTime: The end time of the event.
+/// - recurrence: The recurrence of the event.
+/// - isPublic: Whether the event is public or not.
+/// - isSubscribed: Whether the user is subscribed to the event or not.
+/// - isRegisterable: Whether the event is registerable or not.
+/// - creator: The creator of the event.
+/// - attendees: The attendees of the event.
+/// - admins: The admins of the event.
+/// - organization: The organization of the event.
 
-///This file contains demo data. It contains a list of type Map<String, Object>
-/// and sample data of events.
 const eventsDemoData = [
   {
     "title": "Calculus",
     "description":
         "This course introduces calculus using analytic geometry functions. Topics include limits and continuity, derivatives, optimization, related rates, graphing and other applications of derivatives, definite and indefinite integrals, and numerical integration.",
-    "attendees": "50",
     "location": "Lostilos",
     "recurring": "false",
     "allDay": "true",
@@ -25,17 +40,21 @@ const eventsDemoData = [
       "lastName": "Shendge",
       "_id": "asdasdasd",
     },
-    "registrants": [
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
+    "attendees": [
+      {"id": "attendee1", "firstName": "firstName1", "lastName": "lastName1"},
+      {"id": "attendee2", "firstName": "firstName2", "lastName": "lastName2"},
+      {"id": "attendee3", "firstName": "firstName3", "lastName": "lastName3"},
+      {"id": "attendee4", "firstName": "firstName4", "lastName": "lastName4"},
+      {"id": "attendee5", "firstName": "firstName5", "lastName": "lastName5"},
+      {"id": "attendee6", "firstName": "firstName6", "lastName": "lastName6"},
+      {"id": "attendee7", "firstName": "firstName7", "lastName": "lastName7"},
+      {"id": "attendee8", "firstName": "firstName8", "lastName": "lastName8"},
+      {"id": "attendee9", "firstName": "firstName9", "lastName": "lastName9"},
+      {
+        "id": "attendee10",
+        "firstName": "firstName10",
+        "lastName": "lastName10",
+      },
     ],
     "admins": [
       {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
@@ -55,7 +74,6 @@ const eventsDemoData = [
     "title": "UI/UX",
     "description":
         "UX design refers to the term “user experience design”, while UI stands for “user interface design”. Both elements are crucial to a product and work closely together.",
-    "attendees": "80",
     "location": "Tokyo, Japan",
     "recurring": "false",
     "allDay": "true",
@@ -72,17 +90,21 @@ const eventsDemoData = [
       "lastName": "Chandla",
       "_id": "asdasdasd",
     },
-    "registrants": [
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
+    "attendees": [
+      {"id": "attendee1", "firstName": "firstName1", "lastName": "lastName1"},
+      {"id": "attendee2", "firstName": "firstName2", "lastName": "lastName2"},
+      {"id": "attendee3", "firstName": "firstName3", "lastName": "lastName3"},
+      {"id": "attendee4", "firstName": "firstName4", "lastName": "lastName4"},
+      {"id": "attendee5", "firstName": "firstName5", "lastName": "lastName5"},
+      {"id": "attendee6", "firstName": "firstName6", "lastName": "lastName6"},
+      {"id": "attendee7", "firstName": "firstName7", "lastName": "lastName7"},
+      {"id": "attendee8", "firstName": "firstName8", "lastName": "lastName8"},
+      {"id": "attendee9", "firstName": "firstName9", "lastName": "lastName9"},
+      {
+        "id": "attendee10",
+        "firstName": "firstName10",
+        "lastName": "lastName10",
+      },
     ],
     "admins": [
       {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
@@ -102,7 +124,6 @@ const eventsDemoData = [
     "title": "System Design",
     "description":
         "Systems design is the process of defining the architecture, product design, modules, interfaces, and data for a system to satisfy specified requirements. Systems design could be seen as the application of systems theory to product development.",
-    "attendees": "29",
     "location": "Shimla, India",
     "recurring": "false",
     "allDay": "true",
@@ -119,17 +140,21 @@ const eventsDemoData = [
       "lastName": "Srivastav",
       "_id": "asdasdasd",
     },
-    "registrants": [
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
+    "attendees": [
+      {"id": "attendee1", "firstName": "firstName1", "lastName": "lastName1"},
+      {"id": "attendee2", "firstName": "firstName2", "lastName": "lastName2"},
+      {"id": "attendee3", "firstName": "firstName3", "lastName": "lastName3"},
+      {"id": "attendee4", "firstName": "firstName4", "lastName": "lastName4"},
+      {"id": "attendee5", "firstName": "firstName5", "lastName": "lastName5"},
+      {"id": "attendee6", "firstName": "firstName6", "lastName": "lastName6"},
+      {"id": "attendee7", "firstName": "firstName7", "lastName": "lastName7"},
+      {"id": "attendee8", "firstName": "firstName8", "lastName": "lastName8"},
+      {"id": "attendee9", "firstName": "firstName9", "lastName": "lastName9"},
+      {
+        "id": "attendee10",
+        "firstName": "firstName10",
+        "lastName": "lastName10",
+      },
     ],
     "admins": [
       {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
@@ -147,11 +172,8 @@ const eventsDemoData = [
   },
   {
     "title": "Gaming",
-    // ignore: missing_whitespace_between_adjacent_strings
     "description":
         "Cyberpunk 2077 is a 2020 action role-playing v_ideo game developed and published by CD Projekt. The story takes place in Night City, an open world set in the Cyberpunk universe.",
-
-    "attendees": "5k+",
     "location": "Nagpur, India",
     "recurring": "false",
     "allDay": "true",
@@ -163,23 +185,26 @@ const eventsDemoData = [
     "isPublic": "true",
     "isSubscribed": "true",
     "isRegisterable": "true",
-
     "creator": {
       "firstName": "Utkarsh",
       "lastName": "Shendge",
       "_id": "asdasdasd",
     },
-    "registrants": [
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
-      {"firstName": "Warren", "lastName": "Buff", "_id": "asdasdasd"},
-      {"firstName": "Bustin", "lastName": "Jiber", "_id": "asdasdasd"},
+    "attendees": [
+      {"id": "attendee1", "firstName": "firstName1", "lastName": "lastName1"},
+      {"id": "attendee2", "firstName": "firstName2", "lastName": "lastName2"},
+      {"id": "attendee3", "firstName": "firstName3", "lastName": "lastName3"},
+      {"id": "attendee4", "firstName": "firstName4", "lastName": "lastName4"},
+      {"id": "attendee5", "firstName": "firstName5", "lastName": "lastName5"},
+      {"id": "attendee6", "firstName": "firstName6", "lastName": "lastName6"},
+      {"id": "attendee7", "firstName": "firstName7", "lastName": "lastName7"},
+      {"id": "attendee8", "firstName": "firstName8", "lastName": "lastName8"},
+      {"id": "attendee9", "firstName": "firstName9", "lastName": "lastName9"},
+      {
+        "id": "attendee10",
+        "firstName": "firstName10",
+        "lastName": "lastName10",
+      },
     ],
     "admins": [
       {"firstName": "Utkarsh", "lastName": "Shendge", "_id": "asdasdasd"},

--- a/lib/enums/enums.dart
+++ b/lib/enums/enums.dart
@@ -1,25 +1,71 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
-///This file contains different enums.
-///The enum keyword is used to define an enumeration type in Dart.
-/// The use case of enumeration is to store finite data members under the same type definition.
-
-/// Represents the state of the view
+/// Represents the state of the view.
 enum ViewState {
+  /// The view is not doing anything.
   idle,
+
+  /// The view is loading something.
   busy,
 }
 
-/// Represents the state of the chat
-enum ChatState { initial, loading, complete }
+/// Represents the state of the chat.
+enum ChatState {
+  /// The chat is at initial state.
+  initial,
 
-/// Represents the type of the tile
-enum TileType { user, org, option }
+  /// The chat is loading something.
+  loading,
 
-/// Represents the type of the Message
-enum MessageType { error, warning, info, random }
+  /// The chat state is complete.
+  complete
+}
 
-enum CallFor { login, signup, joinPublicOrg }
+/// Represents the type of the tile.
+enum TileType {
+  /// Represents the tile of the user.
+  user,
 
-enum ModalSheet { donation, invite }
+  /// Represents the tile of the attendee.
+  attendee,
+
+  /// Represents the tile of the organization.
+  org,
+
+  /// Represents the tile of the option.
+  option
+}
+
+/// Represents the type of the Message.
+enum MessageType {
+  /// Represents error message.
+  error,
+
+  /// Represents warning message.
+  warning,
+
+  /// Represents info message.
+  info,
+
+  /// Represents random message.
+  random
+}
+
+/// Represents the type of CallFor.
+enum CallFor {
+  /// Represents the call for login.
+  login,
+
+  /// Represents the call for signup.
+  signup,
+
+  /// Represents the call for joining Public organization.
+  joinPublicOrg
+}
+
+/// Represents the type of ModalSheet.
+enum ModalSheet {
+  /// Represents the modal sheet for donation.
+  donation,
+
+  /// Represents the modal sheet for invite.
+  invite
+}

--- a/lib/models/events/event_model.dart
+++ b/lib/models/events/event_model.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/models/user/user_info.dart';
 
@@ -27,7 +24,6 @@ class Event {
     this.creator,
     this.organization,
     this.admins,
-    this.registrants,
   });
   //Creating a new Event instance from a map structure.
   factory Event.fromJson(
@@ -37,7 +33,6 @@ class Event {
       id: json['_id'] as String,
       title: json['title'] as String?,
       description: json['description'] as String?,
-      attendees: json['attendees'] as String?,
       location: json['location'] as String?,
       longitude: json['longitude'] as double?,
       latitude: json['latitude'] as double?,
@@ -53,14 +48,12 @@ class Event {
       isRegisterable: json['isRegisterable'] as bool?,
       creator: json['creator'] == null
           ? null
-          //Creating a new User instance from a map structure.
           : User.fromJson(
               json['creator'] as Map<String, dynamic>,
               fromOrg: true,
             ),
       organization: json['organization'] == null
           ? null
-          //Creating a new OrgInfo instance from a map structure.
           : OrgInfo.fromJson(json['organization'] as Map<String, dynamic>),
       admins: json['admins'] == null
           ? null
@@ -69,30 +62,116 @@ class Event {
                 (e) => User.fromJson(e as Map<String, dynamic>, fromOrg: true),
               )
               .toList(),
-      registrants: (json['registrants'] as List<dynamic>?)
-          ?.map((e) => User.fromJson(e as Map<String, dynamic>, fromOrg: false))
-          .toList(),
+      attendees: (json["attendees"] as List<dynamic>?)?.isEmpty ?? true
+          ? null
+          : (json['attendees'] as List<dynamic>?)
+              ?.map(
+                (e) => Attendee.fromJson(e as Map<String, dynamic>),
+              )
+              .toList(),
     );
   }
+
+  ///Unique identifier for the event.
   String? id;
+
+  /// The title of the event.
   String? title;
+
+  /// The description of the event.
   String? description;
-  String? attendees;
+
+  /// The location of the event.
   String? location;
+
+  /// The latitude of the event.
   double? latitude;
+
+  /// The longitude of the event.
   double? longitude;
+
+  /// A boolean value that indicates if the event is recurring.
   bool? recurring;
+
+  /// A boolean value that indicates if the event is an all-day event.
   bool? allDay;
+
+  /// The start date of the event.
   String? startDate;
+
+  /// The end date of the event.
   String? endDate;
+
+  /// The start time of the event.
   String? startTime;
+
+  /// The end time of the event.
   String? endTime;
+
+  /// The recurrence of the event.
   String? recurrence;
+
+  /// A boolean value that indicates if the event is public.
   bool? isPublic;
+
+  /// A boolean value that indicates if the user is registered for the event.
   bool? isRegistered;
+
+  /// A boolean value that indicates if the event is registerable.
   bool? isRegisterable;
+
+  /// The creator of the event.
   User? creator;
+
+  /// The organization of the event.
   OrgInfo? organization;
+
+  /// The admins of the event.
   List<User>? admins;
-  List<User>? registrants;
+
+  /// The attendees of the event.
+  List<Attendee>? attendees;
+}
+
+///This class creates an attendee model and returns an Attendee instance.
+class Attendee {
+  Attendee({this.id, this.firstName, this.lastName, this.image});
+
+  Attendee.fromJson(Map<String, dynamic> json) {
+    id = json['_id'] as String?;
+    firstName = json['firstName'] as String?;
+    lastName = json['lastName'] as String?;
+    image = json['image'] as String?;
+  }
+
+  ///Unique identifier for the attendee.
+  String? id;
+
+  /// The first name of the attendee.
+  String? firstName;
+
+  /// The last name of the attendee.
+  String? lastName;
+
+  /// The image of the attendee.
+  String? image;
+
+  /// Converts the Attendee instance to a map structure..
+  ///
+  /// This method is used to convert the Attendee instance to a map structure that can be converted to a JSON object.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  /// * `Map<String, dynamic>`: A map structure that can be converted to a JSON object.
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['_id'] = this.id;
+    data['firstName'] = this.firstName;
+    data['lastName'] = this.lastName;
+    data['image'] = this.image;
+    return data;
+  }
 }

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:talawa/constants/routing_constants.dart';
@@ -17,7 +16,7 @@ import 'package:talawa/widgets/custom_progress_dialog.dart';
 /// Services include:
 /// * `setOrgStreamSubscription` : to set organization stream subscription for user.
 /// * `getEvents` : to get all events of the organization.
-/// * `fetchRegistrantsByEvent` : to fetch all registrants of an event.
+/// * `fetchAttendeesByEvent` : to fetch all attendees of an event.
 /// * `registerForAnEvent` : to register for an event.
 /// * `deleteEvent` : to delete an event.
 /// * `editEvent` : to edit the event.
@@ -78,12 +77,14 @@ class EventService {
     final result = await _dbFunctions.gqlAuthMutation(mutation);
 
     if (result == null) return;
+
     final List eventsJson =
-        (result as QueryResult).data!["eventsByOrganization"] as List;
+        (result as QueryResult).data!["eventsByOrganizationConnection"] as List;
+    debugPrint('Events: $eventsJson');
     eventsJson.forEach((eventJsonData) {
       final Event event = Event.fromJson(eventJsonData as Map<String, dynamic>);
-      event.isRegistered = event.registrants?.any(
-            (registrant) => registrant.id == _userConfig.currentUser.id,
+      event.isRegistered = event.attendees?.any(
+            (attendee) => attendee.id == _userConfig.currentUser.id,
           ) ??
           false;
       _eventStreamController.add(event);
@@ -97,9 +98,9 @@ class EventService {
   ///
   /// **returns**:
   /// * `Future<dynamic>`: Information about event registrants.
-  Future<dynamic> fetchRegistrantsByEvent(String eventId) async {
+  Future<dynamic> fetchAttendeesByEvent(String eventId) async {
     final result = await _dbFunctions.gqlAuthQuery(
-      EventQueries().registrantsByEvent(eventId),
+      EventQueries().attendeesByEvent(eventId),
     );
     return result;
   }

--- a/lib/utils/event_queries.dart
+++ b/lib/utils/event_queries.dart
@@ -14,38 +14,49 @@ class EventQueries {
   String fetchOrgEvents(String orgId) {
     return """
       query {
-        eventsByOrganization(id: "$orgId"){ 
-          _id
-          organization {
-            _id
-            image
-          }
-          title
-          description
-          isPublic
-          isRegisterable
-          recurring
-          startDate
-          endDate
-          allDay
-          startTime
-          endTime
-          location
-          creator{
-            _id
-            firstName
-            lastName
-          }
-          admins {
-            firstName
-            lastName
-          }
-        }
+        eventsByOrganizationConnection(
+      where: {
+        organization_id: "$orgId"
+      }
+    ) {
+      _id
+      organization {
+        _id
+        image
+      }
+      title
+      description
+      isPublic
+      isRegisterable
+      recurring
+      startDate
+      endDate
+      allDay
+      startTime
+      endTime
+      location
+      creator {
+        _id
+        firstName
+        lastName
+      }
+      admins {
+        _id
+        firstName
+        lastName
+      } 
+      attendees {
+        _id
+        firstName
+        lastName
+        image
+      }
+    }
       }
     """;
   }
 
-  /// Fetches registrants by event ID.
+  /// Fetches attendees by event ID.
   ///
   /// **params**:
   /// * `eventId`: The ID of the event to fetch registrants for.
@@ -55,14 +66,16 @@ class EventQueries {
   ///
   /// This function generates a GraphQL query string to fetch registrants
   /// based on the provided event ID.
-  String registrantsByEvent(String eventId) {
+  String attendeesByEvent(String eventId) {
     return '''
       query {
-        registrantsByEvent(id: "$eventId") {
-          _id
-          firstName
-          lastName
-          image
+        getEventAttendeesByEventId(eventId: "$eventId") {
+          eventId
+          userId
+          isRegistered
+          isInvited
+          isCheckedIn
+          isCheckedOut
         }
       }
     ''';

--- a/lib/view_model/after_auth_view_models/event_view_models/event_info_view_model.dart
+++ b/lib/view_model/after_auth_view_models/event_view_models/event_info_view_model.dart
@@ -1,52 +1,52 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:talawa/enums/enums.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/models/events/event_model.dart';
-import 'package:talawa/models/user/user_info.dart';
 import 'package:talawa/services/event_service.dart';
 import 'package:talawa/services/user_config.dart';
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/explore_events_view_model.dart';
 import 'package:talawa/view_model/base_view_model.dart';
 import 'package:talawa/widgets/custom_progress_dialog.dart';
 
-/// EventInfoViewModel class helps interacting with model to serve view with the event information data.'
-///
-/// Methods include:
-/// * `registerForEvent` : to register user for an event.
-/// * `getFabTitle` : to get the status of "registration" for an event.
+/// EventInfoViewModel class helps interacting with model to serve view with the event information data.
 class EventInfoViewModel extends BaseModel {
+  /// ExploreEventsViewModel instance to fetch the event data.
   late ExploreEventsViewModel exploreEventsInstance;
-  late Event event;
-  late String fabTitle;
-  late List<User> registrants;
 
-  /// initialise with the event data fetched from the model.
+  /// Event instance to store the event data.
+  late Event event;
+
+  /// String type variable to store the FAB title.
+  late String fabTitle;
+
+  /// List of Attendee type to store the attendees data.
+  late List<Attendee> attendees = [];
+
+  /// This function initializes the EventInfoViewModel class with the required arguments.
+  ///
+  /// **params**:
+  /// * `args`: A map of arguments required to initialize the EventInfoViewModel class.
+  ///
+  /// **returns**:
+  ///   None
   Future<void> initialize({required Map<String, dynamic> args}) async {
     event = args["event"] as Event;
     exploreEventsInstance =
         args["exploreEventViewModel"] as ExploreEventsViewModel;
     fabTitle = getFabTitle();
     setState(ViewState.busy);
-    final fetchRegistrantsByEventQueryResult = await locator<EventService>()
-        .fetchRegistrantsByEvent(event.id!) as QueryResult;
-    final registrantsJsonList = fetchRegistrantsByEventQueryResult
-        .data!['registrantsByEvent'] as List<Object?>;
-    registrants = registrantsJsonList
-        .map(
-          (registrantJson) => User.fromJson(
-            registrantJson! as Map<String, dynamic>,
-            fromOrg: true,
-          ),
-        )
-        .toList();
+
+    attendees = event.attendees ?? [];
     setState(ViewState.idle);
   }
 
-  /// This function helps the user to register for an event.
+  /// The function allows user to register for an event.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  ///   None
   Future<void> registerForEvent() async {
     // if event registration is open and user not already registered for the event.
     if (event.isRegisterable == true && event.isRegistered == false) {
@@ -59,11 +59,16 @@ class EventInfoViewModel extends BaseModel {
       // use `registerForAnEvent` function provided by `EventService` service.
       final registerResult =
           await locator<EventService>().registerForAnEvent(event.id!);
-      //final registerResult = await EventService().registerForAnEvent(event.id!);
-      // if the registration is successful.
       if (registerResult != null) {
         event.isRegistered = true;
-        registrants.add(locator<UserConfig>().currentUser);
+        attendees.add(
+          Attendee(
+            id: UserConfig().currentUser.id,
+            firstName: UserConfig().currentUser.firstName,
+            lastName: UserConfig().currentUser.lastName,
+            image: UserConfig().currentUser.image,
+          ),
+        );
       }
       print(registerResult);
       fabTitle = getFabTitle();
@@ -72,7 +77,13 @@ class EventInfoViewModel extends BaseModel {
     }
   }
 
-  /// This function returns `String` type for the event registration status.
+  /// The funtion returns title to be displayed on Floating Action Button.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  /// * `String`: Returns the title to be displayed on Floating Action Button.
   String getFabTitle() {
     if (event.isRegisterable == false) {
       return "Not Registrable";

--- a/lib/views/after_auth_screens/events/event_info_body.dart
+++ b/lib/views/after_auth_screens/events/event_info_body.dart
@@ -237,7 +237,7 @@ class EventInfoBody extends StatelessWidget {
               ListView.builder(
                 padding: EdgeInsets.zero,
                 shrinkWrap: true,
-                itemCount: model.registrants.length,
+                itemCount: model.attendees.length,
                 itemBuilder: (BuildContext context, int index) {
                   return CustomListTile(
                     key: Key(
@@ -245,7 +245,7 @@ class EventInfoBody extends StatelessWidget {
                     ),
                     index: index,
                     type: TileType.user,
-                    userInfo: model.registrants[index],
+                    userInfo: model.attendees[index],
                     onTapUserInfo: () {},
                   );
                 },

--- a/lib/views/after_auth_screens/events/event_info_body.dart
+++ b/lib/views/after_auth_screens/events/event_info_body.dart
@@ -244,9 +244,9 @@ class EventInfoBody extends StatelessWidget {
                       '${AppLocalizations.of(context)!.strictTranslate("Attendee")}$index',
                     ),
                     index: index,
-                    type: TileType.user,
-                    userInfo: model.attendees[index],
-                    onTapUserInfo: () {},
+                    type: TileType.attendee,
+                    attendeeInfo: model.attendees[index],
+                    onTapAttendeeInfo: () {},
                   );
                 },
               ),

--- a/lib/widgets/custom_list_tile.dart
+++ b/lib/widgets/custom_list_tile.dart
@@ -1,9 +1,7 @@
-// ignore_for_file: talawa_good_doc_comments, talawa_api_doc
 import 'package:flutter/material.dart';
 import 'package:talawa/enums/enums.dart';
 import 'package:talawa/models/options/options.dart';
 import 'package:talawa/models/organization/org_info.dart';
-import 'package:talawa/models/user/user_info.dart';
 
 /// Returns a widget for rendering Customized tiles.
 ///
@@ -32,7 +30,7 @@ class CustomListTile extends StatelessWidget {
   final OrgInfo? orgInfo;
 
   /// Object containing all the necessary info regarding the user.
-  final User? userInfo;
+  final dynamic userInfo;
 
   /// Object containing all the necessary info regarding the options.
   final Options? option;

--- a/lib/widgets/custom_list_tile.dart
+++ b/lib/widgets/custom_list_tile.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:talawa/enums/enums.dart';
+import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/models/options/options.dart';
 import 'package:talawa/models/organization/org_info.dart';
+import 'package:talawa/models/user/user_info.dart';
 
 /// Returns a widget for rendering Customized tiles.
 ///
@@ -13,11 +15,13 @@ class CustomListTile extends StatelessWidget {
     required this.type,
     this.showIcon = false,
     this.orgInfo,
-    this.onTapOrgInfo,
     this.userInfo,
-    this.onTapUserInfo,
-    this.onTapOption,
+    this.attendeeInfo,
     this.option,
+    this.onTapOrgInfo,
+    this.onTapUserInfo,
+    this.onTapAttendeeInfo,
+    this.onTapOption,
   }) : super(key: key);
 
   /// Index int of tiles.
@@ -30,7 +34,10 @@ class CustomListTile extends StatelessWidget {
   final OrgInfo? orgInfo;
 
   /// Object containing all the necessary info regarding the user.
-  final dynamic userInfo;
+  final User? userInfo;
+
+  /// Object containing all the necessary info regarding the Attendee.
+  final Attendee? attendeeInfo;
 
   /// Object containing all the necessary info regarding the options.
   final Options? option;
@@ -41,6 +48,9 @@ class CustomListTile extends StatelessWidget {
   /// Function to handle the tap on user info.
   final Function()? onTapUserInfo;
 
+  /// Function to handle the tap on attendee info.
+  final Function()? onTapAttendeeInfo;
+
   /// Function to handle the tap on org info.
   final Function(OrgInfo)? onTapOrgInfo;
 
@@ -49,13 +59,31 @@ class CustomListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    String text = '';
+    Function()? onTap;
+
+    switch (type) {
+      case TileType.org:
+        text = orgInfo!.name!;
+        onTap = () => onTapOrgInfo!(orgInfo!);
+        break;
+      case TileType.user:
+        text = '${userInfo!.firstName!} ${userInfo!.lastName!}';
+        onTap = onTapUserInfo;
+        break;
+      case TileType.attendee:
+        text = '${attendeeInfo!.firstName!} ${attendeeInfo!.lastName!}';
+        onTap = onTapAttendeeInfo;
+        break;
+      default:
+        text = option!.title;
+        onTap = onTapOption;
+        break;
+    }
+
     return InkWell(
       // checking whether the tapped tile is of user or org.
-      onTap: () => type == TileType.org
-          ? onTapOrgInfo!(orgInfo!)
-          : type == TileType.user
-              ? onTapUserInfo!()
-              : onTapOption!(),
+      onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.all(18.0),
         child: Container(
@@ -73,17 +101,13 @@ class CustomListTile extends StatelessWidget {
                     horizontal: 25,
                   ),
                   child: Text(
-                    type == TileType.org
-                        ? orgInfo!.name!
-                        : type == TileType.user
-                            ? '${userInfo!.firstName!} ${userInfo!.lastName!}'
-                            : option!.title,
+                    text,
                     style: type == TileType.org
                         ? Theme.of(context)
                             .textTheme
                             .headlineSmall!
                             .copyWith(fontSize: 18, color: Colors.black)
-                        : type == TileType.user
+                        : type == TileType.user || type == TileType.attendee
                             ? Theme.of(context)
                                 .textTheme
                                 .titleLarge!
@@ -105,7 +129,7 @@ class CustomListTile extends StatelessWidget {
               ),
               Expanded(
                 flex: 1,
-                child: type != TileType.user
+                child: type != TileType.user && type != TileType.attendee
                     ? type == TileType.org
                         ? Icon(
                             !orgInfo!.userRegistrationRequired!

--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -247,15 +247,10 @@ class EventCard extends StatelessWidget {
                           SizedBox(
                             width: SizeConfig.screenWidth! * 0.013,
                           ),
-                          event.attendees != null
-                              ? Text(
-                                  event.attendees!,
-                                  style: Theme.of(context).textTheme.bodySmall,
-                                )
-                              : Text(
-                                  (event.registrants?.length ?? 0).toString(),
-                                  style: Theme.of(context).textTheme.bodySmall,
-                                ),
+                          Text(
+                            (event.attendees?.length ?? 0).toString(),
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
                         ],
                       ),
                     ],

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -1,8 +1,4 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'dart:async';
-
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
@@ -97,13 +93,26 @@ import 'test_helpers.mocks.dart';
     MockSpec<ImagePicker>(onMissingStub: OnMissingStub.returnDefault),
   ],
 )
+
+/// member1 represents a member of the organization.
 final User member1 = User(id: "testMem1");
+
+/// member2 represents a member of the organization.
 final User member2 = User(id: "testMem2");
+
+/// admin1 represents an admin of the organization.
 final User admin1 = User(id: "testAdmin1");
+
+/// admin2 represents an admin of the organization.
 final User admin2 = User(id: "testAdmin2");
+
+/// members represents a list of members of the organization.
 final List<User> members = [member1, member2];
+
+/// admins represents a list of admins of the organization.
 final List<User> admins = [admin1, admin2];
 
+/// fakeOrgInfo represents a mock organization.
 final fakeOrgInfo = OrgInfo(
   id: "XYZ",
   name: "Organization Name",
@@ -116,12 +125,26 @@ final fakeOrgInfo = OrgInfo(
   userRegistrationRequired: true,
 );
 
+/// `removeRegistrationIfExists` removes the registration of a service if it is already registered.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+///   None
 void _removeRegistrationIfExists<T extends Object>() {
   if (locator.isRegistered<T>()) {
     locator.unregister<T>();
   }
 }
 
+///  `getAndRegisterNavigationService` returns a mock instance of the `NavigationService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `NavigationService`: A mock instance of the `NavigationService` class.
 NavigationService getAndRegisterNavigationService() {
   _removeRegistrationIfExists<NavigationService>();
   final service = MockNavigationService();
@@ -136,6 +159,13 @@ NavigationService getAndRegisterNavigationService() {
   return service;
 }
 
+/// `getAndRegisterOrganizationService` returns a mock instance of the `OrganizationService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `OrganizationService`: A mock instance of the `OrganizationService` class.
 OrganizationService getAndRegisterOrganizationService() {
   _removeRegistrationIfExists<OrganizationService>();
   final service = MockOrganizationService();
@@ -160,6 +190,13 @@ OrganizationService getAndRegisterOrganizationService() {
   return service;
 }
 
+/// `getAndRegisterAppTheme` returns a mock instance of the `AppTheme` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `AppTheme`: A mock instance of the `AppTheme` class.
 AppTheme getAndRegisterAppTheme() {
   _removeRegistrationIfExists<AppTheme>();
   final service = MockAppTheme();
@@ -167,6 +204,13 @@ AppTheme getAndRegisterAppTheme() {
   return service;
 }
 
+/// `getAndRegisterCommentService` returns a mock instance of the `CommentService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `CommentService`: A mock instance of the `CommentService` class.
 CommentService getAndRegisterCommentService() {
   _removeRegistrationIfExists<CommentService>();
   final service = MockCommentService();
@@ -174,6 +218,13 @@ CommentService getAndRegisterCommentService() {
   return service;
 }
 
+/// `getAndRegisterSessionManager` returns a mock instance of the `SessionManager` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `SessionManager`: A mock instance of the `SessionManager` class.
 SessionManager getAndRegisterSessionManager() {
   _removeRegistrationIfExists<SessionManager>();
   final service = MockSessionManger();
@@ -181,6 +232,13 @@ SessionManager getAndRegisterSessionManager() {
   return service;
 }
 
+/// `getAndRegisterChatService` returns a mock instance of the `ChatService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `ChatService`: A mock instance of the `ChatService` class.
 ChatService getAndRegisterChatService() {
   _removeRegistrationIfExists<ChatService>();
   final service = MockChatService();
@@ -214,6 +272,13 @@ ChatService getAndRegisterChatService() {
   return service;
 }
 
+/// `getAndRegisterAppLanguage` returns a mock instance of the `AppLanguage` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `AppLanguage`: A mock instance of the `AppLanguage` class.
 AppLanguage getAndRegisterAppLanguage() {
   _removeRegistrationIfExists<AppLanguage>();
   final service = MockAppLanguage();
@@ -224,6 +289,13 @@ AppLanguage getAndRegisterAppLanguage() {
   return service;
 }
 
+/// `getAndRegisterGraphqlConfig` returns a mock instance of the `GraphqlConfig` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `GraphqlConfig`: A mock instance of the `GraphqlConfig` class.
 GraphqlConfig getAndRegisterGraphqlConfig() {
   _removeRegistrationIfExists<GraphqlConfig>();
   final service = MockGraphqlConfig();
@@ -261,6 +333,13 @@ GraphqlConfig getAndRegisterGraphqlConfig() {
   return service;
 }
 
+/// `getAndRegisterGraphQLClient` returns a mock instance of the `GraphQLClient` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `GraphQLClient`: A mock instance of the `GraphQLClient` class.
 GraphQLClient getAndRegisterGraphQLClient() {
   _removeRegistrationIfExists<GraphQLClient>();
 
@@ -312,6 +391,13 @@ GraphQLClient getAndRegisterGraphQLClient() {
   return service;
 }
 
+/// `getAndRegisterDatabaseMutationFunctions` returns a mock instance of the `DataBaseMutationFunctions` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `DataBaseMutationFunctions`: A mock instance of the `DataBaseMutationFunctions` class.
 DataBaseMutationFunctions getAndRegisterDatabaseMutationFunctions() {
   _removeRegistrationIfExists<DataBaseMutationFunctions>();
   final service = MockDataBaseMutationFunctions();
@@ -325,6 +411,13 @@ DataBaseMutationFunctions getAndRegisterDatabaseMutationFunctions() {
   return service;
 }
 
+/// `getAndRegisterUserConfig` returns a mock instance of the `UserConfig` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `UserConfig`: A mock instance of the `UserConfig` class.
 UserConfig getAndRegisterUserConfig() {
   _removeRegistrationIfExists<UserConfig>();
   final service = MockUserConfig();
@@ -408,6 +501,13 @@ UserConfig getAndRegisterUserConfig() {
   return service;
 }
 
+/// `getAndRegisterPostService` returns a mock instance of the `PostService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `PostService`: A mock instance of the `PostService` class.
 PostService getAndRegisterPostService() {
   _removeRegistrationIfExists<PostService>();
   final service = MockPostService();
@@ -427,6 +527,13 @@ PostService getAndRegisterPostService() {
   return service;
 }
 
+/// `getAndRegisterMultiMediaPickerService` returns a mock instance of the `MultiMediaPickerService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `MultiMediaPickerService`: A mock instance of the `MultiMediaPickerService` class.
 MultiMediaPickerService getAndRegisterMultiMediaPickerService() {
   _removeRegistrationIfExists<MultiMediaPickerService>();
   final service = MockMultiMediaPickerService();
@@ -434,6 +541,13 @@ MultiMediaPickerService getAndRegisterMultiMediaPickerService() {
   return service;
 }
 
+/// `getAndRegisterImageCropper` returns a mock instance of the `ImageCropper` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `ImageCropper`: A mock instance of the `ImageCropper` class.
 ImageCropper getAndRegisterImageCropper() {
   _removeRegistrationIfExists<ImageCropper>();
   final service = MockImageCropper();
@@ -441,6 +555,13 @@ ImageCropper getAndRegisterImageCropper() {
   return service;
 }
 
+/// `getAndRegisterImageService` returns a mock instance of the `ImageService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `ImageService`: A mock instance of the `ImageService` class.
 ImageService getAndRegisterImageService() {
   _removeRegistrationIfExists<ImageService>();
   final service = MockImageService();
@@ -448,6 +569,13 @@ ImageService getAndRegisterImageService() {
   return service;
 }
 
+/// `getAndRegisterImagePicker` returns a mock instance of the `ImagePicker` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `ImagePicker`: A mock instance of the `ImagePicker` class.
 ImagePicker getAndRegisterImagePicker() {
   _removeRegistrationIfExists<ImagePicker>();
   final service = MockImagePicker();
@@ -455,6 +583,13 @@ ImagePicker getAndRegisterImagePicker() {
   return service;
 }
 
+/// `getAndRegisterEventService` returns a mock instance of the `EventService` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `EventService`: A mock instance of the `EventService` class.
 EventService getAndRegisterEventService() {
   _removeRegistrationIfExists<EventService>();
   final service = MockEventService();
@@ -493,21 +628,19 @@ EventService getAndRegisterEventService() {
     ),
   );
   const data = {
-    'registrantsByEvent': [
+    'getEventAttendeesByEventId': [
       {
-        '_id': 'xzy1',
-        'firstName': 'Test',
-        'lastName': 'User',
+        'userId': 'xzy1',
       }
     ],
   };
-  when(service.fetchRegistrantsByEvent('1')).thenAnswer(
+  when(service.fetchAttendeesByEvent('1')).thenAnswer(
     (realInvocation) async => QueryResult(
       source: QueryResultSource.network,
       data: data,
       options: QueryOptions(
         document: gql(
-          EventQueries().registrantsByEvent('1'),
+          EventQueries().attendeesByEvent('1'),
         ),
       ),
     ),
@@ -517,6 +650,13 @@ EventService getAndRegisterEventService() {
   return service;
 }
 
+/// `getAndRegisterConnectivityService` returns a mock instance of the `Connectivity` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `Connectivity`: A mock instance of the `Connectivity` class.
 Connectivity getAndRegisterConnectivityService() {
   _removeRegistrationIfExists<Connectivity>();
   final service = MockConnectivity();
@@ -524,6 +664,15 @@ Connectivity getAndRegisterConnectivityService() {
   return service;
 }
 
+/// `getPostMockModel` returns a mock instance of the `Post` class.
+///
+/// **params**:
+/// * `sId`: represent the post id.
+/// * `description`: represent the post description.
+/// * `duration`: represent the post duration.
+///
+/// **returns**:
+/// * `Post`: A mock instance of the `Post` class.
 Post getPostMockModel({
   String sId = "PostID",
   String description = "TestDescription",
@@ -542,6 +691,13 @@ Post getPostMockModel({
   return postMock;
 }
 
+/// `getAndRegisterCreateEventModel` returns a mock instance of the `CreateEventViewModel` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `CreateEventViewModel`: A mock instance of the `CreateEventViewModel` class.
 CreateEventViewModel getAndRegisterCreateEventModel() {
   _removeRegistrationIfExists<CreateEventViewModel>();
   final cachedViewModel = MockCreateEventViewModel();
@@ -571,7 +727,6 @@ CreateEventViewModel getAndRegisterCreateEventModel() {
     id: "fakeUser1",
     firstName: 'r',
     lastName: 'p',
-    // image: 'www.image.com',
   );
 
   final mapType = {user1.id!: true};
@@ -581,14 +736,10 @@ CreateEventViewModel getAndRegisterCreateEventModel() {
     return [user1];
   });
 
-  //when(cachedViewModel.selectedAdmins).thenReturn([user2]);
   when(cachedViewModel.selectedMembers).thenReturn([user1]);
   when(cachedViewModel.orgMembersList).thenReturn([user1]);
-
   when(cachedViewModel.memberCheckedMap).thenReturn(mapType);
-
   when(cachedViewModel.isAllDay).thenReturn(true);
-
   when(cachedViewModel.eventStartTime).thenReturn(TimeOfDay.now());
 
   when(cachedViewModel.eventEndTime).thenReturn(
@@ -608,15 +759,17 @@ CreateEventViewModel getAndRegisterCreateEventModel() {
     print('called');
   });
 
-  // when(cachedViewModel.removeUserFromList(userId: "fakeUser2"))
-  //     .thenAnswer((realInvocation) async {
-  //   when(cachedViewModel.selectedAdmins).thenReturn([]);
-  // });
-
   locator.registerSingleton<CreateEventViewModel>(cachedViewModel);
   return cachedViewModel;
 }
 
+/// `getAndRegisterDirectChatViewModel` returns a mock instance of the `DirectChatViewModel` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `DirectChatViewModel`: A mock instance of the `DirectChatViewModel` class.
 DirectChatViewModel getAndRegisterDirectChatViewModel() {
   _removeRegistrationIfExists<DirectChatViewModel>();
   final cachedViewModel = MockDirectChatViewModel();
@@ -641,7 +794,6 @@ DirectChatViewModel getAndRegisterDirectChatViewModel() {
   when(cachedViewModel.name).thenReturn("XYZ");
   when(cachedViewModel.chats).thenReturn([chatListTileDataModel1]);
   when(cachedViewModel.chatMessagesByUser).thenReturn(messages);
-
   when(cachedViewModel.initialise()).thenAnswer((realInvocation) async {});
   when(cachedViewModel.sendMessageToDirectChat("XYZ", "Something"))
       .thenAnswer((realInvocation) async {
@@ -655,6 +807,13 @@ DirectChatViewModel getAndRegisterDirectChatViewModel() {
   return cachedViewModel;
 }
 
+/// `getAndRegisterExploreEventsViewModel` returns a mock instance of the `ExploreEventsViewModel` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `ExploreEventsViewModel`: A mock instance of the `ExploreEventsViewModel` class.
 ExploreEventsViewModel getAndRegisterExploreEventsViewModel() {
   _removeRegistrationIfExists<ExploreEventsViewModel>();
   final cachedViewModel = MockExploreEventsViewModel();
@@ -672,6 +831,13 @@ ExploreEventsViewModel getAndRegisterExploreEventsViewModel() {
   return cachedViewModel;
 }
 
+/// `getAndRegisterMainViewModel` returns a mock instance of the `MainScreenViewModel` class.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `MainScreenViewModel`: A mock instance of the `MainScreenViewModel` class.
 MainScreenViewModel getAndRegisterMainViewModel() {
   _removeRegistrationIfExists<MainScreenViewModel>();
   final cachedViewModel = MockMainScreenViewModel();
@@ -680,6 +846,13 @@ MainScreenViewModel getAndRegisterMainViewModel() {
   return cachedViewModel;
 }
 
+/// `registerServices` registers all the services required for the test.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+///   None
 void registerServices() {
   getAndRegisterNavigationService();
   getAndRegisterAppLanguage();
@@ -698,6 +871,13 @@ void registerServices() {
   getAndRegisterImagePicker();
 }
 
+/// `unregisterServices` unregisters all the services required for the test.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+///   None
 void unregisterServices() {
   locator.unregister<NavigationService>();
   locator.unregister<GraphqlConfig>();
@@ -713,6 +893,13 @@ void unregisterServices() {
   locator.unregister<ImagePicker>();
 }
 
+/// registerViewModels registers all the view models required for the test.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+///   None
 void registerViewModels() {
   locator.registerFactory(() => MainScreenViewModel());
   locator.registerFactory(() => OrganizationFeedViewModel());
@@ -732,6 +919,13 @@ void registerViewModels() {
   locator.registerFactory(() => SelectContactViewModel());
 }
 
+/// `unregisterViewModels` unregisters all the view models required for the test.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+///   None
 void unregisterViewModels() {
   locator.unregister<MainScreenViewModel>();
   locator.unregister<OrganizationFeedViewModel>();

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -1158,10 +1158,10 @@ class MockEventService extends _i2.Mock implements _i11.EventService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<dynamic> fetchRegistrantsByEvent(String? eventId) =>
+  _i5.Future<dynamic> fetchAttendeesByEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchRegistrantsByEvent,
+          #fetchAttendeesByEvent,
           [eventId],
         ),
         returnValue: _i5.Future<dynamic>.value(),

--- a/test/model_tests/events/event_model_test.dart
+++ b/test/model_tests/events/event_model_test.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:talawa/models/events/event_model.dart';
 import 'package:talawa/models/organization/org_info.dart';
@@ -23,7 +20,6 @@ void main() {
         id: '12',
         title: 'for test only',
         description: 'for test only',
-        attendees: 'for test only',
         location: 'for test only',
         latitude: 1233,
         longitude: 123,
@@ -39,7 +35,14 @@ void main() {
         isRegisterable: true,
         organization: OrgInfo(admins: users),
         admins: users,
-        registrants: users,
+        attendees: [
+          Attendee(
+            id: "attendee1",
+            firstName: "firstName1",
+            lastName: "lastName1",
+            image: null,
+          ),
+        ],
       );
 
       final eventJson = {
@@ -52,7 +55,6 @@ void main() {
         '_id': '12',
         'title': 'for test only',
         'description': 'for test only',
-        'attendees': 'for test only',
         'location': 'for test only',
         'latitude': 1233.00,
         'longitude': 123.00,
@@ -88,23 +90,13 @@ void main() {
             'email': 'test@test.com',
           },
         ],
-        'registrants': [
-          <String, dynamic>{
-            'user': {
-              'id': '123',
-              'firstName': 'Ayush',
-              'lastName': 'Chaudhary',
-              'email': 'test@test.com',
-            },
-          },
-          <String, dynamic>{
-            'user': {
-              'id': '123',
-              'firstName': 'Aykkush',
-              'lastName': 'Chaudhary',
-              'email': 'test@test.com',
-            },
-          },
+        'attendees': [
+          Attendee(
+            id: "attendee1",
+            firstName: "firstName1",
+            lastName: "lastName1",
+            image: null,
+          ).toJson(),
         ],
       };
       final eventFromJson = Event.fromJson(eventJson);
@@ -116,7 +108,16 @@ void main() {
       expect(event.title, eventFromJson.title);
       expect(event.id, eventFromJson.id);
       expect(event.description, eventFromJson.description);
-      expect(event.attendees, eventFromJson.attendees);
+      expect(event.attendees?[0].id, eventFromJson.attendees?[0].id);
+      expect(
+        event.attendees?[0].firstName,
+        eventFromJson.attendees?[0].firstName,
+      );
+      expect(
+        event.attendees?[0].lastName,
+        eventFromJson.attendees?[0].lastName,
+      );
+      expect(event.attendees?[0].image, eventFromJson.attendees?[0].image);
       expect(event.location, eventFromJson.location);
       expect(event.latitude, eventFromJson.latitude);
       expect(event.longitude, eventFromJson.longitude);

--- a/test/service_tests/event_service_test.dart
+++ b/test/service_tests/event_service_test.dart
@@ -101,24 +101,24 @@ void main() {
       await services.registerForAnEvent('eventId');
     });
 
-    test('Test fetchRegistrantsByEvent method', () async {
+    test('Test fetchAttendeesByEvent method', () async {
       final dataBaseMutationFunctions = locator<DataBaseMutationFunctions>();
       const query = '';
       when(
         dataBaseMutationFunctions.gqlAuthQuery(
-          EventQueries().registrantsByEvent('eventId'),
+          EventQueries().attendeesByEvent('eventId'),
         ),
       ).thenAnswer(
         (realInvocation) async => QueryResult(
           options: QueryOptions(document: gql(query)),
           data: {
-            'registrant': {'_id': 'registrantId', 'name': 'name'},
+            'getEventAttendeesByEventId': {'userId': 'userId'},
           },
           source: QueryResultSource.network,
         ),
       );
       final services = EventService();
-      services.fetchRegistrantsByEvent('eventId');
+      services.fetchAttendeesByEvent('eventId');
     });
 
     test('Test getEvents method', () async {
@@ -133,12 +133,11 @@ void main() {
         (realInvocation) async => QueryResult(
           options: QueryOptions(document: gql(query)),
           data: {
-            'eventsByOrganization': [
+            'eventsByOrganizationConnection': [
               {
                 "_id": "1234567890",
                 "title": "Sample Event",
                 "description": "This is a sample event description.",
-                "attendees": "John Doe, Jane Smith",
                 "location": "Sample Location",
                 "longitude": -73.935242,
                 "latitude": 40.73061,
@@ -162,7 +161,7 @@ void main() {
                   "name": "Organization Name",
                   "description": "Sample organization description.",
                 },
-                "registrants": [
+                "attendees": [
                   testDataNotFromOrg,
                 ],
               }

--- a/test/utils/event_queries_test.dart
+++ b/test/utils/event_queries_test.dart
@@ -6,33 +6,44 @@ void main() {
     test("Check if fetchOrgEvents works correctly", () {
       const data = """
       query {
-        eventsByOrganization(id: "sampleID"){ 
-          _id
-          organization {
-            _id
-            image
-          }
-          title
-          description
-          isPublic
-          isRegisterable
-          recurring
-          startDate
-          endDate
-          allDay
-          startTime
-          endTime
-          location
-          creator{
-            _id
-            firstName
-            lastName
-          }
-          admins {
-            firstName
-            lastName
-          }
-        }
+        eventsByOrganizationConnection(
+      where: {
+        organization_id: "sampleID"
+      }
+    ) {
+      _id
+      organization {
+        _id
+        image
+      }
+      title
+      description
+      isPublic
+      isRegisterable
+      recurring
+      startDate
+      endDate
+      allDay
+      startTime
+      endTime
+      location
+      creator {
+        _id
+        firstName
+        lastName
+      }
+      admins {
+        _id
+        firstName
+        lastName
+      } 
+      attendees {
+        _id
+        firstName
+        lastName
+        image
+      }
+    }
       }
     """;
 
@@ -40,19 +51,21 @@ void main() {
       expect(fnData, data);
     });
 
-    test("Check if registrantsByEvents works correctly", () {
+    test("Check if attendeesByEvent works correctly", () {
       const data = '''
       query {
-        registrantsByEvent(id: "sampleID") {
-          _id
-          firstName
-          lastName
-          image
+        getEventAttendeesByEventId(eventId: "sampleID") {
+          eventId
+          userId
+          isRegistered
+          isInvited
+          isCheckedIn
+          isCheckedOut
         }
       }
     ''';
 
-      final fnData = EventQueries().registrantsByEvent("sampleID");
+      final fnData = EventQueries().attendeesByEvent("sampleID");
       expect(fnData, data);
     });
 

--- a/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/explore_events_view_model_test.dart
+++ b/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/explore_events_view_model_test.dart
@@ -1,8 +1,4 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -72,7 +68,7 @@ void main() {
       id: "1",
       title: "fake_event_title",
       description: "fake_event_desc",
-      attendees: "20",
+      attendees: [Attendee(id: 'Test Id')],
       location: "fake_event_loc",
       recurring: false,
       startDate: '2024-01-14',

--- a/test/views/after_auth_screens/events/event_info_body_test.dart
+++ b/test/views/after_auth_screens/events/event_info_body_test.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -52,8 +49,9 @@ Event getTestEvent({
         lastName: "shaikh_admin_two",
       ),
     ],
-    registrants: [
-      User(
+    attendees: [
+      Attendee(
+        id: "1",
         firstName: "Test",
         lastName: "User",
       ),

--- a/test/views/after_auth_screens/profile/user_event_test.dart
+++ b/test/views/after_auth_screens/profile/user_event_test.dart
@@ -138,7 +138,6 @@ void main() {
           id: 'a',
           title: 'Sample Event',
           description: 'This is a fake event description.',
-          attendees: 'John Doe, Jane Doe',
           location: 'City Park',
           latitude: 40.7128,
           longitude: -74.0060,
@@ -157,8 +156,8 @@ void main() {
           admins: [
             User(id: 'admin'),
           ],
-          registrants: [
-            User(id: 'registrant'),
+          attendees: [
+            Attendee(id: 'attendee1'),
           ],
         ),
       ]);

--- a/test/widget_tests/widgets/event_card_test.dart
+++ b/test/widget_tests/widgets/event_card_test.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: talawa_api_doc
-// ignore_for_file: talawa_good_doc_comments
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -25,7 +22,7 @@ Event getEvent({bool? isRegistered, bool isPublic = false}) {
     endTime: "08:15PM",
     isPublic: isPublic,
     isRegistered: isRegistered,
-    attendees: "96",
+    attendees: [Attendee(id: "attendee1")],
     creator: User(id: "ravidi"),
   );
 }
@@ -194,7 +191,7 @@ void main() {
           find.text("Testing for the Event Card Widget"),
           findsOneWidget,
         ); // event description
-        expect(find.text("96"), findsOneWidget);
+        expect(find.text("1"), findsOneWidget);
       });
     });
   });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix, refactoring

**Issue Number:**

Fixes #2463 

**Did you add tests for your changes?**

Yes 

**Snapshots/Videos:**


https://github.com/PalisadoesFoundation/talawa/assets/109027247/d23e9acd-0198-40d1-8c01-3ad2753eb760



**Summary**
In API registrants was deprecated and replaced with `attendees` which have attributes such as isRegistered, isInvited, isCheckedIn, isCheckedOut which are further used to determine status of event attendee.
 
- Replaced deprecated `registrantsByEvent` query with getEventAttendeesByEventId.
- Replaced deprecated `eventsByOrganization` with `eventsByOrganizationConnection` as the later provide server-side sorting and filtering support.
- Refac codebase to use `attendees` instead of registrants.
- Updated related tests.
- Added documentation for all modified files 

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes 
