### PR TITLE
Migrate from deprecated uni_links to app_links package

### DIFF
--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:talawa/constants/routing_constants.dart';
@@ -8,7 +9,6 @@ import 'package:talawa/locator.dart';
 import 'package:talawa/models/mainscreen_navigation_args.dart';
 import 'package:talawa/services/size_config.dart';
 import 'package:talawa/utils/app_localization.dart';
-import 'package:uni_links/uni_links.dart';
 
 /// This widget return the SplashScreen. Splash Screen is the first screen that we see when we run our application. It is also known as Launch Screen.
 class SplashScreen extends StatefulWidget {
@@ -43,7 +43,9 @@ class _SplashScreenState extends State<SplashScreen> {
   /// **returns**:
   ///   None
   Future<void> _handleInitialUri() async {
-    _sub = uriLinkStream.listen(
+    final appLinks = AppLinks();
+
+    _sub = appLinks.uriLinkStream.listen(
       (Uri? uri) {
         // After creating a State object and before calling initState, the framework
         // "mounts" the State object by associating it with a BuildContext.
@@ -61,7 +63,7 @@ class _SplashScreenState extends State<SplashScreen> {
     );
     try {
       // Retrieving the initial URI from getInitialUri function.
-      final uri = await getInitialUri();
+      final uri = await appLinks.getInitialLink();
       if (!mounted) return;
       setState(() => _initialUri = uri);
     } on PlatformException {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.3"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "433df2e61b10519407475d7f69e470789d23d593f28224c38ba1068597be7950"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: "direct main"
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   args:
     dependency: transitive
     description:
@@ -357,10 +389,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   file:
     dependency: "direct main"
     description:
@@ -693,6 +725,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   hive:
     dependency: "direct main"
     description:
@@ -881,18 +921,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -929,18 +969,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1485,10 +1525,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timelines:
     dependency: "direct main"
     description:
@@ -1529,30 +1569,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
-  uni_links:
-    dependency: "direct main"
-    description:
-      name: uni_links
-      sha256: "051098acfc9e26a9fde03b487bef5d3d228ca8f67693480c6f33fd4fbb8e2b6e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1"
-  uni_links_platform_interface:
-    dependency: "direct main"
-    description:
-      name: uni_links_platform_interface
-      sha256: "929cf1a71b59e3b7c2d8a2605a9cf7e0b125b13bc858e55083d88c62722d4507"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  uni_links_web:
-    dependency: transitive
-    description:
-      name: uni_links_web
-      sha256: "7539db908e25f67de2438e33cc1020b30ab94e66720b5677ba6763b25f6394df"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1682,13 +1698,13 @@ packages:
     source: hosted
     version: "2.9.2"
   video_player_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: video_player_android
-      sha256: "7f8f25d7ad56819a82b2948357f3c3af071f6a678db33833b26ec36bbc221316"
+      sha256: "391e092ba4abe2f93b3e625bd6b6a6ec7d7414279462c1c0ee42b5ab8d0a0898"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.7.16"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -1725,10 +1741,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -1754,13 +1770,13 @@ packages:
     source: hosted
     version: "2.4.0"
   win32:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: win32
-      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
+      sha256: "154360849a56b7b67331c21f09a386562d88903f90a1099c5987afc1912e1f29"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.10.0"
   win32_registry:
     dependency: transitive
     description:
@@ -1794,5 +1810,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <=3.4.4"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <=3.6.0"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ homepage: https://github.com/PalisadoesFoundation/talawa
 
 repository: https://github.com/PalisadoesFoundation/talawa
 environment:
-  sdk: ">=2.17.0 <=3.4.4"
+  sdk: ">=2.17.0 <=3.6.0"
 
 dependencies:
   ############# Remove ###########
@@ -18,7 +18,8 @@ dependencies:
   # analyzer:
   # analyzer_plugin:
   ################################
-
+  app_links: ^6.3.3
+  app_links_platform_interface: ^2.0.2
   auto_size_text: ^3.0.0
   cached_network_image: ^3.4.1
   clock: ^1.1.1
@@ -72,12 +73,12 @@ dependencies:
   syncfusion_flutter_datepicker: ^27.2.5
   timelines: ^0.1.0
   tutorial_coach_mark: ^1.2.12
-  uni_links: ^0.5.1
-  uni_links_platform_interface: ^1.0.0
   url_launcher: ^6.3.1
   vibration: ^2.0.1
   video_player: ^2.9.2
+  video_player_android: ^2.7.16
   visibility_detector: ^0.4.0+2
+  win32: ^5.10.0
 
 dev_dependencies:
   build_runner: ^2.4.11

--- a/test/widget_tests/pre_auth_screens/splash_screen_test.dart
+++ b/test/widget_tests/pre_auth_screens/splash_screen_test.dart
@@ -3,6 +3,7 @@
 
 // ignore_for_file: unused_import
 
+import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,7 +16,6 @@ import 'package:talawa/splash_screen.dart';
 import 'package:talawa/utils/app_localization.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
 import 'package:talawa/views/base_view.dart';
-import 'package:uni_links/uni_links.dart';
 
 Widget createSplashScreenLight({ThemeMode themeMode = ThemeMode.light}) =>
     BaseView<AppLanguage>(
@@ -228,14 +228,14 @@ Future<void> main() async {
 }
 
 // Added the following test cases
-
+final appLinks = AppLinks();
 Future<void> testWidgets1(WidgetTester tester) async {
   await tester.pumpWidget(createSplashScreenLight());
   await tester.pumpAndSettle();
 
   // Mock the uriLinkStream to emit a test URI
   final testUri = Uri.parse("https://example.com");
-  uriLinkStream.any(testUri as bool Function(Uri? element));
+  appLinks.uriLinkStream.any(testUri as bool Function(Uri? element));
 
   // Wait for the URI to be handled
   await tester.pumpAndSettle();
@@ -267,7 +267,7 @@ Future<void> testWidgets3(WidgetTester tester) async {
 
   // Mock the uriLinkStream to emit a test URI
   final testUri = Uri.parse("https://example.com");
-  uriLinkStream.any(testUri as bool Function(Uri? element));
+  appLinks.uriLinkStream.any(testUri as bool Function(Uri? element));
 
   // Wait for the URI to be handled
   await tester.pumpAndSettle();
@@ -299,7 +299,7 @@ Future<void> testWidgets5(WidgetTester tester) async {
 
   // Mock the initial URI to be a test URI
   final testUri = Uri.parse("https://example.com");
-  when(getInitialUri()).thenAnswer((_) async => testUri);
+  when(appLinks.getInitialLink()).thenAnswer((_) async => testUri);
 
   // Wait for the initial URI to be handled
   await tester.pumpAndSettle();


### PR DESCRIPTION
### What kind of change does this PR introduce?

- This PR migrates our deep linking implementation from the deprecated uni_links package to the actively maintained app_links package. 

### Issue Number:

- Fixes #2706 

### Did you add tests for your changes?

- Yes

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

### Summary
- Updated pubspec.yaml dependencies
- Refactored deep link handlers to use app_links API
- Maintained existing deep linking behavior and user flow
- No changes to Android/iOS configurations required

### Does this PR introduce a breaking change?

- No

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

- Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated SDK version compatibility
	- Replaced `uni_links` package with `app_links`
	- Added new dependencies: `video_player_android` and `win32`

- **Deep Link Handling**
	- Migrated deep link functionality to use `app_links` package
	- Updated URI link stream and initial link retrieval methods

- **Testing**
	- Updated test cases to support new deep link package
	- Enhanced test coverage for splash screen URI handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->