### PR TITLE
add Unittests for lib/widgets/event_card.dart

### DIFF
--- a/test/widget_tests/widgets/event_card_test.dart
+++ b/test/widget_tests/widgets/event_card_test.dart
@@ -65,6 +65,10 @@ void main() {
     testSetupLocator();
   });
 
+  tearDown(() {
+    userConfig.currentUser.id = null;
+  });
+
   group("Test for EventCard widget", () {
     testWidgets('Check if Event Card shows up', (tester) async {
       mockNetworkImages(() async {
@@ -211,13 +215,14 @@ void main() {
       });
     });
 
-    testWidgets('Check for absence of Created Row for non-creators',
+    testWidgets(
+        'should not show Created row and verified icon when current user is not the event creator',
         (tester) async {
       mockNetworkImages(() async {
         final event = getEvent();
         userConfig.currentUser.id = "nonCreatorId";
         await tester.pumpWidget(createCustomEventCard(event));
-        await tester.pumpAndSettle();
+        await tester.pump();
         final BuildContext ctx = tester.element(find.byType(EventCard));
         expect(find.byIcon(Icons.verified), findsNothing);
         expect(

--- a/test/widget_tests/widgets/event_card_test.dart
+++ b/test/widget_tests/widgets/event_card_test.dart
@@ -195,5 +195,36 @@ void main() {
         expect(find.text("1"), findsOneWidget);
       });
     });
+
+    testWidgets('Check for Created Row visibility', (tester) async {
+      mockNetworkImages(() async {
+        final event = getEvent();
+        userConfig.currentUser.id = event.creator!.id;
+        await tester.pumpWidget(createCustomEventCard(event));
+        await tester.pump();
+        final BuildContext ctx = tester.element(find.byType(EventCard));
+        expect(find.byIcon(Icons.verified), findsOneWidget);
+        expect(
+          find.text(AppLocalizations.of(ctx)!.strictTranslate('Created')),
+          findsOneWidget,
+        );
+      });
+    });
+
+    testWidgets('Check for absence of Created Row for non-creators',
+        (tester) async {
+      mockNetworkImages(() async {
+        final event = getEvent();
+        userConfig.currentUser.id = "nonCreatorId";
+        await tester.pumpWidget(createCustomEventCard(event));
+        await tester.pumpAndSettle();
+        final BuildContext ctx = tester.element(find.byType(EventCard));
+        expect(find.byIcon(Icons.verified), findsNothing);
+        expect(
+          find.text(AppLocalizations.of(ctx)!.strictTranslate('Created')),
+          findsNothing,
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
What kind of change does this PR introduce?

Unittests for lib/widgets/event_card.dart

Issue Number:

Fixes https://github.com/PalisadoesFoundation/talawa/issues/2618

Did you add tests for your changes?

Yes

Snapshots/Videos:
![Screenshot 2024-12-17 222343](https://github.com/user-attachments/assets/816dbed7-1cc6-437b-8ceb-34ad2e04f652)

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added test cases for the `EventCard` widget to verify visibility of the "Created" row based on the current user's status as the event creator.
	- Ensured correct behavior of the "Created" row and verified icon when the current user is not the event creator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->