### PR TITLE
Fixed old develop-postgres references

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,7 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - develop-postgres
+      - develop
       - develop
       - main
   path_filters: 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
     # Check the pub.dev registry for updates every day (weekdays)
     schedule:
       interval: "monthly"
-    target-branch: "develop-postgres"
+    target-branch: "develop"
     # # Add default reviewers
     # reviewers:
     #   - "palisadoes"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ This section can be deleted after reading.
 
 We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:
 
-- `develop-postgres`: For unstable code: New features and bug fixes.
+- `develop`: For unstable code: New features and bug fixes.
 - `master`: Where the stable production-ready code lies. Only security-related bugs.
 
 NOTE!!!

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -31,4 +31,4 @@ jobs:
       - uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "Congratulations on making your first Issue! :confetti_ball: If you haven't already, check out our [Contributing Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/CONTRIBUTING.md) and [Issue Reporting Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/ISSUE_GUIDELINES.md) to ensure that you are following our guidelines for contributing and making issues."
+          issue-message: "Congratulations on making your first Issue! :confetti_ball: If you haven't already, check out our [Contributing Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop/CONTRIBUTING.md) and [Issue Reporting Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop/ISSUE_GUIDELINES.md) to ensure that you are following our guidelines for contributing and making issues."

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -66,4 +66,4 @@ jobs:
         uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: "Congratulations on making your first PR! :confetti_ball: If you haven't already, check out our [Contributing Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/CONTRIBUTING.md) and [PR Reporting Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/PR_GUIDELINES.md) to ensure that you are following our guidelines for contributing and creating PR."
+          pr-message: "Congratulations on making your first PR! :confetti_ball: If you haven't already, check out our [Contributing Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop/CONTRIBUTING.md) and [PR Reporting Guidelines](https://github.com/PalisadoesFoundation/talawa/blob/develop/PR_GUIDELINES.md) to ensure that you are following our guidelines for contributing and creating PR."

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,10 +65,10 @@ jobs:
           git branch
           git checkout -b temp_branch
           git branch
-          git checkout develop-postgres
+          git checkout develop
           git pull
           git branch
-          git diff --name-only develop-postgres..HEAD
+          git diff --name-only develop..HEAD
           git checkout temp_branch
           pip install GitPython
           python ./.github/workflows/scripts/check_ignore.py --repository ${{github.repository}} --merge_branch_name ${{github.head_ref}}
@@ -113,10 +113,10 @@ jobs:
     name: "Base branch check"
     runs-on: ubuntu-latest
     steps:
-      - name: "Check if base branch is develop-postgres"
-        if: github.event.pull_request.base.ref != 'develop-postgres'
+      - name: "Check if base branch is develop"
+        if: github.event.pull_request.base.ref != 'develop'
         run: |
-          echo "PR is not against develop-postgres branch. Please refer PR_GUIDELINES.md"
+          echo "PR is not against develop branch. Please refer PR_GUIDELINES.md"
           echo "Error: Close this PR and try again."
           exit 1
 
@@ -217,7 +217,7 @@ jobs:
           echo "Error: Too many files (greater than 100) changed in the pull request."
           echo "Possible issues:"
           echo "- Contributor may be merging into an incorrect branch."
-          echo "- Source branch may be incorrect please use develop-postgres as source branch."
+          echo "- Source branch may be incorrect please use develop as source branch."
           exit 1
 
   Flutter-Testing:
@@ -288,8 +288,8 @@ jobs:
     name: Test Deployment to https://docs-mobile.talawa.io
     runs-on: ubuntu-latest
     needs: [iOS-Build, Android-Build]
-    # Run only if the develop-postgres branch and not dependabot
-    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.base.ref == 'develop-postgres' }}
+    # Run only if the develop branch and not dependabot
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.base.ref == 'develop' }}
     steps:
       - name: Checkout the Repository
         uses: actions/checkout@v4

--- a/.github/workflows/push-deploy-website.yml
+++ b/.github/workflows/push-deploy-website.yml
@@ -14,7 +14,7 @@ name: PUSH Workflow - Website Deployment
 on:
   push:
     branches:
-      - 'develop-postgres'
+      - 'develop'
     paths:
       - docs/**
       
@@ -25,7 +25,7 @@ jobs:
   Deploy-Docusaurus:
     name: Deploy https://docs-mobile.talawa.io website
     runs-on: ubuntu-latest
-    # Run only if the develop-postgres branch and not dependabot
+    # Run only if the develop branch and not dependabot
     if: ${{ github.actor != 'dependabot[bot]' }}
     environment:
       # This "name" has to be the repos' branch that contains 
@@ -34,7 +34,7 @@ jobs:
       # "Code and automation > Environments > gigithub-pages"
       # menu. The branch "name" must match the branch in the 
       # "on.push.branches" section at the top of this file
-      name: develop-postgres
+      name: develop
       url: https://docs-mobile.talawa.io
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,7 +58,7 @@ jobs:
             git stash push -u -- "pubspec.lock"
           fi
           git branch
-          git checkout develop-postgres
+          git checkout develop
           git pull
           git branch
           git checkout -

--- a/.github/workflows/scripts/check_ignore.py
+++ b/.github/workflows/scripts/check_ignore.py
@@ -103,7 +103,7 @@ def _check_for_ignore_directive(filePath):
 
     """
     # Either it is a non-code file, or the file does not exist.
-    # This can happen when `develop-postgres` gets ahead of your branch and
+    # This can happen when `develop` gets ahead of your branch and
     # has some files which you don't have
 
     if (
@@ -222,7 +222,7 @@ def main():
     print(current_branch)
     changed_files = (
         subprocess.check_output(
-            ["git", "diff", "--name-only", "develop-postgres", current_branch]
+            ["git", "diff", "--name-only", "develop", current_branch]
         )
         .decode("utf-8")
         .splitlines()

--- a/docs/docs/auto-docs/index.md
+++ b/docs/docs/auto-docs/index.md
@@ -65,16 +65,16 @@ for more details on its origin and activities.
 # Documentation
 
 1.  You can install the software for this repository using the steps in
-    our [INSTALLATION.md](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/INSTALLATION.md) file.
+    our [INSTALLATION.md](https://github.com/PalisadoesFoundation/talawa/blob/develop/INSTALLATION.md) file.
 2.  Do you want to contribute to our code base? Look at our
-    [CONTRIBUTING.md](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/CONTRIBUTING.md) file to get started. There
+    [CONTRIBUTING.md](https://github.com/PalisadoesFoundation/talawa/blob/develop/CONTRIBUTING.md) file to get started. There
     you/'ll also find links to:
     1.  Our code of conduct documentation in the
-        [CODE_OF_CONDUCT.md](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/CODE_OF_CONDUCT.md) file.
+        [CODE_OF_CONDUCT.md](https://github.com/PalisadoesFoundation/talawa/blob/develop/CODE_OF_CONDUCT.md) file.
     2.  How we handle the processing of new and existing issues in our
-        [ISSUE_GUIDELINES.md](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/ISSUE_GUIDELINES.md) file.
+        [ISSUE_GUIDELINES.md](https://github.com/PalisadoesFoundation/talawa/blob/develop/ISSUE_GUIDELINES.md) file.
     3.  The methodologies we use to manage our pull requests in our
-        [PR_GUIDELINES.md](https://github.com/PalisadoesFoundation/talawa/blob/develop-postgres/PR_GUIDELINES.md) file.
+        [PR_GUIDELINES.md](https://github.com/PalisadoesFoundation/talawa/blob/develop/PR_GUIDELINES.md) file.
 3.  The `talawa` documentation can be found at our
     [docs.talawa.io](https://docs.talawa.io) site.
     1.  It is automatically generated from the markdown files stored in

--- a/scripts/docusaurus/fix_markdown.py
+++ b/scripts/docusaurus/fix_markdown.py
@@ -329,7 +329,7 @@ for root, _, files in os.walk(md_folder):
                     ")"
                     ")",
                     r"(https://github.com/PalisadoesFoundation/talawa/blob/"
-                    "develop-postgres/\1)",
+                    "develop/\1)",
                     content,
                 )
 
@@ -338,7 +338,7 @@ for root, _, files in os.walk(md_folder):
                 content = re.sub(
                     r"\((\.github/workflows/pull-request\.yml)\)",
                     r"(https://github.com/PalisadoesFoundation/talawa/blob/"
-                    "develop-postgres/.github/workflows/pull-request.yml)",
+                    "develop/.github/workflows/pull-request.yml)",
                     content,
                 )
 


### PR DESCRIPTION
Fixed old develop-postgres references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated all references from the "develop-postgres" branch to "develop" across configuration files, documentation links, workflow messages, and deployment settings.
  - Adjusted branch names in workflow triggers, pull request templates, and automated messages to ensure consistency with the current development branch.
  - Updated scripts and markdown link fixers to reflect the new branch naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->