### PR TITLE
Increased test coverage for create_agenda_item_page

### DIFF
--- a/lib/views/after_auth_screens/events/create_agenda_item_page.dart
+++ b/lib/views/after_auth_screens/events/create_agenda_item_page.dart
@@ -23,11 +23,11 @@ class CreateAgendaItemPage extends StatefulWidget {
   final EventInfoViewModel model;
 
   @override
-  _CreateAgendaItemPageState createState() => _CreateAgendaItemPageState();
+  CreateAgendaItemPageState createState() => CreateAgendaItemPageState();
 }
 
 /// State class for [CreateAgendaItemPage].
-class _CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
+class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
   /// Controller for the agenda item title input field.
   TextEditingController titleController = TextEditingController();
 
@@ -167,6 +167,45 @@ class _CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
     });
   }
 
+  /// Validates the event description.
+  ///
+  /// **params**:
+  /// * `value`: The value of the description to be validated.
+  ///
+  /// **returns**:
+  /// * `String?`: Error message if the description is invalid, otherwise null.
+  String? descriptionValidator(String? value) {
+    return Validator.validateEventForm(value!, 'Description');
+  }
+
+  /// Validates the event title.
+  ///
+  /// **params**:
+  /// * `value`: The value of the title to be validated.
+  ///
+  /// **returns**:
+  /// * `String?`: Error message if the title is invalid, otherwise null.
+  String? titleValidator(String? value) {
+    return Validator.validateEventForm(value!, 'Title');
+  }
+
+  /// Validates the event duration.
+  ///
+  /// **params**:
+  /// * `context`: The BuildContext used for localization.
+  /// * `value`: The value of the duration to be validated.
+  ///
+  /// **returns**:
+  /// * `String?`: Error message if the duration is invalid, otherwise null.
+  String? durationValidator(BuildContext context, String? value) {
+    if (value == null || value.isEmpty) {
+      return AppLocalizations.of(context)!
+          .strictTranslate('Please enter a duration');
+    }
+
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final navigationServiceLocal = locator<NavigationService>();
@@ -176,7 +215,7 @@ class _CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
         elevation: 1,
         centerTitle: true,
         leading: GestureDetector(
-          onTap: () => navigationServiceLocal.pop(),
+          onTap: navigationServiceLocal.pop,
           child: const Icon(Icons.close),
         ),
         title: Text(
@@ -266,8 +305,7 @@ class _CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                   keyboardType: TextInputType.name,
                   maxLength: 20,
                   focusNode: titleFocus,
-                  validator: (value) =>
-                      Validator.validateEventForm(value!, 'Title'),
+                  validator: titleValidator,
                   decoration: InputDecoration(
                     labelText: AppLocalizations.of(context)!
                         .strictTranslate('Add Agenda Item Title'),
@@ -295,8 +333,7 @@ class _CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                   keyboardType: TextInputType.multiline,
                   controller: descController,
                   focusNode: descFocus,
-                  validator: (value) =>
-                      Validator.validateEventForm(value!, 'Description'),
+                  validator: descriptionValidator,
                   maxLines: 10,
                   minLines: 1,
                   decoration: InputDecoration(
@@ -345,14 +382,7 @@ class _CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                       ),
                     ),
                   ),
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return AppLocalizations.of(context)!
-                          .strictTranslate('Please enter a duration');
-                    }
-                    // Add additional validation for mm:ss format if needed
-                    return null;
-                  },
+                  validator: (value) => durationValidator(context, value),
                 ),
                 SizedBox(height: SizeConfig.screenHeight! * 0.013),
                 Row(

--- a/lib/views/after_auth_screens/events/create_agenda_item_page.dart
+++ b/lib/views/after_auth_screens/events/create_agenda_item_page.dart
@@ -436,6 +436,7 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                 ),
                 SizedBox(height: SizeConfig.screenHeight! * 0.013),
                 ElevatedButton.icon(
+                  key: const Key('addAttachmentButton'),
                   onPressed: () => _pickAttachment(fromCamera: false),
                   icon: const Icon(Icons.attach_file),
                   label: Text(
@@ -472,10 +473,10 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                           ),
                         ),
                         Positioned(
-                          key: Key('attachmentCloseButton_$index'),
                           top: 0,
                           right: 0,
                           child: GestureDetector(
+                            key: Key('attachmentCloseButton_$index'),
                             onTap: () => _removeAttachment(base64String),
                             child: Container(
                               padding: const EdgeInsets.all(4),

--- a/lib/views/after_auth_screens/events/create_agenda_item_page.dart
+++ b/lib/views/after_auth_screens/events/create_agenda_item_page.dart
@@ -350,6 +350,7 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                       return AppLocalizations.of(context)!
                           .strictTranslate('Please enter a duration');
                     }
+                    // Add additional validation for mm:ss format if needed
                     return null;
                   },
                 ),

--- a/lib/views/after_auth_screens/events/create_agenda_item_page.dart
+++ b/lib/views/after_auth_screens/events/create_agenda_item_page.dart
@@ -446,6 +446,7 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                 const Divider(),
                 const SizedBox(height: 10),
                 GridView.builder(
+                  key: const Key('attachmentGridView'),
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -458,9 +459,11 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                     final base64String = attachments[index];
                     final imageData = base64Decode(base64String);
                     return Stack(
+                      key: Key('attachmentItem_$index'),
                       children: [
                         ClipRRect(
                           borderRadius: BorderRadius.circular(8),
+                          key: Key('attachmentImage_$index'),
                           child: Image.memory(
                             imageData,
                             fit: BoxFit.cover,
@@ -469,6 +472,7 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                           ),
                         ),
                         Positioned(
+                          key: Key('attachmentCloseButton_$index'),
                           top: 0,
                           right: 0,
                           child: GestureDetector(

--- a/lib/views/after_auth_screens/events/create_agenda_item_page.dart
+++ b/lib/views/after_auth_screens/events/create_agenda_item_page.dart
@@ -167,45 +167,6 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
     });
   }
 
-  /// Validates the event description.
-  ///
-  /// **params**:
-  /// * `value`: The value of the description to be validated.
-  ///
-  /// **returns**:
-  /// * `String?`: Error message if the description is invalid, otherwise null.
-  String? descriptionValidator(String? value) {
-    return Validator.validateEventForm(value!, 'Description');
-  }
-
-  /// Validates the event title.
-  ///
-  /// **params**:
-  /// * `value`: The value of the title to be validated.
-  ///
-  /// **returns**:
-  /// * `String?`: Error message if the title is invalid, otherwise null.
-  String? titleValidator(String? value) {
-    return Validator.validateEventForm(value!, 'Title');
-  }
-
-  /// Validates the event duration.
-  ///
-  /// **params**:
-  /// * `context`: The BuildContext used for localization.
-  /// * `value`: The value of the duration to be validated.
-  ///
-  /// **returns**:
-  /// * `String?`: Error message if the duration is invalid, otherwise null.
-  String? durationValidator(BuildContext context, String? value) {
-    if (value == null || value.isEmpty) {
-      return AppLocalizations.of(context)!
-          .strictTranslate('Please enter a duration');
-    }
-
-    return null;
-  }
-
   @override
   Widget build(BuildContext context) {
     final navigationServiceLocal = locator<NavigationService>();
@@ -305,7 +266,8 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                   keyboardType: TextInputType.name,
                   maxLength: 20,
                   focusNode: titleFocus,
-                  validator: titleValidator,
+                  validator: (value) =>
+                      Validator.validateEventForm(value!, 'Title'),
                   decoration: InputDecoration(
                     labelText: AppLocalizations.of(context)!
                         .strictTranslate('Add Agenda Item Title'),
@@ -333,7 +295,8 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                   keyboardType: TextInputType.multiline,
                   controller: descController,
                   focusNode: descFocus,
-                  validator: descriptionValidator,
+                  validator: (value) =>
+                      Validator.validateEventForm(value!, 'Description'),
                   maxLines: 10,
                   minLines: 1,
                   decoration: InputDecoration(
@@ -382,7 +345,13 @@ class CreateAgendaItemPageState extends State<CreateAgendaItemPage> {
                       ),
                     ),
                   ),
-                  validator: (value) => durationValidator(context, value),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return AppLocalizations.of(context)!
+                          .strictTranslate('Please enter a duration');
+                    }
+                    return null;
+                  },
                 ),
                 SizedBox(height: SizeConfig.screenHeight! * 0.013),
                 Row(

--- a/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
@@ -150,11 +150,11 @@ void main() {
         data: {
           'agendaItemCategoriesByOrganization': [
             {
-              'id': '1',
+              '_id': '1',
               'name': 'Category 1',
             },
             {
-              'id': '2',
+              '_id': '2',
               'name': 'Category 2',
             },
           ],
@@ -188,11 +188,11 @@ void main() {
         data: {
           'agendaItemCategoriesByOrganization': [
             {
-              'id': '1',
+              '_id': '1',
               'name': 'Category 1',
             },
             {
-              'id': '2',
+              '_id': '2',
               'name': 'Category 2',
             },
           ],
@@ -212,42 +212,17 @@ void main() {
 
       await tester.tap(find.byType(DropdownButtonFormField<AgendaCategory>));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Category 1').last);
+      await tester.tap(find.text('Category 1').first);
       await tester.pumpAndSettle();
 
       expect(find.byType(Chip), findsOneWidget);
       expect(find.text('Category 1'), findsNWidgets(2));
-
-      final CreateAgendaItemPageState state =
-          tester.state(find.byType(CreateAgendaItemPage));
-      final prevSize = state.selectedCategories.length;
-
-      expect(state.selectedCategories.first.name, 'Category 1');
-      await tester.tap(
-        find
-            .descendant(
-              of: find.byWidgetPredicate(
-                (widget) =>
-                    widget is Chip &&
-                    widget.label is Text &&
-                    (widget.label as Text).data == 'Category 1',
-              ),
-              matching: find.byType(GestureDetector),
-            )
-            .last,
-      );
+      await tester.tap(find.byType(DropdownButtonFormField<AgendaCategory>));
       await tester.pumpAndSettle();
-      expect(
-        state.selectedCategories.contains(
-          AgendaCategory(
-            id: "1",
-            name: 'Category 1',
-          ),
-        ),
-        false,
-      );
-      expect(state.selectedCategories.length, prevSize - 1);
+      await tester.tap(find.text('Category 1').first, warnIfMissed: false);
+      await tester.pumpAndSettle();
       expect(find.byType(Chip), findsNothing);
+      expect(find.text('Category 1'), findsNothing);
     });
 
     testWidgets('Add button works correctly', (WidgetTester tester) async {

--- a/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
@@ -284,7 +284,45 @@ void main() {
       expect(find.byType(Chip), findsNothing);
       expect(find.text('https://example.com'), findsNothing);
     });
+    testWidgets('Deletes category chip on delete icon tap',
+        (WidgetTester tester) async {
+      final mockResult = QueryResult(
+        source: QueryResultSource.network,
+        data: {
+          'agendaItemCategoriesByOrganization': [
+            {
+              '_id': '1',
+              'name': 'Category 1',
+            },
+            {
+              '_id': '2',
+              'name': 'Category 2',
+            },
+          ],
+        },
+        options: QueryOptions(
+          document: gql(
+            EventQueries().fetchAgendaItemCategoriesByOrganization('XYZ'),
+          ),
+        ),
+      );
 
+      when(eventService.fetchAgendaCategories("XYZ"))
+          .thenAnswer((_) async => mockResult);
+      await tester.pumpWidget(createCreateAgendaItemScreen());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(DropdownButtonFormField<AgendaCategory>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Category 1').last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Chip), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.cancel));
+      await tester.pumpAndSettle();
+      expect(find.byType(Chip), findsNothing);
+    });
     testWidgets('Add Attachments button is present',
         (WidgetTester tester) async {
       await tester.pumpWidget(createCreateAgendaItemScreen());

--- a/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
@@ -181,7 +181,7 @@ void main() {
       expect(find.text('Category 1'), findsNWidgets(2));
     });
 
-    testWidgets('Category deselection works correctly',
+    testWidgets('Removing category from selected categories works correctly',
         (WidgetTester tester) async {
       final mockResult = QueryResult(
         source: QueryResultSource.network,

--- a/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
@@ -234,7 +234,6 @@ void main() {
             .last,
       );
       await tester.pumpAndSettle();
-
       expect(state.selectedCategories.length, prevSize - 1);
       expect(find.byType(Chip), findsNothing);
     });
@@ -393,110 +392,45 @@ void main() {
       expect(find.byKey(const Key('attachmentItem_1')), findsNothing);
     });
   });
-  group("description Validator", () {
-    testWidgets('should return null if description is valid',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(
-        createCreateAgendaItemScreen(),
-      );
-      await tester.pumpAndSettle();
+  testWidgets('Description field validation works correctly',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(createCreateAgendaItemScreen());
+    await tester.pumpAndSettle();
 
-      final CreateAgendaItemPageState state =
-          tester.state(find.byType(CreateAgendaItemPage));
-      state.titleController.text = 'Valid Title';
-
-      expect(state.descriptionValidator('Valid Description'), null);
-    });
-
-    test('should return error message if description is invalid - empty', () {
-      final state = CreateAgendaItemPageState();
-      expect(
-        state.descriptionValidator(''),
-        'Description must not be left blank.',
-      );
-    });
-
-    test('should return error message if description is invalid - no letters',
-        () {
-      final state = CreateAgendaItemPageState();
-      expect(state.descriptionValidator('123'), 'Invalid Description');
-    });
+    final validator = tester
+        .widget<TextFormField>(
+          find.byKey(const Key('create_event_agenda_tf2')),
+        )
+        .validator;
+    expect(validator?.call(''), 'Description must not be left blank.');
+    expect(validator?.call('123'), 'Invalid Description');
+    expect(validator?.call('Valid Description'), null);
   });
+  testWidgets('Title field validation works correctly',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(createCreateAgendaItemScreen());
+    await tester.pumpAndSettle();
 
-  group('titleValidator', () {
-    test('should return null if title is valid', () {
-      final state = CreateAgendaItemPageState();
-      expect(state.titleValidator('Valid Title'), null);
-    });
-
-    test('should return error message if title is invalid - empty', () {
-      final state = CreateAgendaItemPageState();
-      expect(state.titleValidator(''), 'Title must not be left blank.');
-    });
-
-    test('should return error message if title is invalid - no letters', () {
-      final state = CreateAgendaItemPageState();
-      expect(state.titleValidator('123'), 'Invalid Title');
-    });
+    final validator = tester
+        .widget<TextFormField>(
+          find.byKey(const Key('create_event_agenda_tf1')),
+        )
+        .validator;
+    expect(validator?.call(''), 'Title must not be left blank.');
+    expect(validator?.call('123'), 'Invalid Title');
+    expect(validator?.call('Valid Title'), null);
   });
+  testWidgets('Duration field validation works correctly',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(createCreateAgendaItemScreen());
+    await tester.pumpAndSettle();
 
-  group('durationValidator', () {
-    testWidgets(
-        'durationValidator should return error message if duration is empty',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(createCreateAgendaItemScreen());
-      await tester.pumpAndSettle();
-
-      final CreateAgendaItemPageState state =
-          tester.state(find.byType(CreateAgendaItemPage));
-      expect(
-        state.durationValidator(
-          tester.element(find.byType(CreateAgendaItemPage)),
-          '',
-        ),
-        'Please enter a duration',
-      );
-    });
-
-    testWidgets('durationValidator should return null if duration is valid',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(createCreateAgendaItemScreen());
-      await tester.pumpAndSettle();
-
-      final CreateAgendaItemPageState state =
-          tester.state(find.byType(CreateAgendaItemPage));
-      expect(
-        state.durationValidator(
-          tester.element(find.byType(CreateAgendaItemPage)),
-          '01:30',
-        ),
-        null,
-      );
-    });
-    // testWidgets('Duration field validation works correctly',
-    //     (WidgetTester tester) async {
-    //   await tester.pumpWidget(createCreateAgendaItemScreen());
-    //   await tester.pumpAndSettle();
-
-    //   // Empty duration input
-    //   await tester.enterText(
-    //     find.byKey(const Key('create_event_agenda_duration')),
-    //     '',
-    //   );
-    //   await tester.pumpAndSettle();
-
-    //   // Trigger form validation
-    //   final form = find.byType(Form);
-    //   await tester.tap(form);
-    //   await tester.pumpAndSettle();
-
-    //   expect(find.text('Please enter a duration'), findsOneWidget);
-
-    //   // Non-empty duration input
-    //   // await tester.enterText(
-    //   //     find.byKey(const Key('create_event_agenda_duration')), '00:30');
-    //   // await tester.pumpAndSettle();
-    //   // expect(find.text('Please enter a duration'), findsNothing);
-    // });
+    final validator = tester
+        .widget<TextFormField>(
+          find.byKey(const Key('create_event_agenda_duration')),
+        )
+        .validator;
+    expect(validator?.call(''), 'Please enter a duration');
+    expect(validator?.call('00:30'), null);
   });
 }

--- a/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
+++ b/test/views/after_auth_screens/events/create_agenda_item_page_test.dart
@@ -217,9 +217,12 @@ void main() {
 
       expect(find.byType(Chip), findsOneWidget);
       expect(find.text('Category 1'), findsNWidgets(2));
+
       final CreateAgendaItemPageState state =
           tester.state(find.byType(CreateAgendaItemPage));
       final prevSize = state.selectedCategories.length;
+
+      expect(state.selectedCategories.first.name, 'Category 1');
       await tester.tap(
         find
             .descendant(
@@ -234,6 +237,15 @@ void main() {
             .last,
       );
       await tester.pumpAndSettle();
+      expect(
+        state.selectedCategories.contains(
+          AgendaCategory(
+            id: "1",
+            name: 'Category 1',
+          ),
+        ),
+        false,
+      );
       expect(state.selectedCategories.length, prevSize - 1);
       expect(find.byType(Chip), findsNothing);
     });


### PR DESCRIPTION
### What kind of change does this PR introduce?

Unit tests and widget tests to improve test coverage for create_agenda_item_page.

### Issue Number:

Fixes #2611

### Did you add tests for your changes?

Yes

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:

![Screenshot from 2025-02-16 00-30-32](https://github.com/user-attachments/assets/b2b5810f-7d3c-414b-90e4-18887fd65e2c)


### Summary

Test coverage increased from 75.72% to 100%.

### Does this PR introduce a breaking change?

No

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal state management for the agenda creation screen.
  
- **UI Enhancements**
  - Improved interaction reliability for managing attachments, categories, and URLs on the agenda creation page.
  
- **Tests**
  - Expanded test coverage to ensure consistent behavior for attachment handling, category selection, and field validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->