### PR TITLE
Pull Request for Unit Tests of `edit_agenda_item_page.dart`

### DIFF
--- a/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
@@ -139,5 +139,30 @@ void main() {
       await tester.tap(find.text('Add Attachments'));
       await tester.pumpAndSettle();
     });
+
+    testWidgets('Remove a selected category', (WidgetTester tester) async {
+      await tester.pumpWidget(createEditAgendaItemScreen());
+      await tester.pumpAndSettle();
+
+      // Step 1: Select a category
+      await tester.tap(find.byType(DropdownButtonFormField<AgendaCategory>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Category 1').last);
+      await tester.pumpAndSettle();
+
+      // Verify the category was added
+      expect(find.byKey(const Key('Category 1')), findsOneWidget);
+
+      // Step 2: Remove the selected category
+      await tester.tap(find.byType(DropdownButtonFormField<AgendaCategory>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Category 1').last);
+      await tester.pumpAndSettle();
+
+      // Verify the category was removed
+      expect(find.byKey(const Key('Category 1')), findsNothing);
+    });
   });
 }

--- a/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: talawa_api_doc
 
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -226,7 +228,9 @@ void main() {
     });
 
     testWidgets('Agenda Item Title Validation', (WidgetTester tester) async {
-      // Build the widget
+      // Title validation rules:
+      // - Must not be empty
+      // - Must contain at least one letter (A-Z or a-z)
       await tester.pumpWidget(createEditAgendaItemScreen());
       await tester.pumpAndSettle();
 
@@ -244,7 +248,7 @@ void main() {
       // Verify the error message for an empty title
       expect(find.text('Title must not be left blank.'), findsOneWidget);
 
-      // Simulate user entering an invalid title and trigger validation
+      // Simulate user entering an invalid title (numbers only) and trigger validation
       await tester.enterText(titleField, '12345');
       await tester.pumpAndSettle();
       final invalidFieldState =
@@ -254,11 +258,24 @@ void main() {
 
       // Verify the error message for an invalid title
       expect(find.text('Invalid Title'), findsOneWidget);
+
+      // Simulate user entering a valid title and trigger validation
+      await tester.enterText(titleField, 'Team Meeting');
+      await tester.pumpAndSettle();
+      final validFieldState = tester.state<FormFieldState<String>>(titleField);
+      validFieldState.validate();
+      await tester.pumpAndSettle();
+
+      // Verify no error message is shown for valid title
+      expect(find.text('Invalid Title'), findsNothing);
+      expect(find.text('Title must not be left blank.'), findsNothing);
     });
 
     testWidgets('Agenda Item Description Validation',
         (WidgetTester tester) async {
-      // Build the widget
+      // Description validation rules:
+      // - Must not be empty
+      // - Must contain valid characters (add specific rules here)
       await tester.pumpWidget(createEditAgendaItemScreen());
       await tester.pumpAndSettle();
 
@@ -266,7 +283,7 @@ void main() {
       final descriptionField = find.byKey(const Key('edit_event_agenda_tf2'));
       expect(descriptionField, findsOneWidget);
 
-      // Simulate user entering empty text and trigger validation
+      // Simulate user entering an invalid description and trigger validation
       await tester.enterText(descriptionField, '');
       await tester.pumpAndSettle();
       final emptyFieldState =
@@ -287,6 +304,15 @@ void main() {
 
       // Verify the error message for an invalid description
       expect(find.text('Invalid Description'), findsOneWidget);
+
+      // Test valid description
+      await tester.enterText(descriptionField, 'Valid Description');
+      await tester.pumpAndSettle();
+      final validFieldState =
+          tester.state<FormFieldState<String>>(descriptionField);
+      validFieldState.validate();
+      await tester.pumpAndSettle();
+      expect(find.text('Invalid Description'), findsNothing);
     });
   });
 }

--- a/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: talawa_api_doc
 
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/edit_agenda_item_page_test.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: talawa_api_doc
-import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -10,7 +9,6 @@ import 'package:talawa/router.dart' as router;
 import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
-import 'package:talawa/utils/validators.dart';
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/edit_agenda_view_model.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
 import 'package:talawa/views/after_auth_screens/events/edit_agenda_item_page.dart';


### PR DESCRIPTION
## **Increasing Code coverage of Unit Tests of `edit_agenda_item_page.dart`**

This PR covers the uncovered line of unit test for   `edit_agenda_item_page.dart` 

Issue: #2613 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Added a new test case for removing a selected category in the Edit Agenda Item page.
	- Improved test coverage for category selection functionality.
	- Added tests for user input validation in the duration, title, and description fields, ensuring appropriate error messages are displayed for empty and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->