### PR TITLE
 Update GitHub Actions Workflow to Use Java Version "17.0"

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '12.0'
+          java-version: '17.0'
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.22.3'
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '12.0'          
+          java-version: '17.0'          
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.22.3'
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '12.0'          
+          java-version: '17.0'          
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.22.3'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- updated push.yml to java-version "17.0"

**Issue Number:**

- Fixes #2679 

**Did you add tests for your changes?**

- No (not required)

**Does this PR introduce a breaking change?**

- No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?**

- Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use Java 17 across multiple jobs, replacing the previous Java 12 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->