### PR TITLE
test: 100% coverage Custom_Drawer_View_Model coverage

### DIFF
--- a/lib/view_model/widgets_view_models/custom_drawer_view_model.dart
+++ b/lib/view_model/widgets_view_models/custom_drawer_view_model.dart
@@ -147,6 +147,7 @@ class CustomDrawerViewModel extends BaseModel {
   /// **returns**:
   ///   None
   void setSelectedOrganizationName(OrgInfo updatedOrganization) {
+    if (_disposed) return;
     // if current and updated organization are not same.
     if (_selectedOrg != updatedOrganization) {
       _selectedOrg = updatedOrganization;


### PR DESCRIPTION
**Fixes #2926** 

### What kind of change does this PR introduce?
Test improvement / bugfix (non-breaking)

---

### Screenshots:

<img width="1796" height="431" alt="html custom drawer" src="https://github.com/user-attachments/assets/34edcbce-436c-4841-99c4-ed78454931ba" />
<img width="1232" height="233" alt="customdrawer" src="https://github.com/user-attachments/assets/dd97fa16-d555-4bdd-82f5-c07460887df5" />

---

### Summary
This PR improves 100% test coverage for `CustomDrawerViewModel` and adds a defensive safeguard to prevent state updates after disposal.

Covered scenarios include:
- `exitAlertDialog` returns a `CustomAlertDialog`
- `initialize()` updates `selectedOrg` when the organization stream emits a new value
- `dispose()` prevents listener notifications and state mutation
- `setSelectedOrganizationName()` does not notify listeners when the same organization is set
- Widget test validates that the exit dialog success callback exits the organization and closes the drawer

A guard was added to `setSelectedOrganizationName` to safely return when the view model is disposed.

---

### Does this PR introduce a breaking change?
No

---

### Checklist for Repository Standards
- [ ] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

---

### Other information
No functional or UI changes were introduced.  
Changes are limited to test improvements and internal state safety.

---

### Have you read the contributing guide?
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where organization selection could attempt to update after the interface was disposed, preventing potential errors during app lifecycle transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->