### PR TITLE
fix: Resolve null safety issues in SplashScreen and MainScreenViewModel

### DIFF
--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -231,7 +231,7 @@ class _SplashScreenState extends State<SplashScreen> {
         return;
       }
 
-      if (currentUser.membershipRequests!.isNotEmpty) {
+      if (currentUser.membershipRequests?.isNotEmpty ?? false) {
         pushReplacementScreen(Routes.waitingScreen, arguments: '0');
         return;
       }

--- a/lib/view_model/main_screen_view_model.dart
+++ b/lib/view_model/main_screen_view_model.dart
@@ -355,7 +355,7 @@ class MainScreenViewModel extends BaseModel {
         description:
             'Click this button to see options related to switching, joining and leaving organization(s)',
         isCircle: true,
-        next: () => scaffoldKey.currentState!.openDrawer(),
+        next: () => scaffoldKey.currentState?.openDrawer(),
         appTour: appTour,
       ),
     );
@@ -463,7 +463,7 @@ class MainScreenViewModel extends BaseModel {
   Future<void> showHome(TargetFocus clickedTarget) async {
     switch (clickedTarget.identify) {
       case "keySHMenuIcon":
-        scaffoldKey.currentState!.openDrawer();
+        scaffoldKey.currentState?.openDrawer();
         break;
       case "keyDrawerLeaveCurrentOrg":
         navigationService.pop();


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bug fix

### Issue Number:

Fixes #2819

### Did you add tests for your changes?

- [ ] Tests are written for all changes made in this PR.
- [ ] Test coverage meets or exceeds the current coverage (~90/95%).

**Note**: This PR fixes critical null safety issues that cause app crashes. Tests will be added in a follow-up PR to verify the null safety handling.

### Snapshots/Videos:

N/A - This is a null safety fix that prevents crashes during hot restart and app tour interactions.

### If relevant, did you update the documentation?

N/A - No documentation updates required for this bug fix.

### Summary

This PR resolves critical null safety issues that cause the app to crash during hot restart and when interacting with the app tour feature.

**Problems Fixed:**
1. **SplashScreen crash**: The [_handleUserLogIn](cci:1://file:///Users/nallanaharikrishna/opensource/talawa/lib/splash_screen.dart:200:2-240:3) method used null assertion operator (`!`) on `membershipRequests` without checking if it was null, causing crashes when the field was uninitialized during hot restart.
2. **MainScreenViewModel crash**: The [tourHomeTargets](cci:1://file:///Users/nallanaharikrishna/opensource/talawa/lib/view_model/main_screen_view_model.dart:332:2-453:3) and [showHome](cci:1://file:///Users/nallanaharikrishna/opensource/talawa/lib/view_model/main_screen_view_model.dart:455:2-479:3) methods used null assertion operator on `scaffoldKey.currentState`, causing crashes when the scaffold state wasn't available during app tour interactions.

**Changes Made:**
- Replaced `currentUser.membershipRequests!.isNotEmpty` with `currentUser.membershipRequests?.isNotEmpty ?? false` in [splash_screen.dart](cci:7://file:///Users/nallanaharikrishna/opensource/talawa/lib/splash_screen.dart:0:0-0:0)
- Replaced `scaffoldKey.currentState!.openDrawer()` with `scaffoldKey.currentState?.openDrawer()` in [main_screen_view_model.dart](cci:7://file:///Users/nallanaharikrishna/opensource/talawa/lib/view_model/main_screen_view_model.dart:0:0-0:0) (2 occurrences)

These changes use null-aware operators (`?.`) and null-coalescing operators (`??`) to gracefully handle null values instead of crashing.

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [ ] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository's contribution guidelines?

### Other information

This fix addresses the root cause of crashes reported in issue #2819. The app now handles hot restarts gracefully and properly manages null values during initialization and app tour interactions.

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed potential crashes by implementing safer null-checking for membership status verification
* Improved drawer operation reliability through enhanced null-aware handling to prevent crashes when accessing drawer functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->