### PR TITLE
Add test coverage for GroupChatDialogs private constructor

### DIFF
--- a/lib/views/after_auth_screens/chat/widgets/group_chat_dialogs.dart
+++ b/lib/views/after_auth_screens/chat/widgets/group_chat_dialogs.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 import 'package:talawa/models/chats/chat.dart';
 import 'package:talawa/view_model/after_auth_view_models/chat_view_models/group_chat_view_model.dart';
 import 'package:talawa/views/after_auth_screens/chat/widgets/group_chat_info_dialogs.dart';
@@ -11,6 +12,10 @@ import 'package:talawa/views/after_auth_screens/chat/widgets/group_chat_manageme
 /// - GroupChatManagementDialogs: For complex management operations
 class GroupChatDialogs {
   const GroupChatDialogs._();
+
+  /// Factory method for testing purposes only.
+  @visibleForTesting
+  factory GroupChatDialogs.testInstance() => const GroupChatDialogs._();
 
   /// Shows group information dialog.
   ///

--- a/test/views/after_auth_screens/chat/widgets/group_chat_dialogs_test.dart
+++ b/test/views/after_auth_screens/chat/widgets/group_chat_dialogs_test.dart
@@ -52,6 +52,15 @@ void main() {
   });
 
   group('GroupChatDialogs Facade Tests', () {
+    test('Private constructor coverage', () {
+      // This test ensures the private constructor line is actually executed
+      // We use the @visibleForTesting factory method to access it
+      final instance = GroupChatDialogs.testInstance();
+      // Verify the instance is created
+      expect(instance, isNotNull);
+      expect(instance, isA<GroupChatDialogs>());
+    });
+
     group('showGroupInfo Tests', () {
       testWidgets('Delegates to GroupChatInfoDialogs.showGroupInfo',
           (tester) async {


### PR DESCRIPTION
# PR: Improve Test Coverage for `GroupChatDialogs`

**Added a `@visibleForTesting` factory constructor and a corresponding test to ensure the private constructor is executed and included in test coverage.**

## What kind of change does this PR introduce?
 Test coverage improvement.

## Issue Number

Fixes #2928


## Did you add tests for your changes?

✔ Tests are written for all changes made in this PR.  
✔ Test coverage meets or exceeds the current coverage target (~90–95%).

## Summary

This PR adds a `@visibleForTesting` factory method inside `GroupChatDialogs` to safely expose the private constructor for testing purposes.  
The private constructor was previously never executed, causing a drop in test coverage.  
A dedicated unit test now invokes this constructor through the factory method, ensuring the line is covered without altering production behavior.

## Does this PR introduce a breaking change?

**No.**  
The change only affects test execution.


## Checklist for Repository Standards

✔ Reviewed and implemented applicable `coderaabbitai` suggestions.  
✔ Confirmed alignment with the repository's contribution guidelines.


## Have you read the contributing guide?

Yes — https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added testing infrastructure for group chat dialogs component to improve test coverage and enable easier unit testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->