### PR TITLE
Bfix: Fix push.yml workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   CODECOV_UNIQUE_NAME: CODECOV_UNIQUE_NAME-${{ github.run_id }}-${{ github.run_number }}
-  FLUTTER_VERSION: 3.32.
+  FLUTTER_VERSION: 3.32.8
 
 jobs:
   Flutter-Codebase-Check:
@@ -168,7 +168,7 @@ jobs:
 
   iOS-Build:
     if: ${{ github.actor != 'dependabot[bot]' }}
-    name: iOS Build and Relaese
+    name: iOS Build and Release
     permissions:
       contents: write
     runs-on: macos-latest
@@ -184,8 +184,6 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: "stable" # or: 'beta', 'dev' or 'master'
           architecture: x64
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable" # or: 'beta', 'dev' or 'master'
       - name: Copy .env.example to .env
         run: cp .env.example .env
       - name: Building for ios
@@ -200,7 +198,7 @@ jobs:
         run: |
           mkdir Payload
           cp -r build/ios/iphoneos/Runner.app Payload/Runner.app
-          zip -r app.ipa Payload
+          zip -r app-release.ipa Payload
         # This packages the Runner.app into an .ipa file
 
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
### What kind of change does this PR introduce?

bugfix : Fixes the ci workflow for push events

### Issue Number:

Fixes #2957 

### Did you add tests for your changes?

Yes

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:


### If relevant, did you update the documentation?
Not relevant
### Summary
- CI was failing due to duplicate flutter version and channel in iOS  build
- Fixed CI failure caused by duplicate flutter-version and channel entries in the iOS build job.
- Removed redundant fields in iOS build.
- Corrected iOS artifact name mismatch (app-release.ipa → app.ipa).
- Fixed typo in job name.
- Updated Flutter version to proper semantic format.

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

### Other information

Flutter version is same as pull-request.yml

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Flutter version to 3.32.8 for iOS builds
  * Corrected iOS job name typo
  * Removed duplicate Flutter action parameters
  * Updated iOS artifact naming to app-release.ipa

<!-- end of auto-generated comment: release notes by coderabbit.ai -->