### PR TITLE
fix: display '?' when image URL is null or empty

### DIFF
--- a/lib/widgets/custom_avatar.dart
+++ b/lib/widgets/custom_avatar.dart
@@ -48,7 +48,7 @@ class CustomAvatar extends StatelessWidget {
             maxRadius: maxRadius,
             child: Center(
               child: Text(
-                firstAlphabet!,
+                firstAlphabet ?? '?',
                 style: Theme.of(context).textTheme.bodySmall!.copyWith(
                       fontSize: fontSize,
                       color: Theme.of(context).colorScheme.onSecondary,


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production-ready code lies. Only security-related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

### What kind of change does this PR introduce?

BugFix

### Issue Number:

Fixes #2776 

### Did you add tests for your changes?

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

- [ ] Tests are written for all changes made in this PR.
- [ ] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:

<!--Add snapshots or videos wherever possible.-->

### If relevant, did you update the documentation?

<!--Add link to Talawa-Docs.-->

### Summary

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The PR fixes the issue where if the image url is null the organization info page shows up an error near the profile icon of the admins and members. Instead of showing an error now a ? is shown 

### Does this PR introduce a breaking change?
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

### Other information

<!--Add extra information about this PR here-->

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced avatar display reliability by providing a default placeholder when the initial letter is missing, preventing potential display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->