### PR TITLE
Implemented tests for org_info.dart

### DIFF
--- a/test/model_tests/organization/org_info_test.dart
+++ b/test/model_tests/organization/org_info_test.dart
@@ -2,6 +2,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:talawa/models/organization/org_info.dart';
 
 void main() {
+  late OrgInfo instance;
+
+  setUp(() {
+    instance = OrgInfo();
+  });
   group('OrgInfo model tests', () {
     final Map<String, dynamic> json1 = {
       "id": "123",
@@ -59,6 +64,292 @@ void main() {
         isTrue,
         reason: 'Hash codes should be equal',
       );
+    });
+  });
+
+  group('fromJsonToList', () {
+    test('returns empty list when json is null', () {
+      final result = instance.fromJsonToList(null);
+      expect(result, isEmpty);
+    });
+
+    test('returns empty list when json is empty list', () {
+      final result = instance.fromJsonToList([]);
+      expect(result, isEmpty);
+    });
+
+    test('does not parse single Map<String, dynamic> directly', () {
+      final json = {
+        'id': '1',
+        'name': 'Test Org',
+      };
+      final result = instance.fromJsonToList(json);
+      expect(result, isEmpty);
+    });
+
+    test('parses single map when wrapped in a list', () {
+      final json = [
+        {
+          'id': '1',
+          'name': 'Test Org',
+        }
+      ];
+      final result = instance.fromJsonToList(json);
+
+      expect(result, hasLength(1));
+      expect(result.first.id, '1');
+      expect(result.first.name, 'Test Org');
+    });
+
+    test('parses flat list of maps correctly', () {
+      final json = [
+        {'id': '1', 'name': 'Org 1'},
+        {'id': '2', 'name': 'Org 2'},
+        {'id': '3', 'name': 'Org 3'},
+      ];
+
+      final result = instance.fromJsonToList(json);
+
+      expect(result, hasLength(3));
+      expect(result[0].id, '1');
+      expect(result[1].id, '2');
+      expect(result[2].id, '3');
+    });
+
+    test('parses nested list of lists correctly', () {
+      final json = [
+        [
+          {'id': '1', 'name': 'Org 1'},
+          {'id': '2', 'name': 'Org 2'},
+        ],
+        [
+          {'id': '3', 'name': 'Org 3'},
+        ],
+      ];
+
+      final result = instance.fromJsonToList(json);
+
+      expect(result, hasLength(3));
+      expect(result[0].id, '1');
+      expect(result[1].id, '2');
+      expect(result[2].id, '3');
+    });
+
+    test('handles mixed nested and flat structure', () {
+      final json = [
+        {'id': '1', 'name': 'Org 1'},
+        [
+          {'id': '2', 'name': 'Org 2'},
+          {'id': '3', 'name': 'Org 3'},
+        ],
+        {'id': '4', 'name': 'Org 4'},
+      ];
+
+      final result = instance.fromJsonToList(json);
+
+      expect(result, hasLength(4));
+      expect(result[0].id, '1');
+      expect(result[1].id, '2');
+      expect(result[2].id, '3');
+      expect(result[3].id, '4');
+    });
+
+    test('skips invalid elements in list', () {
+      final json = [
+        {'id': '1', 'name': 'Org 1'},
+        'invalid string',
+        123,
+        {'id': '2', 'name': 'Org 2'},
+        null,
+      ];
+
+      final result = instance.fromJsonToList(json);
+
+      expect(result, hasLength(2));
+      expect(result[0].id, '1');
+      expect(result[1].id, '2');
+    });
+
+    test('skips invalid maps in nested lists', () {
+      final json = [
+        [
+          {'id': '1', 'name': 'Org 1'},
+          'invalid',
+        ],
+        [
+          {'id': '2', 'name': 'Org 2'},
+        ],
+      ];
+
+      final result = instance.fromJsonToList(json);
+
+      expect(result, hasLength(2));
+    });
+
+    test('returns empty list for invalid json types', () {
+      expect(instance.fromJsonToList('string'), isEmpty);
+      expect(instance.fromJsonToList(123), isEmpty);
+      expect(instance.fromJsonToList(true), isEmpty);
+    });
+
+    test('handles empty nested lists', () {
+      final json = [
+        [],
+        {'id': '1', 'name': 'Org 1'},
+        [],
+      ];
+
+      final result = instance.fromJsonToList(json);
+
+      expect(result, hasLength(1));
+      expect(result[0].id, '1');
+    });
+
+    test('does not handle deeply nested lists (more than 2 levels)', () {
+      final json = [
+        [
+          [
+            {'id': '1', 'name': 'Org 1'},
+          ],
+        ],
+      ];
+
+      final result = instance.fromJsonToList(json);
+
+      expect(result, isEmpty);
+    });
+
+    group('fromBasicJsonToList', () {
+      test('returns empty list when data is null', () {
+        final result = instance.fromBasicJsonToList(null);
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when data is empty map', () {
+        final result = instance.fromBasicJsonToList({});
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when organizations key is missing', () {
+        final data = {
+          'someOtherKey': 'value',
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when organizations is null', () {
+        final data = {
+          'organizations': null,
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when organizations is not a list', () {
+        final data = {
+          'organizations': 'not a list',
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, isEmpty);
+      });
+
+      test('parses organizations list correctly', () {
+        final data = {
+          'organizations': [
+            {'id': '1', 'name': 'Org 1'},
+            {'id': '2', 'name': 'Org 2'},
+            {'id': '3', 'name': 'Org 3'},
+          ],
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, hasLength(3));
+        expect(result[0].id, '1');
+        expect(result[1].id, '2');
+        expect(result[2].id, '3');
+      });
+
+      test('skips invalid items in organizations list', () {
+        final data = {
+          'organizations': [
+            {'id': '1', 'name': 'Org 1'},
+            'invalid',
+            null,
+            {'id': '2', 'name': 'Org 2'},
+            123,
+          ],
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, hasLength(2));
+        expect(result[0].id, '1');
+        expect(result[1].id, '2');
+      });
+
+      test('handles empty organizations list', () {
+        final data = {
+          'organizations': [],
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, isEmpty);
+      });
+
+      test('ignores other keys in data', () {
+        final data = {
+          'organizations': [
+            {'id': '1', 'name': 'Org 1'},
+          ],
+          'otherKey': 'value',
+          'anotherKey': 123,
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, hasLength(1));
+        expect(result[0].id, '1');
+      });
+
+      test('does not handle nested lists in organizations', () {
+        final data = {
+          'organizations': [
+            [
+              {'id': '1', 'name': 'Org 1'},
+              {'id': '2', 'name': 'Org 2'},
+            ],
+          ],
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+        expect(result, isEmpty);
+      });
+
+      test('handles flat list in organizations', () {
+        final data = {
+          'organizations': [
+            {'id': '1', 'name': 'Org 1'},
+            {'id': '2', 'name': 'Org 2'},
+          ],
+        };
+
+        final result = instance.fromBasicJsonToList(data);
+
+        expect(result, hasLength(2));
+        expect(result[0].id, '1');
+        expect(result[1].id, '2');
+      });
     });
   });
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?

feat(tests): Implemented tests for fromJsonToList & fromBasicJsonToList for org_info_test

### Issue Number:

Fixes #2904 

### Did you add tests for your changes?

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:
<img width="2446" height="176" alt="image" src="https://github.com/user-attachments/assets/1dd901ef-d5dd-4d8b-b590-ac4f6057432f" />


### Summary
Earlier the test coverage of org_info was only 60.42%. Functions like fromJsonToList & fromBasicJsonToList had no tests. This pr includes tests for those functions bringing the the test coverage of org_info.dart to 100%.

### Does this PR introduce a breaking change?
No

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?


### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded unit test coverage for organization data parsing, covering null/empty inputs, single and multiple entries, lists, mixed and nested structures, invalid elements, and deeply nested cases.
  - Added shared setup to ensure consistent initialization across tests.
  - Retained and strengthened existing parsing tests to verify multiple fields are correctly mapped.
  - Introduced adapter-related tests to confirm consistent equality and hashing behavior.
  - Overall, increases confidence in data handling and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->