### PR TITLE
test: add custom drawer tests and fix group chat tests

### DIFF
--- a/test/widget_tests/widgets/custom_drawer_test.dart
+++ b/test/widget_tests/widgets/custom_drawer_test.dart
@@ -83,43 +83,31 @@ void main() {
   });
 
   group('MainScreen drawer & demo mode', () {
-    testWidgets('Test main screen renders with drawer capability',
-        (tester) async {
+    testWidgets('Main screen renders with drawer and scaffold', (tester) async {
       await tester.pumpWidget(createHomePageScreen(demoMode: true));
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
-      // Verify main screen rendered
+      // Verify main screen and its scaffold both exist
       expect(find.byKey(const Key('MainScreen')), findsOneWidget);
+      expect(find.byKey(const Key('MainScaffold')), findsOneWidget);
     });
 
-    testWidgets('Test main screen with demo mode enabled', (tester) async {
+    testWidgets('Main screen renders with demo mode enabled', (tester) async {
       await tester.pumpWidget(createHomePageScreen(demoMode: true));
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       // Verify main screen rendered in demo mode
       expect(find.byType(MainScreen), findsOneWidget);
-      final mainScreen = tester.widget<MainScreen>(
-        find.byType(MainScreen),
-      );
+      final mainScreen = tester.widget<MainScreen>(find.byType(MainScreen));
       expect(mainScreen.mainScreenArgs.toggleDemoMode, isTrue);
     });
 
-    testWidgets('Test main screen initializes scaffold', (tester) async {
+    testWidgets('Main screen receives expected arguments', (tester) async {
       await tester.pumpWidget(createHomePageScreen(demoMode: true));
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
-      // Verify scaffold exists for drawer functionality
-      // MainScreen contains a Scaffold with key 'MainScaffold'
-      expect(find.byKey(const Key('MainScaffold')), findsOneWidget);
-    });
-
-    testWidgets('Test main screen receives expected arguments', (tester) async {
-      await tester.pumpWidget(createHomePageScreen(demoMode: true));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-
-      final mainScreen = tester.widget<MainScreen>(
-        find.byKey(const Key('MainScreen')),
-      );
+      final mainScreen =
+          tester.widget<MainScreen>(find.byKey(const Key('MainScreen')));
       expect(mainScreen.mainScreenArgs.mainScreenIndex, 0);
       expect(mainScreen.mainScreenArgs.fromSignUp, isFalse);
       expect(mainScreen.mainScreenArgs.toggleDemoMode, isTrue);


### PR DESCRIPTION
## What Changed

- Fixed 12 group chat test failures
- Restored custom drawer widget tests  
- Fixed lint warnings on 13 lib files
- All CI checks now passing

## Files Changed

- test/widget_tests/widgets/custom_drawer_test.dart
- test/views/after_auth_screens/chat/create_group_bottom_sheet_test.dart
- 13 lib files with consolidated ignore directives

## Status

✅ All checks passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added widget tests covering the custom drawer and exit dialog, including verification of the Exit button and dialog rendering.
  * Added tests for MainScreen rendering with drawer and demo-mode enabled, scaffold initialization checks, and argument/state assertions.
  * Test setup includes lifecycle management and helpers to render the app within a localized, themed MaterialApp; includes a placeholder group for future drawer interaction tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->