### PR TITLE
test: improve group_chats.dart coverage to 100%

### DIFF
--- a/test/views/after_auth_screens/chat/group_chats_test.dart
+++ b/test/views/after_auth_screens/chat/group_chats_test.dart
@@ -222,7 +222,6 @@ void main() {
       verify(groupChatViewModel.refreshChats()).called(1);
 
       // Verify UI reflects refreshed state
-      await tester.pumpAndSettle();
       expect(find.byType(GroupChatTile), findsOneWidget);
     });
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

Test coverage improvement

### Issue Number:

Fixes #2927 

### Did you add tests for your changes?

Yes

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:

<img width="1820" height="49" alt="image" src="https://github.com/user-attachments/assets/94dbf58f-6a9f-4abf-b5ea-d61a580e6eda" />


### If relevant, did you update the documentation?

<!--Add link to Talawa-Docs.-->

### Summary

Improved test coverage for `lib/views/after_auth_screens/chat/group_chats.dart` from 98.46% to 100%.

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

### Other information

- Added test case: "Pull to refresh works correctly with existing chats"
- This test covers the `onRefresh` function (line 91) in the non-empty state RefreshIndicator
- Previous tests only covered the empty state RefreshIndicator

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for group chat pull-to-refresh in both empty and populated chat scenarios.
  * Added a new test for non-empty chats and refined the empty-chat test; both render the UI, simulate pull-to-refresh on the list, wait for the refresh delay, and verify the refresh action is triggered and the UI updates (refresh indicator and chat tiles remain/appear).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->