### PR TITLE
test: fix language icon test analysis issues

### DIFF
--- a/test/custom_painters/language_icon_test.dart
+++ b/test/custom_painters/language_icon_test.dart
@@ -1,0 +1,76 @@
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talawa/custom_painters/language_icon.dart';
+
+void main() {
+  group('LanguageIcon painter tests', () {
+    test('shouldRepaint always returns true', () {
+      final painter = LanguageIcon();
+      final old = _FakeCustomPainter();
+      expect(painter.shouldRepaint(old), isTrue);
+    });
+
+    test(
+        'shouldRepaint returns true even when old delegate is also LanguageIcon',
+        () {
+      final painter = LanguageIcon();
+      final oldPainter = LanguageIcon();
+      expect(painter.shouldRepaint(oldPainter), isTrue);
+    });
+
+    test('paint executes on a raw Canvas without throwing', () {
+      final recorder = ui.PictureRecorder();
+      const size = Size(200.0, 200.0);
+      final canvas =
+          Canvas(recorder, Rect.fromLTWH(0, 0, size.width, size.height));
+
+      final painter = LanguageIcon();
+
+      expect(() => painter.paint(canvas, size), returnsNormally);
+
+      final picture = recorder.endRecording();
+      expect(picture, isNotNull);
+    });
+
+    testWidgets('LanguageIcon renders correctly inside CustomPaint',
+        (tester) async {
+      final painter = LanguageIcon();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 48,
+                height: 48,
+                child: CustomPaint(
+                  key: const Key('language_icon_paint'),
+                  painter: painter,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('language_icon_paint')), findsOneWidget);
+
+      final render = tester.renderObject<RenderBox>(
+        find.byKey(const Key('language_icon_paint')),
+      );
+
+      expect(render.size, equals(const Size(48, 48)));
+    });
+  });
+}
+
+class _FakeCustomPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {}
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?
> 🧪 **Test Improvement** — Added **unit and widget tests** for `LanguageIcon` in `lib/custom_painters/language_icon.dart` to improve test coverage and ensure stable rendering.

---

### Issue Number:
> Fixes #2935 
---

### Did you add tests for your changes?
- [x] Yes, all new logic is covered by tests.
- [x] Test coverage meets or exceeds previous coverage (100%).

---

### Snapshots / Videos:
https://github.com/user-attachments/assets/2c14fe2a-c670-498e-b710-35a780c1a266

---

### Summary
This PR adds **unit and widget tests** for the `LanguageIcon` custom painter.

#### Highlights:
- ✅ Verified `shouldRepaint()` always returns `true`
- ✅ Ensured `paint()` executes without exceptions
- ✅ Confirmed proper rendering in `CustomPaint`
- ✅ Achieved **100% test coverage**

#### Commands used:
```bash
flutter test --coverage test/custom_painters/language_icon_test.dart
lcov --summary coverage/lcov.info


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and widget tests for the LanguageIcon component, verifying rendering behavior and visual output dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->