### PR TITLE
Bug-Fix Image Picker (1.1.0)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   hive: ^2.2.3
   http: ^1.2.1
   image_cropper: ^5.0.1
-  image_picker: ^1.0.6
+  image_picker: ^1.1.0
   intl: ^0.18.1
   json_annotation: ^4.7.0
   mockito: ^5.4.4

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -4203,6 +4203,7 @@ class MockImagePicker extends _i2.Mock implements _i13.ImagePicker {
     double? maxHeight,
     int? imageQuality,
     bool? requestFullMetadata = true,
+    int? limit,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4213,6 +4214,7 @@ class MockImagePicker extends _i2.Mock implements _i13.ImagePicker {
             #maxHeight: maxHeight,
             #imageQuality: imageQuality,
             #requestFullMetadata: requestFullMetadata,
+            #limit: limit,
           },
         ),
         returnValue: _i5.Future<List<_i13.XFile>>.value(<_i13.XFile>[]),
@@ -4248,6 +4250,7 @@ class MockImagePicker extends _i2.Mock implements _i13.ImagePicker {
     double? maxHeight,
     int? imageQuality,
     bool? requestFullMetadata = true,
+    int? limit,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4258,6 +4261,7 @@ class MockImagePicker extends _i2.Mock implements _i13.ImagePicker {
             #maxHeight: maxHeight,
             #imageQuality: imageQuality,
             #requestFullMetadata: requestFullMetadata,
+            #limit: limit,
           },
         ),
         returnValue: _i5.Future<List<_i13.XFile>>.value(<_i13.XFile>[]),


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #2497 

**Did you add tests for your changes?**
No

**Snapshots/Videos:**
<img width="1336" alt="image" src="https://github.com/PalisadoesFoundation/talawa/assets/99138286/33abde66-544d-4b3e-b26d-2498506c1897">
<img width="1332" alt="image" src="https://github.com/PalisadoesFoundation/talawa/assets/99138286/f40b9965-b249-428d-85ce-e56da2344b9d">
<img width="1208" alt="image" src="https://github.com/PalisadoesFoundation/talawa/assets/99138286/bd9c45fa-7376-43f4-962a-bc8d12fc6f84">


<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
No
<!--Add link to Talawa-Docs.-->

**Summary**
In the version 1.0.7 there was no argument `limit` but with the newer version 1.1.0 a newer argument has been added to two such methods of the `image_picker` package which was ultimately causing error of fewer named arguments. Hence I added a new parameter `limit`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Yes, It fixes the dependabot issue for upgrading the package.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
