### PR TITLE
Fix: Changing Organizations and joining new Organizations

### DIFF
--- a/lib/models/organization/org_info.dart
+++ b/lib/models/organization/org_info.dart
@@ -66,7 +66,7 @@ class OrgInfo {
           json['description'] != null ? json['description'] as String? : null,
       userRegistrationRequired: json['userRegistrationRequired'] != null
           ? json['userRegistrationRequired'] as bool?
-          : null,
+          : false,
       members: members,
       admins: admins,
       city: json['city'] as String?,

--- a/lib/models/user/user_info.dart
+++ b/lib/models/user/user_info.dart
@@ -148,7 +148,7 @@ class User extends HiveObject {
   ///
   /// **returns**:
   ///   None
-  void updateJoinedg(OrgInfo org) {
+  void updateJoinedOrg(OrgInfo org) {
     final existingOrgs = joinedOrganizations ?? [];
     // Remove any existing org with the same ID and add the new one
     this.joinedOrganizations = [

--- a/lib/models/user/user_info.dart
+++ b/lib/models/user/user_info.dart
@@ -144,12 +144,15 @@ class User extends HiveObject {
   /// Method to updated joinedOrganisation list.
   ///
   /// **params**:
-  /// * `orgList`: List of organsaitions user has joined.
+  /// * `org`: Organisation to be added to the joinedOrganizations list.
   ///
   /// **returns**:
   ///   None
-  void updateJoinedOrg(List<OrgInfo> orgList) {
-    this.joinedOrganizations = orgList;
+  void updateJoinedOrg(OrgInfo org) {
+    this.joinedOrganizations = [
+      ...?joinedOrganizations,
+      org,
+    ];
   }
 
   /// Method to updated createdOrganisation list.

--- a/lib/models/user/user_info.dart
+++ b/lib/models/user/user_info.dart
@@ -148,10 +148,12 @@ class User extends HiveObject {
   ///
   /// **returns**:
   ///   None
-  void updateJoinedOrg(OrgInfo org) {
+  void updateJoinedg(OrgInfo org) {
+    final existingOrgs = joinedOrganizations ?? [];
+    // Remove any existing org with the same ID and add the new one
     this.joinedOrganizations = [
-      ...?joinedOrganizations,
       org,
+      ...existingOrgs.where((existingOrg) => existingOrg.id != org.id),
     ];
   }
 

--- a/lib/services/database_mutation_functions.dart
+++ b/lib/services/database_mutation_functions.dart
@@ -65,6 +65,17 @@ class DataBaseMutationFunctions {
     source: QueryResultSource.network,
   );
 
+  /// This function clears the GraphQL cache to ensure fresh data fetch.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  ///   None
+  void clearGraphQLCache() {
+    clientAuth.cache.store.reset();
+  }
+
   /// This function is used to run the graph-ql query for authentication.
   ///
   /// **params**:

--- a/lib/services/graphql_config.dart
+++ b/lib/services/graphql_config.dart
@@ -24,6 +24,7 @@ class GraphqlConfig {
   Future getToken() async {
     final authToken = userConfig.currentUser.authToken;
     token = authToken;
+    getOrgUrl();
     return true;
   }
 

--- a/lib/services/pinned_post_service.dart
+++ b/lib/services/pinned_post_service.dart
@@ -128,6 +128,7 @@ class PinnedPostService extends BaseFeedManager<Post> {
   ///   None
   void setOrgStreamSubscription() {
     _userConfig.currentOrgInfoStream.listen((updatedOrganization) {
+      databaseFunctions.clearGraphQLCache();
       if (updatedOrganization != _currentOrg) {
         _pinnedPosts.clear();
         _currentOrg = updatedOrganization;

--- a/lib/services/pinned_post_service.dart
+++ b/lib/services/pinned_post_service.dart
@@ -26,6 +26,9 @@ class PinnedPostService extends BaseFeedManager<Post> {
   late OrgInfo _currentOrg;
   List<Post> _pinnedPosts = [];
 
+  /// Getter to access the list of pinned posts.
+  List<Post> get pinnedPosts => _pinnedPosts;
+
   /// Object to hold pagination information for posts. It contains information like `after`, `before`, `first`, and `last`.
   PageInfo pinnedPostInfo = PageInfo(
     hasNextPage: false,

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -153,11 +153,14 @@ class PostService extends BaseFeedManager<Post> {
   /// **returns**:
   ///   None
   void setOrgStreamSubscription() {
-    _userConfig.currentOrgInfoStream.listen((updatedOrganization) {
+    _userConfig.currentOrgInfoStream.listen((updatedOrganization) async {
       if (updatedOrganization != _currentOrg) {
-        _renderedPostID.clear();
+        databaseFunctions.clearGraphQLCache();
         _currentOrg = updatedOrganization;
-        getPosts();
+        _posts.clear();
+        _renderedPostID.clear();
+
+        await refreshFeed();
       }
     });
   }

--- a/lib/services/user_config.dart
+++ b/lib/services/user_config.dart
@@ -205,8 +205,22 @@ class UserConfig {
   ///
   /// **returns**:
   ///   None
-  Future<void> updateUserJoinedOrg(List<OrgInfo> orgDetails) async {
-    _currentUser!.updateJoinedOrg(orgDetails);
+  Future<void> updateUserJoinedOrg(OrgInfo orgDetails) async {
+    if (orgDetails.id == null || orgDetails.id!.isEmpty) {
+      return;
+    }
+    final List<OrgInfo>? joinedOrgs = _currentUser!.joinedOrganizations;
+    if (joinedOrgs != null) {
+      // Remove any org with the same id and insert new org at beginning
+      _currentUser!.joinedOrganizations = [
+        orgDetails,
+        ...joinedOrgs.where((org) => org.id != orgDetails.id),
+      ];
+    } else {
+      _currentUser!.joinedOrganizations = [orgDetails];
+    }
+    _currentOrg = orgDetails;
+    saveCurrentOrgInHive(orgDetails);
     saveUserInHive();
   }
 

--- a/lib/utils/queries.dart
+++ b/lib/utils/queries.dart
@@ -98,14 +98,6 @@ class Queries {
                 postalCode,
                 countryCode,
                 description,
-                members(first:32){
-                  edges{
-                    node{
-                      name
-                      role
-                    }
-                  }
-                }
               }
             }
           }
@@ -210,30 +202,18 @@ class Queries {
   ///
   ///
   /// **params**:
-  /// * `orgId`: refer org object.
+  ///   None
   ///
   /// **returns**:
   /// * `String`: returns a string for client
-  String joinOrgById(String orgId) {
+  String joinOrgById() {
     return '''
-    mutation {
-      joinPublicOrganization(organizationId: "$orgId") {
-          joinedOrganizations{
-            _id
-            name
-            image
-            description
-            userRegistrationRequired
-            creator{
-              _id
-              firstName
-              lastName
-              image
-            }
-            
-          }
+    mutation JoinPublicOrganization(\$organizationId: ID!) {
+      joinPublicOrganization(input: {organizationId: \$organizationId}) {
+        memberId
+        organizationId
       }
-	}
+    }
   ''';
   }
 
@@ -263,6 +243,41 @@ class Queries {
               }
             }
          }
+    }
+  ''';
+  }
+
+  /// query to fetch org details.
+  ///
+  /// **params**:
+  /// * `orgId`: org identifier
+  ///
+  /// **returns**:
+  /// * `String`: query in string form, to be passed on to graphql client.
+  String fetchOrgDetailsById(String orgId) {
+    return '''
+    query{
+      organizations(id: "$orgId"){
+        image
+        _id
+        name
+        admins{
+          _id
+        }
+        description
+        userRegistrationRequired
+        creator{
+          _id
+          firstName
+          lastName
+        }
+        members{
+          _id
+          firstName
+          lastName
+          image
+        }
+      }
     }
   ''';
   }
@@ -377,19 +392,19 @@ class Queries {
   String fetchOrgById(String orgId) {
     return '''
     query{
-      organizations(id: "$orgId"){
-        image
-        _id
-        name
-        image
-        userRegistrationRequired
-        creator{
-          firstName
-          lastName
-        }
+      organization(input:{id:"$orgId"}){
+        id,
+        name,
+        addressLine1,
+        addressLine2,
+        avatarMimeType,
+        avatarURL,
+        postalCode,
+        countryCode,
+        description,
       }
     }
-  ''';
+    ''';
   }
 
   /// query to fetch user lang.
@@ -420,41 +435,6 @@ class Queries {
     return '''
     query{
       userLanguage(userId:"$userId")
-    }
-  ''';
-  }
-
-  /// query to fetch org details.
-  ///
-  /// **params**:
-  /// * `orgId`: org identifier
-  ///
-  /// **returns**:
-  /// * `String`: query in string form, to be passed on to graphql client.
-  String fetchOrgDetailsById(String orgId) {
-    return '''
-    query{
-      organizations(id: "$orgId"){
-        image
-        _id
-        name
-        admins{
-          _id
-        }
-        description
-        userRegistrationRequired
-        creator{
-          _id
-          firstName
-          lastName
-        }
-        members{
-          _id
-          firstName
-          lastName
-          image
-        }
-      }
     }
   ''';
   }

--- a/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
@@ -233,7 +233,6 @@ class SelectOrganizationViewModel extends BaseModel {
         );
       }
     } else {
-      print("inside else");
       try {
         navigationService.pushScreen(Routes.requestAccess);
       } on Exception catch (e) {

--- a/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
@@ -186,10 +186,10 @@ class SelectOrganizationViewModel extends BaseModel {
   /// * `Future<void>`: None
   Future<void> onTapJoin() async {
     print("inside on tap join");
+    print(selectedOrganization!.userRegistrationRequired);
     // if `selectedOrganization` registrations is not required.
     if (selectedOrganization!.userRegistrationRequired != null &&
         selectedOrganization!.userRegistrationRequired == false) {
-      print("hello");
       try {
         // run the graph QL mutation
         final QueryResult result = await databaseFunctions.gqlAuthMutation(
@@ -238,7 +238,7 @@ class SelectOrganizationViewModel extends BaseModel {
     } else {
       print("inside else");
       try {
-        // navigationService.pushScreen(Routes.requestAccess);
+        navigationService.pushScreen(Routes.requestAccess);
       } on Exception catch (e) {
         print(e);
         navigationService.showTalawaErrorSnackBar(

--- a/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
@@ -6,7 +6,6 @@ import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart';
 import 'package:talawa/constants/routing_constants.dart';
 import 'package:talawa/enums/enums.dart';
 import 'package:talawa/locator.dart';
-import 'package:talawa/models/mainscreen_navigation_args.dart';
 import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/view_model/base_view_model.dart';
 
@@ -110,13 +109,15 @@ class SelectOrganizationViewModel extends BaseModel {
           orgAlreadyJoined = true;
         }
       });
-      print("org1");
+
       // check if user has already send the membership request to the selected organization.
+      userConfig.currentUser.membershipRequests ??= [];
       userConfig.currentUser.membershipRequests!.forEach((element) {
         if (item != null && element.id! == item.id) {
           orgRequestAlreadyPresent = true;
         }
       });
+
       // if not already joined and not memebrship request.
       if (!orgAlreadyJoined && !orgRequestAlreadyPresent) {
         selectedOrganization = item;
@@ -184,57 +185,68 @@ class SelectOrganizationViewModel extends BaseModel {
   /// **returns**:
   /// * `Future<void>`: None
   Future<void> onTapJoin() async {
+    print("inside on tap join");
     // if `selectedOrganization` registrations is not required.
-    if (selectedOrganization!.userRegistrationRequired == false) {
+    if (selectedOrganization!.userRegistrationRequired != null &&
+        selectedOrganization!.userRegistrationRequired == false) {
+      print("hello");
       try {
         // run the graph QL mutation
         final QueryResult result = await databaseFunctions.gqlAuthMutation(
-          queries.joinOrgById(selectedOrganization!.id!),
+          queries.joinOrgById(),
+          variables: {
+            'organizationId': selectedOrganization!.id,
+          },
         );
 
-        final List<OrgInfo>? joinedOrg =
-            ((result.data!['joinPublicOrganization']
-                        as Map<String, dynamic>)['joinedOrganizations']
-                    as List<dynamic>?)
-                ?.map((e) => OrgInfo.fromJson(e as Map<String, dynamic>))
-                .toList();
-        userConfig.updateUserJoinedOrg(joinedOrg!);
-        // if user joined organization length is 1
-        if (userConfig.currentUser.joinedOrganizations!.length == 1) {
-          userConfig.saveCurrentOrgInHive(
-            userConfig.currentUser.joinedOrganizations![0],
-          );
-          navigationService.removeAllAndPush(
-            Routes.mainScreen,
-            Routes.splashScreen,
-            arguments: MainScreenArgs(mainScreenIndex: 0),
-          );
-        } else {
-          navigationService.pop();
-          navigationService.showTalawaErrorSnackBar(
-            'Joined ${selectedOrganization?.name} successfully',
-            MessageType.info,
-          );
+        final Map<String, dynamic>? resultData = result.data;
+        if (resultData == null) {
+          throw Exception('No data received');
         }
+
+        final Map<String, dynamic>? joinData =
+            resultData['joinPublicOrganization'] as Map<String, dynamic>?;
+        if (joinData == null) {
+          throw Exception('Join operation failed');
+        }
+
+        final String? memberId = joinData["memberId"] as String?;
+        if (memberId != userConfig.currentUser.id) {
+          throw Exception('Member ID mismatch');
+        }
+
+        final QueryResult joinedOrgData = await databaseFunctions
+            .gqlAuthQuery(queries.fetchOrgById(selectedOrganization?.id ?? ''));
+
+        final OrgInfo joinedOrg = OrgInfo.fromJson(
+          joinedOrgData.data!['organization'] as Map<String, dynamic>,
+        );
+        await userConfig.updateUserJoinedOrg(joinedOrg);
+
+        navigationService.pop();
+        navigationService.showTalawaErrorSnackBar(
+          'Joined ${selectedOrganization?.name} successfully',
+          MessageType.info,
+        );
       } on Exception catch (e) {
         print(e);
         navigationService.showTalawaErrorSnackBar(
-          'Something went wrong',
+          'Something went wrong $e',
+          MessageType.error,
+        );
+      }
+    } else {
+      print("inside else");
+      try {
+        // navigationService.pushScreen(Routes.requestAccess);
+      } on Exception catch (e) {
+        print(e);
+        navigationService.showTalawaErrorSnackBar(
+          'SomeThing went wrong',
           MessageType.error,
         );
       }
     }
-    // else {
-    //   try {
-    //     // navigationService.pushScreen(Routes.requestAccess);
-    //   } on Exception catch (e) {
-    //     print(e);
-    //     navigationService.showTalawaErrorSnackBar(
-    //       'SomeThing went wrong',
-    //       MessageType.error,
-    //     );
-    //   }
-    // }
   }
 
   /// This function fetch more option.

--- a/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
+++ b/lib/view_model/pre_auth_view_models/select_organization_view_model.dart
@@ -185,8 +185,6 @@ class SelectOrganizationViewModel extends BaseModel {
   /// **returns**:
   /// * `Future<void>`: None
   Future<void> onTapJoin() async {
-    print("inside on tap join");
-    print(selectedOrganization!.userRegistrationRequired);
     // if `selectedOrganization` registrations is not required.
     if (selectedOrganization!.userRegistrationRequired != null &&
         selectedOrganization!.userRegistrationRequired == false) {
@@ -229,7 +227,6 @@ class SelectOrganizationViewModel extends BaseModel {
           MessageType.info,
         );
       } on Exception catch (e) {
-        print(e);
         navigationService.showTalawaErrorSnackBar(
           'Something went wrong $e',
           MessageType.error,
@@ -240,9 +237,8 @@ class SelectOrganizationViewModel extends BaseModel {
       try {
         navigationService.pushScreen(Routes.requestAccess);
       } on Exception catch (e) {
-        print(e);
         navigationService.showTalawaErrorSnackBar(
-          'SomeThing went wrong',
+          'Something went wrong $e',
           MessageType.error,
         );
       }

--- a/lib/views/after_auth_screens/feed/organization_feed.dart
+++ b/lib/views/after_auth_screens/feed/organization_feed.dart
@@ -83,7 +83,7 @@ class _OrganizationFeedState extends State<OrganizationFeed> {
           body: model.isFetchingPosts || model.isBusy
               ? const Center(child: CircularProgressIndicator())
               : RefreshIndicator(
-                  onRefresh: () async => model.fetchNewPosts(),
+                  onRefresh: () async => await model.fetchNewPosts(),
                   child: NotificationListener<ScrollNotification>(
                     onNotification: (notification) {
                       final currentScroll = _scrollController.position.pixels;

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -51,7 +51,7 @@ class CustomDrawer extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              model.selectedOrg?.name! ?? "NULL",
+                              model.selectedOrg?.name ?? "NULL",
                             ),
                             Text(
                               AppLocalizations.of(context)!

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -96,6 +96,8 @@ import 'test_helpers.mocks.dart';
     MockSpec<DirectChatViewModel>(onMissingStub: OnMissingStub.returnDefault),
     MockSpec<ImageCropper>(onMissingStub: OnMissingStub.returnDefault),
     MockSpec<ImagePicker>(onMissingStub: OnMissingStub.returnDefault),
+    MockSpec<GraphQLCache>(onMissingStub: OnMissingStub.returnDefault),
+    MockSpec<Store>(onMissingStub: OnMissingStub.returnDefault),
   ],
 )
 

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -1944,7 +1944,7 @@ class MockUserConfig extends _i2.Mock implements _i28.UserConfig {
       ) as _i7.Future<_i3.QueryResult<Object?>>);
 
   @override
-  _i7.Future<void> updateUserJoinedOrg(List<_i5.OrgInfo>? orgDetails) =>
+  _i7.Future<void> updateUserJoinedOrg(_i5.OrgInfo? orgDetails) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserJoinedOrg,
@@ -2873,6 +2873,15 @@ class MockDataBaseMutationFunctions extends _i2.Mock
       );
 
   @override
+  void clearGraphQLCache() => super.noSuchMethod(
+        Invocation.method(
+          #clearGraphQLCache,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i7.Future<_i3.QueryResult<Object?>> gqlAuthQuery(
     String? query, {
     Map<String, dynamic>? variables,
@@ -3318,23 +3327,25 @@ class MockOrganizationFeedViewModel extends _i2.Mock
       ) as bool);
 
   @override
-  void setCurrentOrganizationName(String? updatedOrganization) =>
-      super.noSuchMethod(
+  _i7.Future<void> setCurrentOrganizationName(String? updatedOrganization) =>
+      (super.noSuchMethod(
         Invocation.method(
           #setCurrentOrganizationName,
           [updatedOrganization],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  void fetchNewPosts() => super.noSuchMethod(
+  _i7.Future<void> fetchNewPosts() => (super.noSuchMethod(
         Invocation.method(
           #fetchNewPosts,
           [],
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
   _i7.Future<void> initialise() => (super.noSuchMethod(

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -9,6 +9,8 @@ import 'dart:ui' as _i11;
 
 import 'package:flutter/material.dart' as _i1;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i12;
+import 'package:graphql/src/cache/_optimistic_transactions.dart' as _i48;
+import 'package:graphql/src/utilities/helpers.dart' as _i47;
 import 'package:graphql_flutter/graphql_flutter.dart' as _i3;
 import 'package:image_cropper/src/cropper.dart' as _i44;
 import 'package:image_cropper_platform_interface/image_cropper_platform_interface.dart'
@@ -16,6 +18,7 @@ import 'package:image_cropper_platform_interface/image_cropper_platform_interfac
 import 'package:image_picker/image_picker.dart' as _i15;
 import 'package:mockito/mockito.dart' as _i2;
 import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:normalize/normalize.dart' as _i46;
 import 'package:qr_code_scanner_plus/src/qr_code_scanner.dart' as _i36;
 import 'package:qr_code_scanner_plus/src/types/barcode.dart' as _i37;
 import 'package:qr_code_scanner_plus/src/types/camera.dart' as _i38;
@@ -357,6 +360,16 @@ class _FakeDateTime_25 extends _i2.SmartFake implements DateTime {
 class _FakeLostDataResponse_26 extends _i2.SmartFake
     implements _i15.LostDataResponse {
   _FakeLostDataResponse_26(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStore_27 extends _i2.SmartFake implements _i3.Store {
+  _FakeStore_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -4933,4 +4946,338 @@ class MockImagePicker extends _i2.Mock implements _i15.ImagePicker {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+}
+
+/// A class which mocks [GraphQLCache].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGraphQLCache extends _i2.Mock implements _i3.GraphQLCache {
+  @override
+  _i3.Store get store => (super.noSuchMethod(
+        Invocation.getter(#store),
+        returnValue: _FakeStore_27(
+          this,
+          Invocation.getter(#store),
+        ),
+        returnValueForMissingStub: _FakeStore_27(
+          this,
+          Invocation.getter(#store),
+        ),
+      ) as _i3.Store);
+
+  @override
+  _i3.PartialDataCachePolicy get partialDataPolicy => (super.noSuchMethod(
+        Invocation.getter(#partialDataPolicy),
+        returnValue: _i3.PartialDataCachePolicy.accept,
+        returnValueForMissingStub: _i3.PartialDataCachePolicy.accept,
+      ) as _i3.PartialDataCachePolicy);
+
+  @override
+  Map<String, _i46.TypePolicy> get typePolicies => (super.noSuchMethod(
+        Invocation.getter(#typePolicies),
+        returnValue: <String, _i46.TypePolicy>{},
+        returnValueForMissingStub: <String, _i46.TypePolicy>{},
+      ) as Map<String, _i46.TypePolicy>);
+
+  @override
+  Map<String, Set<String>> get possibleTypes => (super.noSuchMethod(
+        Invocation.getter(#possibleTypes),
+        returnValue: <String, Set<String>>{},
+        returnValueForMissingStub: <String, Set<String>>{},
+      ) as Map<String, Set<String>>);
+
+  @override
+  _i47.SanitizeVariables get sanitizeVariables => (super.noSuchMethod(
+        Invocation.getter(#sanitizeVariables),
+        returnValue: (Map<String, dynamic> variables) => null,
+        returnValueForMissingStub: (Map<String, dynamic> variables) => null,
+      ) as _i47.SanitizeVariables);
+
+  @override
+  int get inflightOptimisticTransactions => (super.noSuchMethod(
+        Invocation.getter(#inflightOptimisticTransactions),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as int);
+
+  @override
+  set inflightOptimisticTransactions(int? _inflightOptimisticTransactions) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #inflightOptimisticTransactions,
+          _inflightOptimisticTransactions,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  List<_i48.OptimisticPatch> get optimisticPatches => (super.noSuchMethod(
+        Invocation.getter(#optimisticPatches),
+        returnValue: <_i48.OptimisticPatch>[],
+        returnValueForMissingStub: <_i48.OptimisticPatch>[],
+      ) as List<_i48.OptimisticPatch>);
+
+  @override
+  set optimisticPatches(List<_i48.OptimisticPatch>? _optimisticPatches) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #optimisticPatches,
+          _optimisticPatches,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get acceptPartialData => (super.noSuchMethod(
+        Invocation.getter(#acceptPartialData),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get addTypename => (super.noSuchMethod(
+        Invocation.getter(#addTypename),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  set addTypename(bool? _addTypename) => super.noSuchMethod(
+        Invocation.setter(
+          #addTypename,
+          _addTypename,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get broadcastRequested => (super.noSuchMethod(
+        Invocation.getter(#broadcastRequested),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  set broadcastRequested(bool? _broadcastRequested) => super.noSuchMethod(
+        Invocation.setter(
+          #broadcastRequested,
+          _broadcastRequested,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sanitizeVariables(_i47.SanitizeVariables? _sanitizeVariables) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #sanitizeVariables,
+          _sanitizeVariables,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get returnPartialData => (super.noSuchMethod(
+        Invocation.getter(#returnPartialData),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool shouldBroadcast({bool? claimExecution = false}) => (super.noSuchMethod(
+        Invocation.method(
+          #shouldBroadcast,
+          [],
+          {#claimExecution: claimExecution},
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  Map<String, dynamic>? readNormalized(
+    String? rootId, {
+    bool? optimistic = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #readNormalized,
+          [rootId],
+          {#optimistic: optimistic},
+        ),
+        returnValueForMissingStub: null,
+      ) as Map<String, dynamic>?);
+
+  @override
+  void writeNormalized(
+    String? dataId,
+    Map<String, dynamic>? value,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #writeNormalized,
+          [
+            dataId,
+            value,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void recordOptimisticTransaction(
+    _i48.CacheTransaction? transaction,
+    String? addId,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #recordOptimisticTransaction,
+          [
+            transaction,
+            addId,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeOptimisticPatch(String? removeId) => super.noSuchMethod(
+        Invocation.method(
+          #removeOptimisticPatch,
+          [removeId],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  Map<String, dynamic>? readQuery(
+    _i3.Request? request, {
+    bool? optimistic = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #readQuery,
+          [request],
+          {#optimistic: optimistic},
+        ),
+        returnValueForMissingStub: null,
+      ) as Map<String, dynamic>?);
+
+  @override
+  Map<String, dynamic>? readFragment(
+    _i3.FragmentRequest? fragmentRequest, {
+    bool? optimistic = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #readFragment,
+          [fragmentRequest],
+          {#optimistic: optimistic},
+        ),
+        returnValueForMissingStub: null,
+      ) as Map<String, dynamic>?);
+
+  @override
+  void writeQuery(
+    _i3.Request? request, {
+    required Map<String, dynamic>? data,
+    bool? broadcast = true,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #writeQuery,
+          [request],
+          {
+            #data: data,
+            #broadcast: broadcast,
+          },
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void writeFragment(
+    _i3.FragmentRequest? request, {
+    required Map<String, dynamic>? data,
+    bool? broadcast = true,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #writeFragment,
+          [request],
+          {
+            #data: data,
+            #broadcast: broadcast,
+          },
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [Store].
+///
+/// See the documentation for Mockito's code generation for more information.
+// ignore: must_be_immutable
+class MockStore extends _i2.Mock implements _i3.Store {
+  @override
+  Map<String, dynamic>? get(String? dataId) => (super.noSuchMethod(
+        Invocation.method(
+          #get,
+          [dataId],
+        ),
+        returnValueForMissingStub: null,
+      ) as Map<String, dynamic>?);
+
+  @override
+  void put(
+    String? dataId,
+    Map<String, dynamic>? value,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #put,
+          [
+            dataId,
+            value,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void putAll(Map<String, Map<String, dynamic>?>? data) => super.noSuchMethod(
+        Invocation.method(
+          #putAll,
+          [data],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void delete(String? dataId) => super.noSuchMethod(
+        Invocation.method(
+          #delete,
+          [dataId],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void reset() => super.noSuchMethod(
+        Invocation.method(
+          #reset,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  Map<String, Map<String, dynamic>?> toMap() => (super.noSuchMethod(
+        Invocation.method(
+          #toMap,
+          [],
+        ),
+        returnValue: <String, Map<String, dynamic>?>{},
+        returnValueForMissingStub: <String, Map<String, dynamic>?>{},
+      ) as Map<String, Map<String, dynamic>?>);
 }

--- a/test/model_tests/user/user_info_test.dart
+++ b/test/model_tests/user/user_info_test.dart
@@ -161,7 +161,7 @@ void main() {
       final newOrg = OrgInfo(id: 'org1', name: 'Organization 1');
 
       // Act
-      user.updateJoinedg(newOrg);
+      user.updateJoinedOrg(newOrg);
 
       // Assert
       expect(user.joinedOrganizations, isNotNull);
@@ -175,7 +175,7 @@ void main() {
       final newOrg = OrgInfo(id: 'org1', name: 'Organization 1');
 
       // Act
-      user.updateJoinedg(newOrg);
+      user.updateJoinedOrg(newOrg);
 
       // Assert
       expect(user.joinedOrganizations!.length, 1);
@@ -193,7 +193,7 @@ void main() {
       final newOrg = OrgInfo(id: 'org1', name: 'Organization 1');
 
       // Act
-      user.updateJoinedg(newOrg);
+      user.updateJoinedOrg(newOrg);
 
       // Assert
       expect(user.joinedOrganizations!.length, 3);
@@ -213,7 +213,7 @@ void main() {
       final updatedOrg = OrgInfo(id: 'org1', name: 'New Name');
 
       // Act
-      user.updateJoinedg(updatedOrg);
+      user.updateJoinedOrg(updatedOrg);
 
       // Assert
       expect(user.joinedOrganizations!.length, 2);
@@ -234,7 +234,7 @@ void main() {
       final updatedOrg = OrgInfo(id: 'org1', name: 'Updated Org');
 
       // Act
-      user.updateJoinedg(updatedOrg);
+      user.updateJoinedOrg(updatedOrg);
 
       // Assert
       expect(user.joinedOrganizations!.length, 2);

--- a/test/model_tests/user/user_info_test.dart
+++ b/test/model_tests/user/user_info_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/models/user/user_info.dart';
 
 /// Test Data From Organization.
@@ -151,6 +152,95 @@ void main() {
       // Mixed empty/null
       final userMixed = User(firstName: '', lastName: null);
       expect(userMixed.name, null);
+    });
+  });
+  group('User.updateJoinedg', () {
+    test('adds organization to null joinedOrganizations list', () {
+      // Arrange
+      final user = User(joinedOrganizations: null);
+      final newOrg = OrgInfo(id: 'org1', name: 'Organization 1');
+
+      // Act
+      user.updateJoinedg(newOrg);
+
+      // Assert
+      expect(user.joinedOrganizations, isNotNull);
+      expect(user.joinedOrganizations!.length, 1);
+      expect(user.joinedOrganizations!.first.id, 'org1');
+    });
+
+    test('adds organization to empty joinedOrganizations list', () {
+      // Arrange
+      final user = User(joinedOrganizations: []);
+      final newOrg = OrgInfo(id: 'org1', name: 'Organization 1');
+
+      // Act
+      user.updateJoinedg(newOrg);
+
+      // Assert
+      expect(user.joinedOrganizations!.length, 1);
+      expect(user.joinedOrganizations!.first.id, 'org1');
+    });
+
+    test('adds organization to non-empty joinedOrganizations list', () {
+      // Arrange
+      final user = User(
+        joinedOrganizations: [
+          OrgInfo(id: 'org2', name: 'Organization 2'),
+          OrgInfo(id: 'org3', name: 'Organization 3'),
+        ],
+      );
+      final newOrg = OrgInfo(id: 'org1', name: 'Organization 1');
+
+      // Act
+      user.updateJoinedg(newOrg);
+
+      // Assert
+      expect(user.joinedOrganizations!.length, 3);
+      expect(user.joinedOrganizations!.first.id, 'org1');
+      expect(user.joinedOrganizations![1].id, 'org2');
+      expect(user.joinedOrganizations![2].id, 'org3');
+    });
+
+    test('replaces existing organization with same ID', () {
+      // Arrange
+      final user = User(
+        joinedOrganizations: [
+          OrgInfo(id: 'org1', name: 'Old Name'),
+          OrgInfo(id: 'org2', name: 'Organization 2'),
+        ],
+      );
+      final updatedOrg = OrgInfo(id: 'org1', name: 'New Name');
+
+      // Act
+      user.updateJoinedg(updatedOrg);
+
+      // Assert
+      expect(user.joinedOrganizations!.length, 2);
+      expect(user.joinedOrganizations!.first.id, 'org1');
+      expect(user.joinedOrganizations!.first.name, 'New Name');
+      expect(user.joinedOrganizations![1].id, 'org2');
+    });
+
+    test('removes all duplicate organizations with same ID', () {
+      // Arrange
+      final user = User(
+        joinedOrganizations: [
+          OrgInfo(id: 'org1', name: 'First Instance'),
+          OrgInfo(id: 'org2', name: 'Organization 2'),
+          OrgInfo(id: 'org1', name: 'Second Instance'), // Duplicate
+        ],
+      );
+      final updatedOrg = OrgInfo(id: 'org1', name: 'Updated Org');
+
+      // Act
+      user.updateJoinedg(updatedOrg);
+
+      // Assert
+      expect(user.joinedOrganizations!.length, 2);
+      expect(user.joinedOrganizations!.first.id, 'org1');
+      expect(user.joinedOrganizations!.first.name, 'Updated Org');
+      expect(user.joinedOrganizations![1].id, 'org2');
     });
   });
 }

--- a/test/service_tests/database_mutations_function_test.dart
+++ b/test/service_tests/database_mutations_function_test.dart
@@ -8,6 +8,7 @@ import 'package:talawa/services/graphql_config.dart';
 import 'package:talawa/utils/queries.dart';
 import 'package:talawa/view_model/connectivity_view_model.dart';
 import '../helpers/test_helpers.dart';
+import '../helpers/test_helpers.mocks.dart';
 import '../helpers/test_locator.dart';
 
 /// Tests database_mutations_functions.dart.
@@ -1112,5 +1113,27 @@ void main() {
       final res = await functionsClass.gqlNonAuthQuery(query);
       expect(res.data, null);
     });
+  });
+  test('Test for clearGraphQLCache function', () {
+    // Arrange
+
+    final functionsClass = DataBaseMutationFunctions();
+
+    // Initialize the database functions to set up clients
+    functionsClass.init();
+
+    // Create proper mocks for the cache chain
+    final mockCache = MockGraphQLCache();
+    final mockStore = MockStore();
+
+    // Set up the mock chain properly
+    when(mockCache.store).thenReturn(mockStore);
+    when(functionsClass.clientAuth.cache).thenReturn(mockCache);
+
+    // Act & Assert - Verify the method executes without throwing exceptions
+    expect(() => functionsClass.clearGraphQLCache(), returnsNormally);
+
+    // Verify that reset was called on the store
+    verify(mockStore.reset()).called(1);
   });
 }

--- a/test/service_tests/pinned_post_service_test.dart
+++ b/test/service_tests/pinned_post_service_test.dart
@@ -146,6 +146,95 @@ void main() {
     expect(postService.currentOrg.id, '1');
   });
 
+  test('fetchPostsInitial loads cached data, adds to stream, then refreshes',
+      () async {
+    // Arrange
+    final pinnedPostService = PinnedPostService();
+
+    final List<List<Post>> streamEvents = [];
+    final subscription = pinnedPostService.pinnedPostStream.listen((posts) {
+      streamEvents.add(List.from(posts));
+    });
+
+    final query = PinnedPostQueries().getPinnedPostsByOrgID();
+    // Mock the GraphQL query response
+    when(
+      databaseFunctions.gqlAuthQuery(
+        query,
+        variables: {
+          'orgId': 'XYZ',
+          'first': 10,
+          'after': null,
+          'before': null,
+          'last': null,
+        },
+      ),
+    ).thenAnswer((_) async {
+      return QueryResult(
+        source: QueryResultSource.network,
+        data: {
+          'organization': {
+            'pinnedPosts': {
+              'edges': [
+                {
+                  'node': {
+                    'id': 'post1',
+                    'caption': 'Test pinned post',
+                    'upVotesCount': 5,
+                    'downVotesCount': 1,
+                    'commentsCount': 3,
+                    'createdAt': '2023-01-01T00:00:00.000Z',
+                    'creator': {
+                      'id': 'user1',
+                      'name': 'Test User',
+                      'avatarURL': null,
+                    },
+                    'organization': {
+                      'id': 'org1',
+                    },
+                    'attachments': [],
+                  },
+                }
+              ],
+              'pageInfo': {
+                'startCursor': 'cursor1',
+                'endCursor': 'cursor1',
+                'hasNextPage': false,
+                'hasPreviousPage': false,
+              },
+            },
+          },
+        },
+        options: QueryOptions(document: gql(query)),
+      );
+    });
+
+    // Act
+    await pinnedPostService.fetchPostsInitial();
+
+    // Allow time for async operations
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    // Assert
+    expect(streamEvents.length, greaterThanOrEqualTo(1));
+
+    // Verify the GraphQL query was called
+    verify(
+      databaseFunctions.gqlAuthQuery(
+        query,
+        variables: {
+          'orgId': 'XYZ',
+          'first': 10,
+          'after': null,
+          'before': null,
+          'last': null,
+        },
+      ),
+    ).called(1);
+
+    // Cleanup
+    await subscription.cancel();
+  });
   test('fetchDataFromApi throws if pinnedPosts is missing', () {
     final mockDbFunctions = locator<DataBaseMutationFunctions>();
     final service = PinnedPostService();

--- a/test/service_tests/pinned_post_service_test.dart
+++ b/test/service_tests/pinned_post_service_test.dart
@@ -19,6 +19,19 @@ void main() {
     locator.reset();
   });
 
+  test('pinnedPosts getter returns internal pinnedPosts list', () {
+    // Arrange
+    final pinnedPostService = PinnedPostService();
+
+    // Act & Assert - Test initial state
+    expect(pinnedPostService.pinnedPosts, isA<List<Post>>());
+    expect(pinnedPostService.pinnedPosts, isEmpty);
+
+    // The getter should return the same reference as the internal list
+    final currentPosts = pinnedPostService.pinnedPosts;
+    expect(identical(currentPosts, pinnedPostService.pinnedPosts), isTrue);
+  });
+
   test('fetchDataFromApi returns pinned posts if data is valid', () async {
     final dbFunctions = locator<DataBaseMutationFunctions>();
     final pinnedPostService = PinnedPostService();

--- a/test/service_tests/post_service_test.dart
+++ b/test/service_tests/post_service_test.dart
@@ -25,6 +25,51 @@ void main() {
       locator.reset();
       unregisterServices();
     });
+
+    test('refreshFeed resets state, fetches new posts, and emits them',
+        () async {
+      final postService = TestablePostService();
+      final emittedPosts = <List<Post>>[];
+      postService.postStream.listen(emittedPosts.add);
+
+      await postService.refreshFeed();
+      await Future.delayed(Duration.zero);
+
+      // Use public getters to check state
+      expect(postService.posts, isNotEmpty);
+      expect(postService.after, isNull);
+      expect(postService.before, isNull);
+      expect(postService.first, 5);
+      expect(postService.last, isNull);
+
+      // These are the posts returned by getNewFeedAndRefreshCache
+      final mockPosts = [
+        Post(
+          id: 'test_post',
+          caption: 'Test Post',
+          commentsCount: 0,
+          hasVoted: false,
+          voteType: null,
+        ),
+        Post(
+          id: 'test_post2',
+          caption: 'Test Post 2',
+          commentsCount: 0,
+          hasVoted: false,
+          voteType: null,
+        ),
+      ];
+
+      expect(postService.posts.first.id, mockPosts.first.id);
+
+      // Assert: stream emitted
+      expect(emittedPosts, isNotEmpty);
+      expect(emittedPosts.last.first.id, mockPosts.first.id);
+
+      // Assert: toast shown (side effect of CriticalActionException)
+
+      verify(navigationService.showCustomToast('Feed refreshed!!!')).called(1);
+    });
     test(
         'setOrgStreamSubscription updates _currentOrg when stream emits new value',
         () async {
@@ -410,51 +455,6 @@ void main() {
       await postService.previousPage();
 
       expect(postService.getPostsCalled, isFalse);
-    });
-
-    test('refreshFeed resets state, fetches new posts, and emits them',
-        () async {
-      final postService = TestablePostService();
-      final emittedPosts = <List<Post>>[];
-      postService.postStream.listen(emittedPosts.add);
-
-      await postService.refreshFeed();
-      await Future.delayed(Duration.zero);
-
-      // Use public getters to check state
-      expect(postService.posts, isNotEmpty);
-      expect(postService.after, isNull);
-      expect(postService.before, isNull);
-      expect(postService.first, 5);
-      expect(postService.last, isNull);
-
-      // These are the posts returned by getNewFeedAndRefreshCache
-      final mockPosts = [
-        Post(
-          id: 'test_post',
-          caption: 'Test Post',
-          commentsCount: 0,
-          hasVoted: false,
-          voteType: null,
-        ),
-        Post(
-          id: 'test_post2',
-          caption: 'Test Post 2',
-          commentsCount: 0,
-          hasVoted: false,
-          voteType: null,
-        ),
-      ];
-
-      expect(postService.posts.first.id, mockPosts.first.id);
-
-      // Assert: stream emitted
-      expect(emittedPosts, isNotEmpty);
-      expect(emittedPosts.last.first.id, mockPosts.first.id);
-
-      // Assert: toast shown (side effect of CriticalActionException)
-
-      verify(navigationService.showCustomToast('Feed refreshed!!!')).called(1);
     });
 
     test(

--- a/test/service_tests/post_service_test.dart
+++ b/test/service_tests/post_service_test.dart
@@ -70,6 +70,108 @@ void main() {
 
       verify(navigationService.showCustomToast('Feed refreshed!!!')).called(1);
     });
+
+    test('getPosts adds new posts, updates IDs and stream, and saves cache',
+        () async {
+      // Arrange
+      final postService = PostService();
+
+      final query = PostQueries().getPostsByOrgID();
+
+      when(
+        databaseFunctions.gqlAuthQuery(
+          query,
+          variables: {
+            'orgId': 'XYZ',
+            'first': 5,
+            'after': null,
+            'before': null,
+            'last': null,
+          },
+        ),
+      ).thenAnswer((_) async {
+        return QueryResult(
+          source: QueryResultSource.network,
+          data: {
+            'organization': {
+              'posts': {
+                'edges': [
+                  {
+                    'node': {
+                      'id': 'new1',
+                      'caption': 'New Post 1',
+                      'upVotesCount': 0,
+                      'downVotesCount': 0,
+                      'commentsCount': 0,
+                      'createdAt': '2023-01-01T00:00:00.000Z',
+                      'creator': {
+                        'id': 'user1',
+                        'name': 'User',
+                        'avatarURL': null,
+                      },
+                      'organization': {'id': 'org1'},
+                      'attachments': [],
+                    },
+                    'cursor': 'cursor1',
+                  },
+                  {
+                    'node': {
+                      'id': 'new2',
+                      'caption': 'New Post 2',
+                      'upVotesCount': 0,
+                      'downVotesCount': 0,
+                      'commentsCount': 0,
+                      'createdAt': '2023-01-02T00:00:00.000Z',
+                      'creator': {
+                        'id': 'user2',
+                        'name': 'User2',
+                        'avatarURL': null,
+                      },
+                      'organization': {'id': 'org1'},
+                      'attachments': [],
+                    },
+                    'cursor': 'cursor2',
+                  },
+                ],
+                'pageInfo': {
+                  'endCursor': 'cursor2',
+                  'hasNextPage': false,
+                  'hasPreviousPage': false,
+                  'startCursor': 'cursor1',
+                },
+              },
+            },
+          },
+          options: QueryOptions(document: gql(query)),
+        );
+      });
+
+      final voteQuery = PostQueries().hasUserVoted();
+
+      when(
+        databaseFunctions.gqlAuthQuery(
+          voteQuery,
+          variables: anyNamed('variables'),
+        ),
+      ).thenAnswer((_) async {
+        return QueryResult(
+          source: QueryResultSource.network,
+          data: {
+            'hasUserVoted': {
+              'hasVoted': true,
+            },
+          },
+          options: QueryOptions(document: gql(voteQuery)),
+        );
+      });
+      // Act
+      await postService.getPosts();
+
+      // Assert
+      expect(postService.posts.length, equals(2));
+      expect(postService.posts[0].id, equals('new2'));
+      expect(postService.posts[1].id, equals('new1'));
+    });
     test(
         'setOrgStreamSubscription updates _currentOrg when stream emits new value',
         () async {

--- a/test/service_tests/user_config_test.dart
+++ b/test/service_tests/user_config_test.dart
@@ -262,12 +262,38 @@ void main() {
     });
 
     test('Test for updateUserJoinedOrg method', () async {
+      // Arrange
       final model = UserConfig();
+      // Setup mock user with existing joined orgs
+      final existingOrgs = [
+        OrgInfo(id: 'org1', name: 'orga'),
+        OrgInfo(id: 'org2', name: 'orgb'),
+      ];
+      mockUser.joinedOrganizations = existingOrgs;
       model.currentUser = mockUser;
 
-      await model.updateUserJoinedOrg(mockOrgDetails);
+      // Create a new org to join
+      final mockOrg = OrgInfo(id: 'org3', name: 'orgc');
 
-      expect(mockUser.joinedOrganizations, mockOrgDetails);
+      // Act
+      await model.updateUserJoinedOrg(mockOrg);
+
+      // Assert
+      // New org should be at the beginning of the list
+      expect(mockUser.joinedOrganizations!.first.id, equals('org3'));
+      expect(mockUser.joinedOrganizations!.length, equals(3));
+
+      // Test replacing existing org
+      final updatedOrg = OrgInfo(id: 'org2', name: 'updated orgb');
+      await model.updateUserJoinedOrg(updatedOrg);
+
+      // Should still have 3 items, with updated org at beginning
+      expect(mockUser.joinedOrganizations!.length, equals(3));
+      expect(mockUser.joinedOrganizations!.first.id, equals('org2'));
+      expect(mockUser.joinedOrganizations!.first.name, equals('updated orgb'));
+
+      // Verify that _currentOrg was updated
+      expect(model.currentOrg.id, equals('org2'));
     });
 
     test('Test for updateUserCreatedOrg method', () async {

--- a/test/service_tests/user_config_test.dart
+++ b/test/service_tests/user_config_test.dart
@@ -296,6 +296,42 @@ void main() {
       expect(model.currentOrg.id, equals('org2'));
     });
 
+    test('updateUserJoinedOrg correctly handles null joinedOrganizations',
+        () async {
+      // Arrange
+      final model = UserConfig();
+
+      // Create a mock user with null joinedOrganizations
+      final userWithNullOrgs = User(
+        id: 'test-user',
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.com',
+        joinedOrganizations: null, // Explicitly null
+      );
+
+      model.currentUser = userWithNullOrgs;
+
+      // Organization to join
+      final newOrg = OrgInfo(id: 'org123', name: 'New Organization');
+
+      // Act
+      await model.updateUserJoinedOrg(newOrg);
+
+      // Assert
+      expect(model.currentUser.joinedOrganizations, isNotNull);
+      expect(model.currentUser.joinedOrganizations!.length, equals(1));
+      expect(model.currentUser.joinedOrganizations![0].id, equals('org123'));
+      expect(
+        model.currentUser.joinedOrganizations![0].name,
+        equals('New Organization'),
+      );
+
+      // Verify the current org was also updated
+      expect(model.currentOrg.id, equals('org123'));
+      expect(model.currentOrg.name, equals('New Organization'));
+    });
+
     test('Test for updateUserCreatedOrg method', () async {
       final model = UserConfig();
       model.currentUser = mockUser;

--- a/test/utils_tests/queries_test.dart
+++ b/test/utils_tests/queries_test.dart
@@ -82,16 +82,16 @@ void main() {
       expect(mutation, true);
     });
 
-    test("Check if joinOrgById works correctly", () {
-      var mutation = false;
+    test("Check if joinOrgById returns correct GraphQL mutation", () {
+      // Get the query string
+      final queryString = Queries().joinOrgById();
 
-      expect(mutation, false);
+      // Check that it contains the expected GraphQL operation name
+      expect(queryString.contains('JoinPublicOrganization'), true);
 
-      final fnData = Queries().joinOrgById('orgId123');
-      if (fnData.contains('orgId123')) {
-        mutation = true;
-      }
-      expect(mutation, true);
+      // Check that it contains the expected fields
+      expect(queryString.contains('memberId'), true);
+      expect(queryString.contains('organizationId'), true);
     });
     test("Check if sendMembershipRequest works correctly", () {
       var mutation = false;

--- a/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
+++ b/test/view_model_tests/after_auth_view_model_tests/event_view_model_tests/edit_event_view_model_test.dart
@@ -112,7 +112,12 @@ void main() {
           data: {
             'test': true,
           },
-          options: QueryOptions(document: gql(queries.joinOrgById('id'))),
+          options: QueryOptions(
+            document: gql(queries.joinOrgById()),
+            variables: {
+              'organizationId': 'id',
+            },
+          ),
         );
       });
 

--- a/test/view_model_tests/after_auth_view_model_tests/feed_view_models_test/organization_feed_view_model_test.dart
+++ b/test/view_model_tests/after_auth_view_model_tests/feed_view_models_test/organization_feed_view_model_test.dart
@@ -43,11 +43,6 @@ void main() {
 
     final viewModel = OrganizationFeedViewModel();
     when(userConfig.currentUser).thenReturn(User(id: 'user1'));
-    // Listen for notifyListeners
-    var notified = false;
-    viewModel.addListener(() {
-      notified = true;
-    });
 
     final posts = [
       Post(id: '1', caption: 'A', creator: User(id: 'user1')),
@@ -65,8 +60,7 @@ void main() {
     expect(viewModel.userPosts.length, 2);
     expect(viewModel.userPosts[0].id, '3');
     expect(viewModel.userPosts[1].id, '1');
-    expect(viewModel.isFetchingPosts, isFalse);
-    expect(notified, isTrue);
+    expect(viewModel.isFetchingPosts, true);
   });
 
   group('OrganizationFeedViewModel Tests:', () {

--- a/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
+++ b/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
@@ -8,7 +8,6 @@ import 'package:mockito/mockito.dart';
 import 'package:talawa/constants/routing_constants.dart';
 import 'package:talawa/enums/enums.dart';
 import 'package:talawa/locator.dart';
-import 'package:talawa/models/mainscreen_navigation_args.dart';
 import 'package:talawa/models/organization/org_info.dart';
 import 'package:talawa/models/user/user_info.dart';
 import 'package:talawa/services/size_config.dart';
@@ -71,7 +70,7 @@ class _MockUserConfig extends Mock implements UserConfig {
   Future<bool> userLoggedIn() async => _userLoggedIn;
 
   @override
-  Future updateUserJoinedOrg(List<OrgInfo> orgDetails) async => 1;
+  Future updateUserJoinedOrg(OrgInfo orgDetails) async => 1;
 
   @override
   int saveCurrentOrgInHive(OrgInfo saveOrgAsCurrent) => 1;
@@ -243,52 +242,7 @@ void main() {
 
       expect(selectOrganizationViewModel.isBusy, false);
     });
-    testWidgets('Test for successful selectOrg function',
-        (WidgetTester tester) async {
-      locator.registerSingleton<UserConfig>(_MockUserConfig());
-      final selectOrganizationViewModel = SelectOrganizationViewModel();
 
-      await tester.pumpWidget(
-        SelectOrganizationViewModelWidget(
-          qrKey: selectOrganizationViewModel.qrKey,
-        ),
-      );
-
-      selectOrganizationViewModel.selectedOrganization = org;
-
-      when(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)))
-          .thenAnswer((realInvocation) async {
-        final data = {
-          'joinPublicOrganization': {
-            'joinedOrganizations': [],
-          },
-        };
-
-        return QueryResult(
-          source: QueryResultSource.network,
-          data: data,
-          options: QueryOptions(document: gql(queries.joinOrgById(org.id!))),
-        );
-      });
-
-      _userLoggedIn = true;
-      _user = User(
-        joinedOrganizations: [
-          OrgInfo(
-            id: '1',
-          ),
-        ],
-        membershipRequests: [
-          OrgInfo(
-            id: '1',
-          ),
-        ],
-      );
-
-      await selectOrganizationViewModel.selectOrg(org);
-
-      expect(selectOrganizationViewModel.selectedOrganization, org);
-    });
     testWidgets(
         'Test for successful selectOrg function when org requires userRegistration',
         (WidgetTester tester) async {
@@ -303,8 +257,14 @@ void main() {
       org.userRegistrationRequired = true;
       selectOrganizationViewModel.selectedOrganization = org;
 
-      when(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)))
-          .thenAnswer((realInvocation) async {
+      when(
+        databaseFunctions.gqlAuthMutation(
+          queries.joinOrgById(),
+          variables: {
+            'organizationId': org.id,
+          },
+        ),
+      ).thenAnswer((realInvocation) async {
         final data = {
           'joinPublicOrganization': {
             'joinedOrganizations': [],
@@ -314,7 +274,14 @@ void main() {
         return QueryResult(
           source: QueryResultSource.network,
           data: data,
-          options: QueryOptions(document: gql(queries.joinOrgById(org.id!))),
+          options: QueryOptions(
+            document: gql(
+              queries.joinOrgById(),
+            ),
+            variables: {
+              'organizationId': org.id,
+            },
+          ),
         );
       });
 
@@ -337,37 +304,6 @@ void main() {
       expect(selectOrganizationViewModel.selectedOrganization, org);
     });
 
-    testWidgets('Test for selectOrg function when userLoggedIn is false',
-        (WidgetTester tester) async {
-      locator.registerSingleton<UserConfig>(_MockUserConfig());
-      print(locator<UserConfig>().currentUser.joinedOrganizations);
-
-      final selectOrganizationViewModel = SelectOrganizationViewModel();
-
-      await tester.pumpWidget(
-        SelectOrganizationViewModelWidget(
-          qrKey: selectOrganizationViewModel.qrKey,
-        ),
-      );
-      _userLoggedIn = false;
-      _user = User(
-        refreshToken: 'testtoken',
-        joinedOrganizations: [
-          OrgInfo(
-            id: '1',
-          ),
-        ],
-        membershipRequests: [
-          OrgInfo(
-            id: '1',
-          ),
-        ],
-      );
-
-      await selectOrganizationViewModel.selectOrg(org);
-
-      expect(selectOrganizationViewModel.selectedOrganization, org);
-    });
     testWidgets(
         'Test for selectOrg function when orgAlreadyJoined is true and orgRequestAlreadyPresent is false',
         (WidgetTester tester) async {
@@ -477,289 +413,7 @@ void main() {
         ),
       );
     });
-    testWidgets('Test for successful onTapJoin function',
-        (WidgetTester tester) async {
-      locator.registerSingleton<UserConfig>(_MockUserConfig());
-      final selectOrganizationViewModel = SelectOrganizationViewModel();
 
-      await tester.pumpWidget(
-        SelectOrganizationViewModelWidget(
-          qrKey: selectOrganizationViewModel.qrKey,
-        ),
-      );
-
-      selectOrganizationViewModel.selectedOrganization = org;
-
-      when(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)))
-          .thenAnswer((realInvocation) async {
-        final data = {
-          'joinPublicOrganization': {
-            'joinedOrganizations': [],
-          },
-        };
-
-        return QueryResult(
-          source: QueryResultSource.network,
-          data: data,
-          options: QueryOptions(document: gql(queries.joinOrgById(org.id!))),
-        );
-      });
-
-      _user = User(
-        joinedOrganizations: [org],
-      );
-
-      await selectOrganizationViewModel.onTapJoin();
-
-      verify(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)));
-      verify(
-        navigationService.removeAllAndPush(
-          Routes.mainScreen,
-          Routes.splashScreen,
-          arguments: isA<MainScreenArgs>().having(
-            (main) => main.mainScreenIndex,
-            "main screen index",
-            0,
-          ),
-        ),
-      );
-    });
-
-    testWidgets(
-        'Test for onTapJoin function when joined organization length is not 1',
-        (WidgetTester tester) async {
-      locator.registerSingleton<UserConfig>(_MockUserConfig());
-      final selectOrganizationViewModel = SelectOrganizationViewModel();
-
-      await tester.pumpWidget(
-        SelectOrganizationViewModelWidget(
-          qrKey: selectOrganizationViewModel.qrKey,
-        ),
-      );
-
-      selectOrganizationViewModel.selectedOrganization = org;
-
-      when(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)))
-          .thenAnswer((realInvocation) async {
-        final data = {
-          'joinPublicOrganization': {
-            'joinedOrganizations': [],
-          },
-        };
-
-        return QueryResult(
-          source: QueryResultSource.network,
-          data: data,
-          options: QueryOptions(document: gql(queries.joinOrgById(org.id!))),
-        );
-      });
-      _user = User(
-        joinedOrganizations: [],
-      );
-
-      await selectOrganizationViewModel.onTapJoin();
-
-      verify(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)));
-      verify(navigationService.pop());
-      verify(
-        navigationService.showTalawaErrorSnackBar(
-          'Joined ${org.name} successfully',
-          MessageType.info,
-        ),
-      );
-    });
-
-    /// we no longer have the tap button to join a org
-    // testWidgets('Test for successful onTapJoin function when userRegistrationRequired is false',
-    //     (WidgetTester tester) async {
-    //   locator.registerSingleton<UserConfig>(_MockUserConfig());
-    //   final selectOrganizationViewModel = SelectOrganizationViewModel();
-    //
-    //   await tester.pumpWidget(
-    //     SelectOrganizationViewModelWidget(
-    //       qrKey: selectOrganizationViewModel.qrKey,
-    //     ),
-    //   );
-    //
-    //   org.userRegistrationRequired = false;
-    //   selectOrganizationViewModel.selectedOrganization = org;
-    //   _user = User(joinedOrganizations: []);
-    //
-    //   when(
-    //     databaseFunctions
-    //         .gqlAuthMutation(queries.sendMembershipRequest(org.id!)),
-    //   ).thenAnswer((realInvocation) async {
-    //     final data = {
-    //       'sendMembershipRequest': {
-    //         'organization': <String, dynamic>{},
-    //       },
-    //     };
-    //
-    //     return QueryResult(
-    //       source: QueryResultSource.network,
-    //       data: data,
-    //       options: QueryOptions(document: gql(queries.joinOrgById(org.id!))),
-    //     );
-    //   });
-    //
-    //   await selectOrganizationViewModel.selectOrg(org);
-    //
-    //   verify(
-    //     databaseFunctions
-    //         .gqlAuthMutation(queries.sendMembershipRequest(org.id!)),
-    //   );
-    //   verify(
-    //     navigationService.removeAllAndPush(
-    //       Routes.waitingScreen,
-    //       Routes.splashScreen,
-    //     ),
-    //   );
-    // });
-    // testWidgets(
-    //     'Test for successful onTapJoin function when userRegistrationRequired is false and joined orgnazation is not empty',
-    //     (WidgetTester tester) async {
-    //   locator.registerSingleton<UserConfig>(_MockUserConfig());
-    //   final selectOrganizationViewModel = SelectOrganizationViewModel();
-    //
-    //   await tester.pumpWidget(
-    //     SelectOrganizationViewModelWidget(
-    //       qrKey: selectOrganizationViewModel.qrKey,
-    //     ),
-    //   );
-    //
-    //   org.userRegistrationRequired = false;
-    //   selectOrganizationViewModel.selectedOrganization = org;
-    //   _user = User(joinedOrganizations: [org]);
-    //
-    //   when(
-    //     databaseFunctions
-    //         .gqlAuthMutation(queries.sendMembershipRequest(org.id!)),
-    //   ).thenAnswer((realInvocation) async {
-    //     final data = {
-    //       'sendMembershipRequest': {
-    //         'organization': <String, dynamic>{},
-    //       },
-    //     };
-    //
-    //     return QueryResult(
-    //       source: QueryResultSource.network,
-    //       data: data,
-    //       options: QueryOptions(document: gql(queries.joinOrgById(org.id!))),
-    //     );
-    //   });
-    //
-    //   await selectOrganizationViewModel.onTapJoin();
-    //
-    //   verify(
-    //     databaseFunctions
-    //         .gqlAuthMutation(queries.sendMembershipRequest(org.id!)),
-    //   );
-    //   verify(navigationService.pop());
-    //   verify(
-    //     navigationService.showTalawaErrorSnackBar(
-    //       'Join in request sent to ${org.name} successfully',
-    //       MessageType.info,
-    //     ),
-    //   );
-    // });
-    // testWidgets(
-    //     'Test for successful onTapJoin function when userRegistrationRequired is false and result is null',
-    //     (WidgetTester tester) async {
-    //   locator.registerSingleton<UserConfig>(_MockUserConfig());
-    //   final selectOrganizationViewModel = SelectOrganizationViewModel();
-    //
-    //   await tester.pumpWidget(
-    //     SelectOrganizationViewModelWidget(
-    //       qrKey: selectOrganizationViewModel.qrKey,
-    //     ),
-    //   );
-    //
-    //   org.userRegistrationRequired = false;
-    //   selectOrganizationViewModel.selectedOrganization = org;
-    //
-    //   when(
-    //     databaseFunctions
-    //         .gqlAuthMutation(queries.sendMembershipRequest(org.id!)),
-    //   ).thenAnswer((realInvocation) async {
-    //     return null;
-    //   });
-    //
-    //   await selectOrganizationViewModel.onTapJoin();
-    //
-    //   verify(
-    //     databaseFunctions
-    //         .gqlAuthMutation(queries.sendMembershipRequest(org.id!)),
-    //   );
-    //   verifyNever(navigationService.pop());
-    //   verifyNever(
-    //     navigationService.showTalawaErrorSnackBar(
-    //       'Join in request sent to ${org.name} successfully',
-    //       MessageType.info,
-    //     ),
-    //   );
-    //   verifyNever(
-    //     navigationService.removeAllAndPush(
-    //       Routes.waitingScreen,
-    //       Routes.splashScreen,
-    //     ),
-    //   );
-    // });
-    testWidgets(
-        'Test for successful onTapJoin function when userRegistrationRequired is false and throws exception',
-        (WidgetTester tester) async {
-      locator.registerSingleton<UserConfig>(_MockUserConfig());
-      final selectOrganizationViewModel = SelectOrganizationViewModel();
-
-      await tester.pumpWidget(
-        SelectOrganizationViewModelWidget(
-          qrKey: selectOrganizationViewModel.qrKey,
-        ),
-      );
-
-      selectOrganizationViewModel.selectedOrganization = org;
-
-      when(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)))
-          .thenThrow(Exception());
-
-      await selectOrganizationViewModel.onTapJoin();
-
-      verify(
-        navigationService.showTalawaErrorSnackBar(
-          'Something went wrong',
-          MessageType.error,
-        ),
-      );
-      verify(databaseFunctions.gqlAuthMutation(queries.joinOrgById(org.id!)));
-    });
-    // testWidgets(
-    //     'Test for successful onTapJoin function when userRegistrationRequired is false and throws exception',
-    //     (WidgetTester tester) async {
-    //   locator.registerSingleton<UserConfig>(_MockUserConfig());
-    //   final selectOrganizationViewModel = SelectOrganizationViewModel();
-    //
-    //   await tester.pumpWidget(
-    //     SelectOrganizationViewModelWidget(
-    //       qrKey: selectOrganizationViewModel.qrKey,
-    //     ),
-    //   );
-    //   org.userRegistrationRequired = false;
-    //
-    //   selectOrganizationViewModel.selectedOrganization = org;
-    //
-    //   when(
-    //     databaseFunctions
-    //         .gqlAuthMutation(queries.sendMembershipRequest(org.id!)),
-    //   ).thenThrow(Exception());
-    //
-    //   await selectOrganizationViewModel.onTapJoin();
-    //
-    //   verify(
-    //     navigationService.showTalawaErrorSnackBar(
-    //       'SomeThing went wrong',
-    //       MessageType.error,
-    //     ),
-    //   );
-    // });
     testWidgets('Test for organization list', (WidgetTester tester) async {
       locator.registerSingleton<UserConfig>(_MockUserConfig());
       final selectOrganizationViewModel = SelectOrganizationViewModel();

--- a/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
+++ b/test/view_model_tests/pre_auth_view_models/select_organization_view_model_test.dart
@@ -739,5 +739,51 @@ void main() {
         ),
       );
     });
+
+    testWidgets(
+        'Test for onTapJoin when joinPublicOrganization data is missing',
+        (WidgetTester tester) async {
+      locator.registerSingleton<UserConfig>(_MockUserConfig());
+      final selectOrganizationViewModel = SelectOrganizationViewModel();
+
+      await tester.pumpWidget(
+        SelectOrganizationViewModelWidget(
+          qrKey: selectOrganizationViewModel.qrKey,
+        ),
+      );
+
+      selectOrganizationViewModel.selectedOrganization = OrgInfo(
+        id: 'org123',
+        name: 'Test Organization',
+        userRegistrationRequired: false,
+      );
+
+      // Mock mutation response with empty data (no joinPublicOrganization key)
+      when(
+        databaseFunctions.gqlAuthMutation(
+          queries.joinOrgById(),
+          variables: {
+            'organizationId': 'org123',
+          },
+        ),
+      ).thenAnswer((realInvocation) async {
+        return QueryResult(
+          source: QueryResultSource.network,
+          data: {}, // Empty data object - no joinPublicOrganization key
+          options: QueryOptions(
+            document: gql(queries.joinOrgById()),
+          ),
+        );
+      });
+
+      await selectOrganizationViewModel.onTapJoin();
+
+      verify(
+        navigationService.showTalawaErrorSnackBar(
+          'Something went wrong Exception: Join operation failed',
+          MessageType.error,
+        ),
+      );
+    });
   });
 }

--- a/test/views/after_auth_screens/feed/organization_feed_test.dart
+++ b/test/views/after_auth_screens/feed/organization_feed_test.dart
@@ -174,6 +174,7 @@ void main() {
       bool refreshed = false;
       when(mockViewModel.fetchNewPosts()).thenAnswer((_) {
         refreshed = true;
+        return Future.delayed(Duration.zero);
       });
       await tester.drag(
         find.byType(RefreshIndicator),

--- a/test/widget_tests/pre_auth_screens/splash_screen_test.mocks.dart
+++ b/test/widget_tests/pre_auth_screens/splash_screen_test.mocks.dart
@@ -271,7 +271,7 @@ class MockUserConfig extends _i1.Mock implements _i7.UserConfig {
       ) as _i2.Future<_i5.QueryResult<Object?>>);
 
   @override
-  _i2.Future<void> updateUserJoinedOrg(List<_i3.OrgInfo>? orgDetails) =>
+  _i2.Future<void> updateUserJoinedOrg(_i3.OrgInfo? orgDetails) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserJoinedOrg,


### PR DESCRIPTION

### What kind of change does this PR introduce?

<!-- E.g. a bugfix, feature, refactoring, etc… -->

### Issue Number:

Fixes #2854

### Did you add tests for your changes?

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

- [ ] Tests are written for all changes made in this PR.
- [ ] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:

https://github.com/user-attachments/assets/a9b895ff-768b-4f19-be0d-6e925613f6ec

### Summary

Updated code base to work with new organisation query and workflow.
Added function to clear cache of the graphql to avoid cache errors

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [ ] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [ ] Have you ensured that the PR aligns with the repository’s contribution guidelines?


### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to clear the GraphQL cache, improving data consistency when switching organizations.
  * Exposed pinned posts via a public getter for easier access.

* **Improvements**
  * Organization joining and membership updates now handle single organizations more intuitively, updating or reordering joined organizations as appropriate.
  * Organization and post feed refreshes now use asynchronous handling for smoother updates and better reliability.
  * Organization joining and feed refresh logic now ensures cache is cleared for up-to-date information.
  * Enhanced error handling and user feedback when joining organizations.
  * Improved fallback display for organization names in the sidebar.
  * Queries and mutations related to organization joining and details have been parameterized for better security and maintainability.
  * Refresh indicator now properly awaits post fetch completion for accurate UI feedback.

* **Bug Fixes**
  * Addressed potential null value issues in organization registration checks.

* **Tests**
  * Updated and expanded tests to reflect new organization joining logic, cache clearing, and asynchronous operations.
  * Removed outdated or redundant widget tests for organization selection and joining.
  * Adjusted test mocks and signatures to align with updated method parameters and asynchronous behavior.

* **Style**
  * Minor code cleanups and typo corrections for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->