### PR TITLE
fix: added language icon and test (clean and scoped)

### DIFF
--- a/test/custom_painters/language_icon_test.dart
+++ b/test/custom_painters/language_icon_test.dart
@@ -1,12 +1,9 @@
-// test/custom_painters/language_icon_test.dart
 import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:talawa/custom_painters/language_icon.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   group('LanguageIcon painter tests', () {
     test('shouldRepaint always returns true', () {
       final painter = LanguageIcon();
@@ -14,8 +11,15 @@ void main() {
       expect(painter.shouldRepaint(old), isTrue);
     });
 
-    test('paint executes on a raw Canvas (PictureRecorder) without throwing',
+    test(
+        'shouldRepaint returns true even when old delegate is also LanguageIcon',
         () {
+      final painter = LanguageIcon();
+      final oldPainter = LanguageIcon();
+      expect(painter.shouldRepaint(oldPainter), isTrue);
+    });
+
+    test('paint executes on a raw Canvas without throwing', () {
       final recorder = ui.PictureRecorder();
       const size = Size(200.0, 200.0);
       final canvas =
@@ -29,7 +33,7 @@ void main() {
       expect(picture, isNotNull);
     });
 
-    testWidgets('LanguageIcon renders inside a CustomPaint widget',
+    testWidgets('LanguageIcon renders correctly inside CustomPaint',
         (tester) async {
       final painter = LanguageIcon();
 


### PR DESCRIPTION
### What kind of change does this PR introduce?
> 🧪 **Test Improvement** — Added **unit and widget tests** for `LanguageIcon` in `lib/custom_painters/language_icon.dart` to improve test coverage and ensure stable rendering.

---

### Issue Number:
> Fixes #2935

---

### Did you add tests for your changes?
- [x] Yes, all new logic is covered by tests.
- [x] Test coverage meets or exceeds previous coverage (100%).

---

### Snapshots / Videos:
https://github.com/user-attachments/assets/2c14fe2a-c670-498e-b710-35a780c1a266

---

### Summary
This PR adds **unit and widget tests** for the `LanguageIcon` custom painter.

#### Highlights:
- ✅ Verified `shouldRepaint()` always returns `true`
- ✅ Ensured `paint()` executes without exceptions
- ✅ Confirmed proper rendering in `CustomPaint`
- ✅ Achieved **100% test coverage**

#### Commands used:
```bash
flutter test --coverage test/custom_painters/language_icon_test.dart
lcov --summary coverage/lcov.info


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit and widget tests for the LanguageIcon painter verifying repaint behavior, successful painting to a raw canvas without errors, and proper rendering inside a CustomPaint widget (including expected size checks). Tests include a simulated prior painter to exercise repaint logic and ensure integration with the rendering lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->