### PR TITLE
Fixed loading indicator in Pinned Posts

### DIFF
--- a/lib/views/after_auth_screens/feed/pinned_post_screen.dart
+++ b/lib/views/after_auth_screens/feed/pinned_post_screen.dart
@@ -62,7 +62,11 @@ class _PinnedPostScreenState extends State<PinnedPostScreen> {
               cacheManager: widget.cacheManager,
               imageUrl: widget.post['imageUrl']!,
               errorWidget: (context, url, error) {
-                return const CircularProgressIndicator();
+                return const SizedBox(
+                  child: Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                );
               },
               height: SizeConfig.screenHeight! * .75,
               fit: BoxFit.cover,

--- a/lib/views/demo_screens/organization_feed_demo.dart
+++ b/lib/views/demo_screens/organization_feed_demo.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: talawa_api_doc
 import 'package:flutter/material.dart';
 import 'package:talawa/models/post/post_model.dart';
 import 'package:talawa/utils/app_localization.dart';
@@ -19,9 +18,7 @@ class DemoOrganizationFeed extends StatelessWidget {
   /// To implement the test.
   final bool forTest;
 
-  /// a_line_ending_with_end_punctuation.
-  ///
-  /// more_info_if_required
+  /// List of dummy pinned posts.
   static const List<Map<String, String>> pinnedPosts = [
     {
       'text': 'Church Meeting',
@@ -88,6 +85,13 @@ class DemoOrganizationFeed extends StatelessWidget {
     },
   ];
 
+  /// function returns a widget that shows the feed of the organization.
+  ///
+  /// **params**:
+  /// * `context`: build context of the widget.
+  ///
+  /// **returns**:
+  /// * `Widget`: returns a widget that shows the feed of the organization.
   Widget demoOrganisationFeedPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/widgets/pinned_post.dart
+++ b/lib/widgets/pinned_post.dart
@@ -5,14 +5,11 @@ import 'package:talawa/services/size_config.dart';
 import 'package:talawa/view_model/main_screen_view_model.dart';
 import 'package:talawa/views/after_auth_screens/feed/pinned_post_screen.dart';
 
-/// a_line_ending_with_end_punctuation.
-///
-/// more_info_if_required
+/// PinnedPost returns a widget that shows the pinned post.
 class PinnedPost extends StatelessWidget {
   const PinnedPost({super.key, required this.pinnedPost, required this.model});
 
   /// contains the pinned post.
-  ///
   final List<Post> pinnedPost;
 
   /// gives access mainScreenViewModel's attributes.
@@ -58,7 +55,12 @@ class PinnedPost extends StatelessWidget {
                                       ? 'placeHolderUrl'
                                       : pinnedPost[index].imageUrl!,
                               errorWidget: (context, url, error) {
-                                return const CircularProgressIndicator();
+                                print(error);
+                                return const SizedBox(
+                                  child: Center(
+                                    child: CircularProgressIndicator(),
+                                  ),
+                                );
                               },
                               height: SizeConfig.screenHeight! * 0.15,
                               fit: BoxFit.cover,
@@ -104,9 +106,7 @@ class PinnedPost extends StatelessWidget {
     );
   }
 
-  /// converts date time to hrs.
-  ///
-  /// more_info_if_required
+  /// Function returns the time difference in hours.
   ///
   /// **params**:
   /// * `createdAtString`: the time from post
@@ -122,8 +122,6 @@ class PinnedPost extends StatelessWidget {
   }
 
   /// converts post to mapped string.
-  ///
-  /// more_info_if_required
   ///
   /// **params**:
   /// * `index`: current index

--- a/test/widget_tests/widgets/pinned_post_test.dart
+++ b/test/widget_tests/widgets/pinned_post_test.dart
@@ -194,7 +194,7 @@ void main() {
               widgetTester.binding.rootElement!,
               '',
               Exception(),
-            ) is CircularProgressIndicator,
+            ) is SizedBox,
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #2391 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<table>
  <tr>
    <td><img src="https://github.com/PalisadoesFoundation/talawa/assets/109027247/9e809912-fa24-40f7-9310-7450f6dea38d" width="200" height="500"></td>
    <td><img src="https://github.com/PalisadoesFoundation/talawa/assets/109027247/6ba0e516-31ec-4b85-81b3-dc920ef28741" width="200" height="500"></td>
  </tr>
</table>

**Summary**

- Centered the loading indicator.

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes 
