### PR TITLE
fix: Resolve null safety issues in SplashScreen and MainScreenViewModel

### DIFF
--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -231,7 +231,7 @@ class _SplashScreenState extends State<SplashScreen> {
         return;
       }
 
-      if (currentUser.membershipRequests!.isNotEmpty) {
+      if (currentUser.membershipRequests?.isNotEmpty ?? false) {
         pushReplacementScreen(Routes.waitingScreen, arguments: '0');
         return;
       }

--- a/lib/view_model/main_screen_view_model.dart
+++ b/lib/view_model/main_screen_view_model.dart
@@ -355,7 +355,7 @@ class MainScreenViewModel extends BaseModel {
         description:
             'Click this button to see options related to switching, joining and leaving organization(s)',
         isCircle: true,
-        next: () => scaffoldKey.currentState!.openDrawer(),
+        next: () => scaffoldKey.currentState?.openDrawer(),
         appTour: appTour,
       ),
     );
@@ -463,7 +463,7 @@ class MainScreenViewModel extends BaseModel {
   Future<void> showHome(TargetFocus clickedTarget) async {
     switch (clickedTarget.identify) {
       case "keySHMenuIcon":
-        scaffoldKey.currentState!.openDrawer();
+        scaffoldKey.currentState?.openDrawer();
         break;
       case "keyDrawerLeaveCurrentOrg":
         navigationService.pop();


### PR DESCRIPTION
### What kind of change does this PR introduce?
- Bugfix: Resolves null safety issues in SplashScreen and MainScreenViewModel to prevent runtime crashes.

### Issue Number:
Fixes #2819

### Summary
- Added null safety for `membershipRequests` in SplashScreen.
- Added null checks for `scaffoldKey.currentState` in MainScreenViewModel.
- Prevents crashes during hot restart and app tour.
- Ensures app stability and prevents unexpected crashes caused by null values.

### Did you add tests for your changes?
- [ ] Tests are written for all changes made in this PR.
- [x] Manual testing performed:
  - Hot restart tested without crashes.
  - App tour tested successfully.
  - Verified membershipRequests handling in SplashScreen.

### Snapshots/Videos:
<!-- Optional: Add screenshots or screen recordings if relevant -->

### If relevant, did you update the documentation?
- No documentation changes needed.

### Does this PR introduce a breaking change?
- No breaking changes.

### Checklist for Repository Standards
- [x] Reviewed and followed all applicable review suggestions.
- [x] PR aligns with the repository’s contribution guidelines.

### Other information
- Submitted against `develop-postgres` branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential null reference crashes by replacing unsafe null assertions with safe null-handling operations in membership request validation during app startup and menu icon interaction handling during navigation. This improves overall application stability and prevents unwanted crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->