### PR TITLE
Update image_cropper 5.0.1 to 8.0.2

### DIFF
--- a/lib/services/image_service.dart
+++ b/lib/services/image_service.dart
@@ -29,10 +29,6 @@ class ImageService {
     try {
       final CroppedFile? croppedImage = await _imageCropper.cropImage(
         sourcePath: imageFile.path,
-        aspectRatioPresets: [
-          CropAspectRatioPreset.square,
-          CropAspectRatioPreset.original,
-        ],
         uiSettings: [
           AndroidUiSettings(
             toolbarTitle: 'Crop Image',
@@ -42,9 +38,17 @@ class ImageService {
             cropGridColor: Colors.white,
             initAspectRatio: CropAspectRatioPreset.original,
             lockAspectRatio: false,
+            aspectRatioPresets: [
+              CropAspectRatioPreset.square,
+              CropAspectRatioPreset.original,
+            ],
           ),
           IOSUiSettings(
             minimumAspectRatio: 1.0,
+            aspectRatioPresets: [
+              CropAspectRatioPreset.square,
+              CropAspectRatioPreset.original,
+            ],
           ),
         ],
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   file:
     dependency: "direct main"
     description:
@@ -434,26 +434,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "40e6fbd2da7dcc7ed78432c5cdab1559674b4af035fddbfb2f9a8f9c2112fcef"
+      sha256: c500d5d9e7e553f06b61877ca6b9c8b92c570a4c8db371038702e8ce57f8a50f
       url: "https://pub.dev"
     source: hosted
-    version: "17.1.2"
+    version: "17.2.2"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0+1"
+    version: "4.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "340abf67df238f7f0ef58f4a26d2a83e1ab74c77ab03cd2b2d5018ac64db30b7"
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -809,18 +809,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -857,18 +857,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1413,10 +1413,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timelines:
     dependency: "direct main"
     description:
@@ -1645,10 +1645,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -1677,10 +1677,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
+      sha256: "68d1e89a91ed61ad9c370f9f8b6effed9ae5e0ede22a270bdfa6daf79fc2290a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.5.4"
   win32_registry:
     dependency: transitive
     description:
@@ -1714,5 +1714,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <3.19.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -769,10 +769,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -681,26 +681,26 @@ packages:
     dependency: "direct main"
     description:
       name: image_cropper
-      sha256: f4bad5ed2dfff5a7ce0dfbad545b46a945c702bb6182a921488ef01ba7693111
+      sha256: fe37d9a129411486e0d93089b61bd326d05b89e78ad4981de54b560725bf5bd5
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "8.0.2"
   image_cropper_for_web:
     dependency: transitive
     description:
       name: image_cropper_for_web
-      sha256: "865d798b5c9d826f1185b32e5d0018c4183ddb77b7b82a931e1a06aa3b74974e"
+      sha256: "34256c8fb7fcb233251787c876bb37271744459b593a948a2db73caa323034d0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "6.0.2"
   image_cropper_platform_interface:
     dependency: transitive
     description:
       name: image_cropper_platform_interface
-      sha256: ee160d686422272aa306125f3b6fb1c1894d9b87a5e20ed33fa008e7285da11e
+      sha256: e8e9d2ca36360387aee39295ce49029362ae4df3071f23e8e71f2b81e40b7531
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "7.0.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -769,10 +769,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -809,26 +809,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lint:
     dependency: "direct dev"
     description:
@@ -865,10 +865,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1413,10 +1413,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   timelines:
     dependency: "direct main"
     description:
@@ -1645,10 +1645,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -1715,4 +1715,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.0 <3.19.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ homepage: https://github.com/PalisadoesFoundation/talawa
 
 repository: https://github.com/PalisadoesFoundation/talawa
 environment:
-  sdk: ">=2.17.0 <3.19.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   ############# Remove ###########
@@ -37,7 +37,7 @@ dependencies:
     sdk: flutter
   flutter_braintree: ^4.0.0
   flutter_cache_manager: ^3.3.2
-  flutter_local_notifications: ^17.1.2
+  flutter_local_notifications: ^17.2.2
   flutter_localizations:
     sdk: flutter
   flutter_reaction_button: ^3.0.0+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   http: ^1.2.1
   image_cropper: ^8.0.2
   image_picker: ^1.1.1
-  intl: ^0.19.0
+  intl: ^0.18.1
   json_annotation: ^4.7.0
   mockito: ^5.4.4
   network_image_mock: ^2.1.1
@@ -92,6 +92,9 @@ dev_dependencies:
     path: talawa_lint/
 
   url_launcher_platform_interface: 2.3.2
+
+dependency_overrides:
+  intl: ^0.18.1
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,9 +48,9 @@ dependencies:
   graphql_flutter: ^5.1.2
   hive: ^2.2.3
   http: ^1.2.1
-  image_cropper: ^5.0.1
+  image_cropper: ^8.0.2
   image_picker: ^1.1.1
-  intl: ^0.18.1
+  intl: ^0.19.0
   json_annotation: ^4.7.0
   mockito: ^5.4.4
   network_image_mock: ^2.1.1

--- a/talawa-mobile-docs/services_third_party_service_multi_media_pick_service/MultiMediaPickerService/cropImage.md
+++ b/talawa-mobile-docs/services_third_party_service_multi_media_pick_service/MultiMediaPickerService/cropImage.md
@@ -1,21 +1,7 @@
-
-
-
 # cropImage method
-
-
-
-
-
-
-
 
 [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)&lt;[File](https://api.flutter.dev/flutter/dart-io/File-class.html)?> cropImage
 ({required [File](https://api.flutter.dev/flutter/dart-io/File-class.html) imageFile})
-
-
-
-
 
 <p>This function is used to crop the image selected by the user.</p>
 <p>The function accepts a <code>File</code> type image and returns <code>File</code> type of cropped image.</p>
@@ -28,8 +14,6 @@
 <li><code>Future&lt;File?&gt;</code>: the image after been cropped.</li>
 </ul>
 
-
-
 ## Implementation
 
 ```dart
@@ -38,10 +22,6 @@ Future<File?> cropImage({required File imageFile}) async {
   try {
     final CroppedFile? croppedImage = await locator<ImageCropper>().cropImage(
       sourcePath: imageFile.path,
-      aspectRatioPresets: [
-        CropAspectRatioPreset.square,
-        CropAspectRatioPreset.original,
-      ],
       uiSettings: [
         AndroidUiSettings(
           toolbarTitle: 'Crop Image',
@@ -51,6 +31,10 @@ Future<File?> cropImage({required File imageFile}) async {
           cropGridColor: Colors.white,
           initAspectRatio: CropAspectRatioPreset.original,
           lockAspectRatio: false,
+          aspectRatioPresets: [
+            CropAspectRatioPreset.square,
+            CropAspectRatioPreset.original,
+          ],
         ),
         IOSUiSettings(
           minimumAspectRatio: 1.0,
@@ -68,10 +52,3 @@ Future<File?> cropImage({required File imageFile}) async {
   return null;
 }
 ```
-
-
-
-
-
-
-

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -4203,8 +4203,6 @@ class MockImageCropper extends _i2.Mock implements _i39.ImageCropper {
             #maxWidth: maxWidth,
             #maxHeight: maxHeight,
             #aspectRatio: aspectRatio,
-            #aspectRatioPresets: aspectRatioPresets,
-            #cropStyle: cropStyle,
             #compressFormat: compressFormat,
             #compressQuality: compressQuality,
             #uiSettings: uiSettings,

--- a/test/service_tests/image_service_test.dart
+++ b/test/service_tests/image_service_test.dart
@@ -43,10 +43,6 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          // aspectRatioPresets: [
-          //   CropAspectRatioPreset.square,
-          //   CropAspectRatioPreset.original,
-          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenAnswer((realInvocation) async => croppedFile);
@@ -63,10 +59,6 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          // aspectRatioPresets: [
-          //   CropAspectRatioPreset.square,
-          //   CropAspectRatioPreset.original,
-          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenThrow(Exception());

--- a/test/service_tests/image_service_test.dart
+++ b/test/service_tests/image_service_test.dart
@@ -43,10 +43,10 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          aspectRatioPresets: [
-            CropAspectRatioPreset.square,
-            CropAspectRatioPreset.original,
-          ],
+          // aspectRatioPresets: [
+          //   CropAspectRatioPreset.square,
+          //   CropAspectRatioPreset.original,
+          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenAnswer((realInvocation) async => croppedFile);
@@ -63,10 +63,10 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          aspectRatioPresets: [
-            CropAspectRatioPreset.square,
-            CropAspectRatioPreset.original,
-          ],
+          // aspectRatioPresets: [
+          //   CropAspectRatioPreset.square,
+          //   CropAspectRatioPreset.original,
+          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenThrow(Exception());

--- a/test/service_tests/multi_media_pick_service_test.dart
+++ b/test/service_tests/multi_media_pick_service_test.dart
@@ -41,10 +41,6 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          // aspectRatioPresets: [
-          //   CropAspectRatioPreset.square,
-          //   CropAspectRatioPreset.original,
-          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenAnswer((realInvocation) async => CroppedFile(path));
@@ -65,10 +61,6 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          // aspectRatioPresets: [
-          //   CropAspectRatioPreset.square,
-          //   CropAspectRatioPreset.original,
-          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenAnswer((realInvocation) async => CroppedFile(path));

--- a/test/service_tests/multi_media_pick_service_test.dart
+++ b/test/service_tests/multi_media_pick_service_test.dart
@@ -41,10 +41,10 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          aspectRatioPresets: [
-            CropAspectRatioPreset.square,
-            CropAspectRatioPreset.original,
-          ],
+          // aspectRatioPresets: [
+          //   CropAspectRatioPreset.square,
+          //   CropAspectRatioPreset.original,
+          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenAnswer((realInvocation) async => CroppedFile(path));
@@ -65,10 +65,10 @@ void main() {
       when(
         mockImageCropper.cropImage(
           sourcePath: "test",
-          aspectRatioPresets: [
-            CropAspectRatioPreset.square,
-            CropAspectRatioPreset.original,
-          ],
+          // aspectRatioPresets: [
+          //   CropAspectRatioPreset.square,
+          //   CropAspectRatioPreset.original,
+          // ],
           uiSettings: anyNamed('uiSettings'),
         ),
       ).thenAnswer((realInvocation) async => CroppedFile(path));


### PR DESCRIPTION
**Upgrading `image_cropper` 5.0.1 to 8.0.2**

It involve  changes involve reorganizing the `aspectRatioPresets `configuration within the `ImageService` class, moving it from the `cropImage` method to the `AndroidUiSettings` and `IOSUiSettings` . The pubspec.yaml file has been updated to upgrade the `image_cropper`. Additionally, test files have been modified to  removing the `aspectRatioPresets` parameter in the `mockImageCropper.cropImage` method calls, simplifying the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the image cropping functionality to enhance organization and clarity in the code.
	- Upgraded the `image_cropper` package for potential new features and improvements.
  
- **Bug Fixes**
	- Addressed compatibility issues with the `intl` package through dependency overrides.

- **Documentation**
	- Streamlined documentation for the `cropImage` method for improved clarity. 

- **Tests**
	- Simplified test cases by removing unnecessary parameters related to aspect ratio presets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->