### PR TITLE
Test: added tests for `lib/views/after_auth_screens/feed/organization_feed.dart`

### DIFF
--- a/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
+++ b/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
@@ -315,15 +315,18 @@ void main() {
         await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
         await tester.pumpAndSettle();
 
-        // Simulate Drag
+        // Simulate Scroll within content (not at edge)
         await tester.drag(
           find.byKey(const Key('listView')),
           const Offset(0, -200),
         );
         await tester.pumpAndSettle();
 
-        // Verify that counters are reset
+        // Verify that counters are reset and loading state
         expect(find.byType(CircularProgressIndicator), findsNothing);
+
+        verifyNever(mockViewModel.nextPage());
+        verifyNever(mockViewModel.previousPage());
       },
     );
   });

--- a/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
+++ b/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
@@ -285,5 +285,24 @@ void main() {
       verify(mockViewModel.nextPage()).called(1);
       verify(mockViewModel.previousPage()).called(1);
     });
+
+    testWidgets(
+      'check if FloatingActionButton click works fine',
+      (tester) async {
+        // Arrange
+        final model = locator<MainScreenViewModel>();
+        await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
+        await tester.pumpAndSettle();
+        
+        // Simulate Tap
+        final fabFinder = find.byKey(const Key('floating_action_btn'));
+        expect(fabFinder, findsOneWidget);
+        await tester.tap(fabFinder);
+
+        // Verify the /addpostscreen is pushed
+        await tester.pump();
+        verify(locator<NavigationService>().pushScreen('/addpostscreen'));
+      },
+    );
   });
 }

--- a/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
+++ b/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
@@ -304,5 +304,27 @@ void main() {
         verify(locator<NavigationService>().pushScreen('/addpostscreen'));
       },
     );
+
+    testWidgets(
+        'check if counters reset when scrolling occurs anywhere other than at the edge',
+        (tester) async {
+        // Arrange
+        when(mockViewModel.posts)
+            .thenReturn([post, post, post, post, post, post]);
+        final model = locator<MainScreenViewModel>();
+        await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
+        await tester.pumpAndSettle();
+
+        // Simulate Drag
+        await tester.drag(
+          find.byKey(const Key('listView')),
+          const Offset(0, -200),
+        );
+        await tester.pumpAndSettle();
+
+        // Verify that counters are reset
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      },
+    );
   });
 }

--- a/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
+++ b/test/widget_tests/after_auth_screens/feed/organization_feed_test.dart
@@ -286,48 +286,44 @@ void main() {
       verify(mockViewModel.previousPage()).called(1);
     });
 
-    testWidgets(
-      'check if FloatingActionButton click works fine',
-      (tester) async {
-        // Arrange
-        final model = locator<MainScreenViewModel>();
-        await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
-        await tester.pumpAndSettle();
-        
-        // Simulate Tap
-        final fabFinder = find.byKey(const Key('floating_action_btn'));
-        expect(fabFinder, findsOneWidget);
-        await tester.tap(fabFinder);
+    testWidgets('check if FloatingActionButton click works fine',
+        (tester) async {
+      // Arrange
+      final model = locator<MainScreenViewModel>();
+      await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
+      await tester.pumpAndSettle();
 
-        // Verify the /addpostscreen is pushed
-        await tester.pump();
-        verify(locator<NavigationService>().pushScreen('/addpostscreen'));
-      },
-    );
+      // Simulate Tap
+      final fabFinder = find.byKey(const Key('floating_action_btn'));
+      expect(fabFinder, findsOneWidget);
+      await tester.tap(fabFinder);
+
+      // Verify the /addpostscreen is pushed
+      await tester.pump();
+      verify(locator<NavigationService>().pushScreen('/addpostscreen'));
+    });
 
     testWidgets(
         'check if counters reset when scrolling occurs anywhere other than at the edge',
         (tester) async {
-        // Arrange
-        when(mockViewModel.posts)
-            .thenReturn([post, post, post, post, post, post]);
-        final model = locator<MainScreenViewModel>();
-        await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
-        await tester.pumpAndSettle();
+      // Arrange
+      when(mockViewModel.posts)
+          .thenReturn([post, post, post, post, post, post]);
+      final model = locator<MainScreenViewModel>();
+      await tester.pumpWidget(createOrganizationFeedScreen(homeModel: model));
+      await tester.pumpAndSettle();
 
-        // Simulate Scroll within content (not at edge)
-        await tester.drag(
-          find.byKey(const Key('listView')),
-          const Offset(0, -200),
-        );
-        await tester.pumpAndSettle();
+      // Simulate Scroll within content (not at edge)
+      await tester.drag(
+        find.byKey(const Key('listView')),
+        const Offset(0, -200),
+      );
+      await tester.pumpAndSettle();
 
-        // Verify that counters are reset and loading state
-        expect(find.byType(CircularProgressIndicator), findsNothing);
-
-        verifyNever(mockViewModel.nextPage());
-        verifyNever(mockViewModel.previousPage());
-      },
-    );
+      // Verify that counters are reset and loading state
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      verifyNever(mockViewModel.nextPage());
+      verifyNever(mockViewModel.previousPage());
+    });
   });
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Unittest for `lib/views/after_auth_screens/feed/organization_feed.dart`

**Issue Number:**

Fixes #2622 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/1d2e90ea-4454-4add-8079-5f4adb93baa9)

![image](https://github.com/user-attachments/assets/270dfce9-d471-42cc-839c-639824fd3d5e)

**Summary**

This PR includes unit tests for `lib/views/after_auth_screens/feed/organization_feed.dart`

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Introduced new test cases for the OrganizationFeed widget to enhance testing coverage.
		- Verified that the Floating Action Button correctly navigates to the add post screen.
		- Assessed UI behavior when scrolling, ensuring counters reset properly without displaying loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->