### PR TITLE
test/improve group chat coverage to 100%

### DIFF
--- a/test/views/after_auth_screens/chat/group_chats_test.dart
+++ b/test/views/after_auth_screens/chat/group_chats_test.dart
@@ -223,7 +223,7 @@ void main() {
       // Verify UI reflects refreshed state
       expect(find.byType(GroupChatTile), findsOneWidget);
     });
-    
+
     testWidgets('onRefresh method functionality test', (tester) async {
       // Test that we can create the widget and verify the onRefresh callback exists
       when(groupChatViewModel.groupChats).thenReturn([]);


### PR DESCRIPTION
### What kind of change does this PR introduce?

Test coverage improvement

### Issue Number:

Fixes #2927 

### Did you add tests for your changes?

Yes

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:

<img width="1820" height="49" alt="image" src="https://github.com/user-attachments/assets/9b714032-dd5a-4a6d-a2a9-fbb3522de6c2" />


### If relevant, did you update the documentation?

<!--Add link to Talawa-Docs.-->

### Summary

Improved test coverage for `lib/views/after_auth_screens/chat/group_chats.dart` from 98.46% to 100%.

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

### Other information

- Added test case: "Pull to refresh works correctly with existing chats"
- This test covers the `onRefresh` lambda (line 91) in the non-empty state RefreshIndicator
- Previous tests only covered the empty state RefreshIndicator

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a widget test confirming pull-to-refresh triggers a refresh when group chats exist and that group chat items remain visible after refresh.
  * Expanded coverage of pull-to-refresh behavior for group chats; existing non-refresh tests remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->