### PR TITLE
Upgrade build_runner to 2.4.15 and resolve custom lint compatibility issues

### DIFF
--- a/lib/models/organization/org_info.g.dart
+++ b/lib/models/organization/org_info.g.dart
@@ -36,7 +36,7 @@ class OrgInfoAdapter extends TypeAdapter<OrgInfo> {
   @override
   void write(BinaryWriter writer, OrgInfo obj) {
     writer
-      ..writeByte(14)
+      ..writeByte(13)
       ..writeByte(0)
       ..write(obj.image)
       ..writeByte(1)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "64.0.0"
+    version: "76.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.11.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -117,26 +122,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: c9e32d21dd6626b5c163d48b037ce906bbe428bc23ab77bcd77bb21e593b6185
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.11"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -317,34 +322,42 @@ packages:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: dfb893ff17c83cf08676c6b64df11d3e53d80590978d7c1fb242afff3ba6dedb
+      sha256: "3486c470bb93313a9417f926c7dd694a2e349220992d7b9d14534dc49c15bba9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.7.0"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: "8df6634b38a36a6c6cb74a9c0eb02e9ba0b0ab89b29e38e6daa86e8ed2c6288d"
+      sha256: "42cdc41994eeeddab0d7a722c7093ec52bd0761921eeb2cbdbf33d192a234759"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.7.0"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: "2b235be098d157e244f18ea905a15a18c16a205e30553888fac6544bbf52f03f"
+      sha256: "02450c3e45e2a6e8b26c4d16687596ab3c4644dd5792e3313aa9ceba5a49b7f5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.7.0"
+  custom_lint_visitor:
+    dependency: transitive
+    description:
+      name: custom_lint_visitor
+      sha256: bfe9b7a09c4775a587b58d10ebb871d4fe618237639b1e84d5ec62d7dfef25f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+6.11.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
+      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.8"
   dbus:
     dependency: transitive
     description:
@@ -625,10 +638,10 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   get_it:
     dependency: "direct main"
     description:
@@ -957,6 +970,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -1297,10 +1318,10 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1629,10 +1650,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.5.1"
   vector_graphics:
     dependency: transitive
     description:
@@ -1749,10 +1770,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,8 +80,8 @@ dependencies:
   visibility_detector: ^0.4.0+2
 
 dev_dependencies:
-  build_runner: ^2.4.11
-  custom_lint: 0.5.8
+  build_runner: ^2.4.15
+  custom_lint: 0.7.0
   fake_async: ^1.3.1
   flutter_test:
     sdk: flutter

--- a/talawa_lint/lib/helpers.dart
+++ b/talawa_lint/lib/helpers.dart
@@ -147,10 +147,7 @@ bool isPrivate(Token? name) =>
 class TalawaLintHelpers {
   static bool isVoid(Declaration node) {
     return returnType(node) is VoidType ||
-        returnType(node)?.getDisplayString(
-              withNullability: true,
-            ) ==
-            "Future<void>";
+        returnType(node)?.getDisplayString() == "Future<void>";
   }
 
   static bool isImplicitReturn(Declaration node) {

--- a/talawa_lint/lib/talawa_api_doc/talawa_api_doc.dart
+++ b/talawa_lint/lib/talawa_api_doc/talawa_api_doc.dart
@@ -2,7 +2,7 @@
 // ignore_for_file: talawa_good_doc_comments
 // ignore_for_file: depend_on_referenced_packages
 
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' as analyzer;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:talawa_lint/talawa_api_doc/talawa_api_doc_fixer.dart';
@@ -18,7 +18,7 @@ class TalawaApiDocLintRule extends DartLintRule {
     problemMessage: 'No documentation found for this field.',
     correctionMessage: "Add a valid documentation describing usecase.",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   @override

--- a/talawa_lint/lib/talawa_api_doc/talawa_api_doc_visitor.dart
+++ b/talawa_lint/lib/talawa_api_doc/talawa_api_doc_visitor.dart
@@ -35,10 +35,10 @@ class TalawaApiDocVisitor extends SimpleAstVisitor {
         !isMain) {
       final errorNode = getNodeToAnnotate(node);
 
-      reporter.reportErrorForOffset(
-        rule.code,
-        errorNode.offset,
-        errorNode.length,
+      reporter.atOffset(
+        errorCode: rule.code,
+        offset: errorNode.offset,
+        length: errorNode.length,
       );
 
       return true;

--- a/talawa_lint/lib/talawa_good_doc/talawa_good_doc.dart
+++ b/talawa_lint/lib/talawa_good_doc/talawa_good_doc.dart
@@ -2,7 +2,7 @@
 // ignore_for_file: talawa_good_doc_comments
 // ignore_for_file: depend_on_referenced_packages
 
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' as analyzer;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:talawa_lint/talawa_good_doc/talawa_good_doc_visitor.dart';
@@ -18,7 +18,7 @@ class TalawaGoodDocComments extends DartLintRule {
     correctionMessage:
         'Use "/// ..." for public api and "// ..." for other cases.',
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   @override

--- a/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
+++ b/talawa_lint/lib/talawa_good_doc/talawa_good_doc_visitor.dart
@@ -141,9 +141,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
 
     final doc = node.documentationComment!.tokens;
     if (!doc[0].lexeme.endsWith('.')) {
-      reporter.reportErrorForToken(
-        TalawaGoodDocLintRules.firstLineEndCode,
+      reporter.atToken(
         doc[0],
+        TalawaGoodDocLintRules.firstLineEndCode,
       );
     }
 
@@ -155,9 +155,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
 
     if (doc.length == 1) {
       if (node is FunctionDeclaration || node is MethodDeclaration) {
-        reporter.reportErrorForNode(
-          TalawaGoodDocLintRules.includeParamsKeywordCode,
+        reporter.atNode(
           node.documentationComment!,
+          TalawaGoodDocLintRules.includeParamsKeywordCode,
         );
 
         return false;
@@ -175,9 +175,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     //    space at the end when formatted
 
     if (doc[1].lexeme.trim() != '///') {
-      reporter.reportErrorForToken(
-        TalawaGoodDocLintRules.secondLineEmptyCode,
+      reporter.atToken(
         doc[1],
+        TalawaGoodDocLintRules.secondLineEmptyCode,
       );
     }
 
@@ -218,9 +218,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     }
 
     if (!containsParamsKeyword) {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.includeParamsKeywordCode,
+      reporter.atNode(
         node.documentationComment!,
+        TalawaGoodDocLintRules.includeParamsKeywordCode,
       );
 
       return false;
@@ -232,9 +232,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
       if (currentDocLine == doc.length) {
         return false;
       } else if (doc[currentDocLine].lexeme != "///   None") {
-        reporter.reportErrorForToken(
-          TalawaGoodDocLintRules.noParamNone,
+        reporter.atToken(
           doc[currentDocLine],
+          TalawaGoodDocLintRules.noParamNone,
         );
         return false;
       }
@@ -257,25 +257,25 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
         // TODO: RegExp.hasMatch() doesn't work for some reason.
         if (!line.lexeme.startsWith(paramRegex.pattern)) {
           if (line.lexeme.trim() == '/// **returns**:') {
-            reporter.reportErrorForToken(
-              TalawaGoodDocLintRules.allParamsNotDocumented,
+            reporter.atToken(
               line,
+              TalawaGoodDocLintRules.allParamsNotDocumented,
             );
 
             return false;
           }
 
-          reporter.reportErrorForToken(
-            TalawaGoodDocLintRules.startShouldFollowParam,
+          reporter.atToken(
             line,
+            TalawaGoodDocLintRules.startShouldFollowParam,
           );
 
           return false;
         } else {
           if (line.lexeme.trim() == paramRegex.pattern) {
-            reporter.reportErrorForToken(
-              TalawaGoodDocLintRules.emptyParamDoc,
+            reporter.atToken(
               line,
+              TalawaGoodDocLintRules.emptyParamDoc,
             );
 
             return false;
@@ -289,9 +289,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     }
 
     if (currentParam != paramList.length) {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.allParamsNotDocumented,
+      reporter.atNode(
         node,
+        TalawaGoodDocLintRules.allParamsNotDocumented,
       );
 
       return false;
@@ -324,9 +324,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     final isVoid = TalawaLintHelpers.isVoid(node);
 
     if (!containsReturn) {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.doesNotContainReturn,
+      reporter.atNode(
         node.documentationComment!,
+        TalawaGoodDocLintRules.doesNotContainReturn,
       );
 
       return;
@@ -335,9 +335,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     // Check if there is atleast one blank line above
 
     if (doc[currentDocLine - 1].lexeme.trim() != '///') {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.noBlankLineBWParamAndReturn,
+      reporter.atNode(
         node.documentationComment!,
+        TalawaGoodDocLintRules.noBlankLineBWParamAndReturn,
       );
 
       return;
@@ -349,9 +349,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     // if (isVoid && currentDocLine == doc.length) return;
 
     if (doc[currentDocLine].lexeme.trim() != '/// **returns**:') {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.wrongReturnsDoc,
+      reporter.atNode(
         node.documentationComment!,
+        TalawaGoodDocLintRules.wrongReturnsDoc,
       );
 
       return;
@@ -362,9 +362,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     currentDocLine++;
 
     if (currentDocLine == doc.length) {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.noReturnDoc,
+      reporter.atNode(
         node.documentationComment!,
+        TalawaGoodDocLintRules.noReturnDoc,
       );
 
       return;
@@ -379,9 +379,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
     if (isVoid &&
         (doc[currentDocLine - 1].lexeme != '///   None' ||
             currentDocLine != doc.length)) {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.noEndWithNoneForVoid,
+      reporter.atNode(
         node.documentationComment!,
+        TalawaGoodDocLintRules.noEndWithNoneForVoid,
       );
 
       return;
@@ -399,9 +399,9 @@ class TalawaGoodDocVisitor extends SimpleAstVisitor {
         !doc[currentDocLine - 1].lexeme.startsWith(
               returnTypeDocPattern.pattern,
             )) {
-      reporter.reportErrorForNode(
-        TalawaGoodDocLintRules.wrongReturnsDoc,
+      reporter.atNode(
         node.documentationComment!,
+        TalawaGoodDocLintRules.wrongReturnsDoc,
       );
 
       return;

--- a/talawa_lint/lib/talawa_lint_rules.dart
+++ b/talawa_lint/lib/talawa_lint_rules.dart
@@ -2,7 +2,7 @@
 // ignore_for_file: talawa_good_doc_comments
 // ignore_for_file: depend_on_referenced_packages
 
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' as analyzer;
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 class TalawaAPIDocLintRules {}
@@ -14,7 +14,7 @@ class TalawaGoodDocLintRules {
         "First line of the documentation doesn't end with end punctuation.",
     correctionMessage: "End first line of documentation with '.', '!' etc",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const secondLineEmptyCode = LintCode(
@@ -23,7 +23,7 @@ class TalawaGoodDocLintRules {
     correctionMessage:
         "Second line should be left empty to improve readability",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const includeParamsKeywordCode = LintCode(
@@ -31,7 +31,7 @@ class TalawaGoodDocLintRules {
     problemMessage: 'params block not found in the documentation.',
     correctionMessage: "Include `**params**:` keyword in function/method doc",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const noParamNone = LintCode(
@@ -39,7 +39,7 @@ class TalawaGoodDocLintRules {
     problemMessage: 'Wrong doc format.',
     correctionMessage: "Empty param list should be documented as `///   None`",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const startShouldFollowParam = LintCode(
@@ -48,7 +48,7 @@ class TalawaGoodDocLintRules {
     correctionMessage: "Make sure you have added a param name after *, and it\n"
         "is in the same order as it appears in the function",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const emptyParamDoc = LintCode(
@@ -56,7 +56,7 @@ class TalawaGoodDocLintRules {
     problemMessage: 'No documentation is written for this parameter',
     correctionMessage: "Param name should follow its documentation",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const allParamsNotDocumented = LintCode(
@@ -65,7 +65,7 @@ class TalawaGoodDocLintRules {
     correctionMessage: "Please make sure that you have documented all\n"
         "of the parameters in the same order as they appear in the function.",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const noBlankLineBWParamAndReturn = LintCode(
@@ -74,7 +74,7 @@ class TalawaGoodDocLintRules {
     correctionMessage: "Add a blank line between the end of 'params:' block\n"
         "and start of 'returns:' block.",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const doesNotContainReturn = LintCode(
@@ -84,7 +84,7 @@ class TalawaGoodDocLintRules {
         "Documentation does not contain information about the return type.\n"
         "Add '**returns**:' block followed by the return doc.",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const wrongReturnsDoc = LintCode(
@@ -98,7 +98,7 @@ class TalawaGoodDocLintRules {
         "/// **returns**: \n"
         "/// * `return_type`: documentation of the return type.",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const noReturnDoc = LintCode(
@@ -108,7 +108,7 @@ class TalawaGoodDocLintRules {
         "'**returns**:' should immediately be followed by documentation about\n"
         "the return type",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 
   static const noEndWithNoneForVoid = LintCode(
@@ -119,6 +119,6 @@ class TalawaGoodDocLintRules {
         "`///   None`\n"
         "without extra lines.",
     url: "https://docs.talawa.io/docs/developers/talawa/talawa-lint/",
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: analyzer.ErrorSeverity.WARNING,
   );
 }

--- a/talawa_lint/pubspec.lock
+++ b/talawa_lint/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "65.0.0"
+    version: "76.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.3"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.11.0"
   analyzer_plugin:
     dependency: "direct main"
     description:
@@ -69,18 +74,18 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -101,34 +106,42 @@ packages:
     dependency: "direct main"
     description:
       name: custom_lint
-      sha256: dfb893ff17c83cf08676c6b64df11d3e53d80590978d7c1fb242afff3ba6dedb
+      sha256: "3486c470bb93313a9417f926c7dd694a2e349220992d7b9d14534dc49c15bba9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.7.0"
   custom_lint_builder:
     dependency: "direct main"
     description:
       name: custom_lint_builder
-      sha256: "8df6634b38a36a6c6cb74a9c0eb02e9ba0b0ab89b29e38e6daa86e8ed2c6288d"
+      sha256: "42cdc41994eeeddab0d7a722c7093ec52bd0761921eeb2cbdbf33d192a234759"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.7.0"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: "2b235be098d157e244f18ea905a15a18c16a205e30553888fac6544bbf52f03f"
+      sha256: "02450c3e45e2a6e8b26c4d16687596ab3c4644dd5792e3313aa9ceba5a49b7f5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.7.0"
+  custom_lint_visitor:
+    dependency: transitive
+    description:
+      name: custom_lint_visitor
+      sha256: bfe9b7a09c4775a587b58d10ebb871d4fe618237639b1e84d5ec62d7dfef25f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+6.11.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
+      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.8"
   file:
     dependency: transitive
     description:
@@ -149,10 +162,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.4"
   glob:
     dependency: transitive
     description:
@@ -173,10 +186,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   lint:
     dependency: "direct dev"
     description:
@@ -193,6 +206,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -205,10 +226,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.16.0"
   package_config:
     dependency: transitive
     description:
@@ -237,18 +258,18 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.5.0"
   rxdart:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   source_span:
     dependency: transitive
     description:
@@ -325,10 +346,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.5.1"
   vm_service:
     dependency: transitive
     description:
@@ -354,4 +375,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"

--- a/talawa_lint/pubspec.yaml
+++ b/talawa_lint/pubspec.yaml
@@ -9,13 +9,13 @@ dev_dependencies:
 dependencies:
   # we will use analyzer for inspecting Dart files
   # _fe_analyzer_shared: ^61.0.0
-  analyzer: ">=5.12.0 <7.0.0"
+  analyzer: ">=5.12.0 <=7.3.0"
   analyzer_plugin: ^0.11.0
   # args:
   
   # custom_lint_builder will give us tools for writing lints
   args: ^2.4.2
-  custom_lint: 0.5.8
-  custom_lint_builder: ^0.5.8
+  custom_lint: 0.7.0
+  custom_lint_builder: ^0.7.0
   # watcher: ^1.1.0
   


### PR DESCRIPTION
### What kind of change does this PR introduce?

- Upgrade build_runner to 2.4.15 and fix custom lint compatibility

### Issue Number:

- Fixes #2805 

### Did you add tests for your changes?

- Not Required

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

### Summary

- Resolved name conflicts between analyzer and custom_lint_builder packages
- Replaced deprecated reportErrorForOffset method with the recommended atOffset() approach
- Replaced deprecated reportErrorForToken method with the recommended atToken() approach
- Replaced deprecated reportErrorForNode method with the recommended atNode() approach

### Does this PR introduce a breaking change?

- No

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

### Other information

- This PR required upgrading other package dependencies which were dependent on build_runner and custom_lint.

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

- Yes