### PR TITLE
Fixed Auto Assignment for issues created by collaborators

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -149,10 +149,7 @@ jobs:
             * Author is the owner of the repository.
             */
 
-            // Restrict /assign based on issue creator's permissions
-            // 1. We don't want non repo members using the feature to assign themselves issues created by other non-members. This could prevent the 
-            //    the issue creator from using the feature if they are slower than someone else monitoring the issue queue more diligently
-            // 2. This feature also forces the issues created by non-members from assigning themselves issues without manual intervention by members
+            // Issues created by non-members require manual intervention by members for auto-assignment.
             if (isAssign) {
               const issueCreator = issue.user.login;
               let issueCreatorAssociation;


### PR DESCRIPTION
Fixed Auto Assignment for issues created by collaborators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `/assign` command now checks the issue creator's association (OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR) before proceeding.
  * Creators without an allowed association receive a bot comment denying the assignment.

* **Bug Fixes / Improvements**
  * Validation and denial are enforced earlier to prevent unauthorized assignment attempts and reduce unnecessary processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->