### PR TITLE
Fix/volunteer groups test coverage

### DIFF
--- a/test/views/after_auth_screens/events/volunteer_groups_screen_test.dart
+++ b/test/views/after_auth_screens/events/volunteer_groups_screen_test.dart
@@ -22,6 +22,12 @@ import 'package:talawa/views/base_view.dart';
 import '../../../helpers/test_helpers.dart';
 import '../../../helpers/test_locator.dart';
 
+const kAddGroupBtnKey = Key("add_group_btn");
+const kGroupNameFieldKey = Key("group_name_field");
+const kVolunteersRequiredFieldKey = Key("volunteers_required_field");
+const kAddGrpDialogueKey = Key("add_grp_dialogue");
+const kGroupDataKey = Key("group_data");
+
 Event getTestEvent({
   bool isPublic = false,
   bool viewOnMap = true,
@@ -84,7 +90,7 @@ Widget volunteerGroupsScreen({
             home: Scaffold(
               body: VolunteerGroupsScreen(
                 event: getTestEvent(),
-                model: EventInfoViewModel(),
+                model: model,
               ),
             ),
             navigatorKey: locator<NavigationService>().navigatorKey,
@@ -94,6 +100,24 @@ Widget volunteerGroupsScreen({
       );
     },
   );
+}
+
+/// Helper to setup mocks and pump widget with groups
+Future<void> setupAndPumpWithGroups(
+  WidgetTester tester,
+  List<EventVolunteerGroup> groups, {
+  Future<void> Function()? additionalSetup,
+}) async {
+  final mockEventService = locator<EventService>();
+  when(mockEventService.fetchVolunteerGroupsByEvent("1"))
+      .thenAnswer((_) async => groups);
+
+  if (additionalSetup != null) {
+    await additionalSetup();
+  }
+
+  await tester.pumpWidget(volunteerGroupsScreen());
+  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -110,10 +134,31 @@ void main() {
     unregisterServices();
   });
 
-  group("Widget Tests for VolunteerGroupscreen", () {
-    testWidgets("Check if VolunteerGroupscreen shows up", (tester) async {
-      await tester.pumpWidget(volunteerGroupsScreen());
-      await tester.pumpAndSettle();
+  setUp(() {
+    reset(locator<EventService>());
+    reset(locator<NavigationService>());
+    when(locator<NavigationService>().navigatorKey)
+        .thenReturn(GlobalKey<NavigatorState>());
+
+    // Default mocks for EventInfoViewModel initialization to prevent log errors
+    final mockEventService = locator<EventService>();
+    when(mockEventService.fetchAgendaCategories("1")).thenAnswer(
+      (_) async => QueryResult(
+        options: QueryOptions(document: gql('query {}')),
+        source: QueryResultSource.network,
+      ),
+    );
+    when(mockEventService.fetchAgendaItems("1")).thenAnswer(
+      (_) async => QueryResult(
+        options: QueryOptions(document: gql('query {}')),
+        source: QueryResultSource.network,
+      ),
+    );
+  });
+
+  group("Widget Tests for VolunteerGroupsScreen", () {
+    testWidgets("Check if VolunteerGroupsScreen shows up", (tester) async {
+      await setupAndPumpWithGroups(tester, []);
 
       expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
     });
@@ -121,14 +166,12 @@ void main() {
     testWidgets(
         "Check if no groups are displayed when there are no volunteer groups",
         (tester) async {
-      await tester.pumpWidget(volunteerGroupsScreen());
-      await tester.pumpAndSettle();
+      await setupAndPumpWithGroups(tester, []);
 
       expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
       expect(find.text("There aren't any volunteer groups"), findsOneWidget);
     });
     testWidgets("Check if groups show up", (tester) async {
-      final mockEventService = locator<EventService>();
       final mockGroups = [
         EventVolunteerGroup(name: "Group 1", createdAt: "2027-09-08"),
         EventVolunteerGroup(name: "Group 2", createdAt: "2027-09-09"),
@@ -142,27 +185,27 @@ void main() {
         },
       };
 
-      when(mockEventService.fetchVolunteerGroupsByEvent("1"))
-          .thenAnswer((_) async => mockGroups);
-
-      when(
-        mockEventService.createVolunteerGroup({
-          'eventId': "1",
-          'name': "New Group",
-          'volunteersRequired': 5,
-        }),
-      ).thenAnswer(
-        (realInvocation) async => QueryResult(
-          data: mockResult2,
-          source: QueryResultSource.network,
-          options: QueryOptions(
-            document: gql(EventQueries().createVolunteerGroup()),
-          ),
-        ),
+      await setupAndPumpWithGroups(
+        tester,
+        mockGroups,
+        additionalSetup: () async {
+          when(
+            locator<EventService>().createVolunteerGroup({
+              'eventId': "1",
+              'name': "New Group",
+              'volunteersRequired': 5,
+            }),
+          ).thenAnswer(
+            (realInvocation) async => QueryResult(
+              data: mockResult2,
+              source: QueryResultSource.network,
+              options: QueryOptions(
+                document: gql(EventQueries().createVolunteerGroup()),
+              ),
+            ),
+          );
+        },
       );
-
-      await tester.pumpWidget(volunteerGroupsScreen());
-      await tester.pumpAndSettle();
 
       expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
       expect(find.text("There aren't any volunteer groups"), findsNothing);
@@ -192,7 +235,6 @@ void main() {
       );
     });
     testWidgets("Check if edit group icon show up", (tester) async {
-      final mockEventService = locator<EventService>();
       final mockGroups = [
         EventVolunteerGroup(
           name: "Group 1",
@@ -206,15 +248,11 @@ void main() {
         ),
       ];
 
-      when(mockEventService.fetchVolunteerGroupsByEvent("1"))
-          .thenAnswer((_) async => mockGroups);
-
-      await tester.pumpWidget(volunteerGroupsScreen());
-      await tester.pumpAndSettle();
+      await setupAndPumpWithGroups(tester, mockGroups);
 
       expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
       expect(find.text("There aren't any volunteer groups"), findsNothing);
-      expect(find.byKey(const Key("group_data")), findsNWidgets(2));
+      expect(find.byKey(kGroupDataKey), findsNWidgets(2));
 
       expect(find.byIcon(Icons.edit), findsNWidgets(2));
 
@@ -222,63 +260,56 @@ void main() {
       await tester.pumpAndSettle();
     });
     testWidgets("Check if no groups show up", (tester) async {
-      final mockEventService = locator<EventService>();
-
-      when(mockEventService.fetchVolunteerGroupsByEvent("1"))
-          .thenAnswer((_) async => []);
-
-      await tester.pumpWidget(volunteerGroupsScreen());
-      await tester.pumpAndSettle();
+      await setupAndPumpWithGroups(tester, []);
 
       expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
       expect(find.text("There aren't any volunteer groups"), findsOneWidget);
     });
     testWidgets("Check if add group method throw error show up",
         (tester) async {
-      final mockEventService = locator<EventService>();
       final mockGroups = [
         EventVolunteerGroup(name: "Group 1", createdAt: "2027-09-08"),
         EventVolunteerGroup(name: "Group 2", createdAt: "2027-09-09"),
       ];
 
-      when(mockEventService.fetchVolunteerGroupsByEvent("1"))
-          .thenAnswer((_) async => mockGroups);
-
-      when(
-        mockEventService.createVolunteerGroup({
-          'eventId': "1",
-          'name': "New Group",
-          'volunteersRequired': 5,
-        }),
-      ).thenThrow("exception");
-
-      await tester.pumpWidget(volunteerGroupsScreen());
-      await tester.pumpAndSettle();
+      await setupAndPumpWithGroups(
+        tester,
+        mockGroups,
+        additionalSetup: () async {
+          when(
+            locator<EventService>().createVolunteerGroup({
+              'eventId': "1",
+              'name': "New Group",
+              'volunteersRequired': 5,
+            }),
+          ).thenThrow("exception");
+        },
+      );
 
       expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
       expect(find.text("There aren't any volunteer groups"), findsNothing);
-      expect(find.byKey(const Key("group_data")), findsNWidgets(2));
+      expect(find.byKey(kGroupDataKey), findsNWidgets(2));
 
-      expect(find.byKey(const Key("add_group_btn")), findsOneWidget);
-      await tester.tap(find.byKey(const Key("add_group_btn")));
+      expect(find.byKey(kAddGroupBtnKey), findsOneWidget);
+      await tester.tap(find.byKey(kAddGroupBtnKey));
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const Key("add_grp_dialogue")), findsOneWidget);
+      expect(find.byKey(kAddGrpDialogueKey), findsOneWidget);
       expect(find.text("Cancel"), findsOneWidget);
 
       await tester.tap(find.text("Cancel"));
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const Key("add_grp_dialogue")), findsNothing);
-      await tester.tap(find.byKey(const Key("add_group_btn")));
+      expect(find.byKey(kAddGrpDialogueKey), findsNothing);
+      await tester.tap(find.byKey(kAddGroupBtnKey));
       await tester.pumpAndSettle();
 
       await tester.enterText(
-        find.byKey(const Key("group_name_field")),
+        find.byKey(kGroupNameFieldKey),
         "New Group",
       );
       await tester.enterText(
-        find.byKey(const Key("volunteers_required_field")),
+        find.byKey(kVolunteersRequiredFieldKey),
         "5",
       );
 
@@ -290,44 +321,33 @@ void main() {
         findsOneWidget,
       );
     });
-    testWidgets("Check if add group method throw entre data show up",
+    testWidgets("Check if add group method validates entered data",
         (tester) async {
-      final mockEventService = locator<EventService>();
       final mockGroups = [
         EventVolunteerGroup(name: "Group 1", createdAt: "2027-09-08"),
         EventVolunteerGroup(name: "Group 2", createdAt: "2027-09-09"),
       ];
 
-      when(mockEventService.fetchVolunteerGroupsByEvent("1"))
-          .thenAnswer((_) async => mockGroups);
+      await setupAndPumpWithGroups(tester, mockGroups);
 
-      when(
-        mockEventService.createVolunteerGroup({
-          'eventId': "1",
-          'name': "New Group",
-          'volunteersRequired': 5,
-        }),
-      ).thenThrow("exception");
-
-      await tester.pumpWidget(volunteerGroupsScreen());
       await tester.pumpAndSettle();
 
       expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
       expect(find.text("There aren't any volunteer groups"), findsNothing);
-      expect(find.byKey(const Key("group_data")), findsNWidgets(2));
+      expect(find.byKey(kGroupDataKey), findsNWidgets(2));
 
-      expect(find.byKey(const Key("add_group_btn")), findsOneWidget);
-      await tester.tap(find.byKey(const Key("add_group_btn")));
+      expect(find.byKey(kAddGroupBtnKey), findsOneWidget);
+      await tester.tap(find.byKey(kAddGroupBtnKey));
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const Key("add_grp_dialogue")), findsOneWidget);
+      expect(find.byKey(kAddGrpDialogueKey), findsOneWidget);
 
       await tester.enterText(
-        find.byKey(const Key("group_name_field")),
+        find.byKey(kGroupNameFieldKey),
         "",
       );
       await tester.enterText(
-        find.byKey(const Key("volunteers_required_field")),
+        find.byKey(kVolunteersRequiredFieldKey),
         "0",
       );
 
@@ -338,6 +358,209 @@ void main() {
         find.text('Please enter valid data'),
         findsOneWidget,
       );
+    });
+    testWidgets("Check if invalid date is handled correctly", (tester) async {
+      final mockGroups = [
+        EventVolunteerGroup(
+          name: "Srikar's Team",
+          createdAt: "invalid-date-string",
+          volunteersRequired: 5,
+        ),
+      ];
+
+      await setupAndPumpWithGroups(tester, mockGroups);
+
+      expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
+      expect(find.text("Invalid date"), findsOneWidget);
+    });
+
+    testWidgets("Check if pull to refresh calls fetchVolunteerGroups",
+        (tester) async {
+      final mockEventService = locator<EventService>();
+      final mockGroups = [
+        EventVolunteerGroup(
+          name: "Srikar's Team",
+          createdAt: "2027-09-08",
+          volunteersRequired: 5,
+        ),
+      ];
+
+      await setupAndPumpWithGroups(tester, mockGroups);
+
+      await tester.drag(find.byType(RefreshIndicator), const Offset(0, 300));
+      await tester.pumpAndSettle();
+
+      verify(mockEventService.fetchVolunteerGroupsByEvent("1")).called(2);
+    });
+
+    testWidgets("Check if edit group navigation works with correct arguments",
+        (tester) async {
+      final mockNavigationService = locator<NavigationService>();
+      final mockGroups = [
+        EventVolunteerGroup(
+          name: "Srikar's Team",
+          createdAt: "2027-09-08",
+          volunteersRequired: 5,
+        ),
+      ];
+
+      await setupAndPumpWithGroups(tester, mockGroups);
+
+      await tester.tap(find.byIcon(Icons.edit).first);
+      await tester.pumpAndSettle();
+
+      verify(
+        mockNavigationService.pushScreen(
+          "/manageVolunteerScreen",
+          arguments: argThat(
+            isA<List>()
+                .having((list) => list.length, 'length', 2)
+                .having((list) => list[0], 'event', isA<Event>())
+                .having(
+                  (list) => list[1],
+                  'group',
+                  isA<EventVolunteerGroup>()
+                      .having((g) => g.name, 'name', "Srikar's Team"),
+                ),
+            named: 'arguments',
+          ),
+        ),
+      ).called(1);
+    });
+
+    testWidgets("Check if successful group creation navigates to manage screen",
+        (tester) async {
+      final mockEventService = locator<EventService>();
+      final mockNavigationService = locator<NavigationService>();
+      final mockGroups = [
+        EventVolunteerGroup(name: "Srikar's Team", createdAt: "2027-09-08"),
+      ];
+      final newGroupMap = {
+        '_id': "fakeUser2",
+        'name': "Srikar's Team",
+        'volunteersRequired': 5,
+        'volunteers': [],
+      };
+
+      await setupAndPumpWithGroups(
+        tester,
+        mockGroups,
+        additionalSetup: () async {
+          when(
+            mockEventService.createVolunteerGroup({
+              'eventId': "1",
+              'name': "Srikar's Team",
+              'volunteersRequired': 5,
+            }),
+          ).thenAnswer(
+            (realInvocation) async => QueryResult(
+              data: {'createEventVolunteerGroup': newGroupMap},
+              source: QueryResultSource.network,
+              options: QueryOptions(
+                document: gql(EventQueries().createVolunteerGroup()),
+              ),
+            ),
+          );
+        },
+      );
+
+      await tester.tap(find.byKey(kAddGroupBtnKey));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(kGroupNameFieldKey),
+        "Srikar's Team",
+      );
+      await tester.enterText(
+        find.byKey(kVolunteersRequiredFieldKey),
+        "5",
+      );
+
+      await tester.tap(find.text('Create Group'));
+      await tester.pumpAndSettle();
+
+      verify(
+        mockNavigationService.pushScreen(
+          "/manageVolunteerScreen",
+          arguments: argThat(
+            isA<List>()
+                .having((list) => list.length, 'length', 2)
+                .having((list) => list[0], 'event', isA<Event>())
+                .having(
+                  (list) => list[1],
+                  'group',
+                  isA<EventVolunteerGroup>()
+                      .having((g) => g.name, 'name', "Srikar's Team")
+                      .having(
+                        (g) => g.volunteersRequired,
+                        'volunteersRequired',
+                        5,
+                      ),
+                ),
+            named: 'arguments',
+          ),
+        ),
+      ).called(1);
+    });
+
+    testWidgets("Check if null date is handled correctly", (tester) async {
+      final mockGroups = [
+        EventVolunteerGroup(
+          name: "Srikar's Team",
+          createdAt: null,
+          volunteersRequired: 5,
+        ),
+      ];
+
+      await setupAndPumpWithGroups(tester, mockGroups);
+
+      expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
+      expect(find.text("N/A"), findsOneWidget);
+    });
+
+    testWidgets(
+        "Check if createVolunteerGroup returning null shows failure message",
+        (tester) async {
+      final mockEventService = locator<EventService>();
+      final mockGroups = [
+        EventVolunteerGroup(name: "Srikar's Team", createdAt: "2027-09-08"),
+      ];
+
+      await setupAndPumpWithGroups(
+        tester,
+        mockGroups,
+        additionalSetup: () async {
+          when(
+            mockEventService.createVolunteerGroup({
+              'eventId': "1",
+              'name': "Srikar's Team",
+              'volunteersRequired': 5,
+            }),
+          ).thenAnswer(
+            (realInvocation) async => QueryResult(
+              options: QueryOptions(document: gql('query {}')),
+              source: QueryResultSource.network,
+            ),
+          );
+        },
+      );
+
+      await tester.tap(find.byKey(kAddGroupBtnKey));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(kGroupNameFieldKey),
+        "Srikar's Team",
+      );
+      await tester.enterText(
+        find.byKey(kVolunteersRequiredFieldKey),
+        "5",
+      );
+
+      await tester.tap(find.text('Create Group'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Failed to create group'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?

feat(tests): Implemented tests for 100% coverage of volunteer_groups_screen.dart

### Issue Number:

Fixes #2907

### Did you add tests for your changes?
Yes
    •  Tests are written for all changes made in this PR.
    •  Test coverage meets or exceeds the current coverage (~90/95%).


Snapshots/Videos:
<img width="2670" height="1074" alt="Screenshot from 2025-12-18 10-49-29" src="https://github.com/user-attachments/assets/5041984a-3b23-42fa-b5b0-169e9ca44dca" />

### If relevant, did you update the documentation?

<!--Add link to Talawa-Docs.-->

### Summary

    1. Created a Helper Function: We implemented 
       setupAndPumpWithGroups to encapsulate the repetitive logic of setting up mocks and initializing the widget, drastically reducing boilerplate code.
    2. Flexible Test Configuration: The helper includes an 
       additionalSetup
        callback, allowing individual tests to inject specific behaviors (like mocking a successful creation or an error) without rewriting the main setup.
    3. Simplified Test Structure: Tests are now cleaner and easier to read; complex setup logic is abstracted away, leaving only the test-specific assertions and interactions visible.
    4. Verified Empty States: We ensured the UI correctly displays "There aren't any volunteer groups" when the list is empty by passing an empty list to the helper.
    5. Validated Data Entry: We confirmed that the "Create Group" dialog correctly validates inputs, showing error messages for empty names or invalid volunteer counts.
    6. Tested Error Handling: We covered failure scenarios, such as the backend throwing an exception or returning 
       null
       , ensuring the user sees the "Failed to create group" message.
    7. Ensured Correct Navigation: We verified that tapping the edit icon or successfully creating a group triggers the correct navigation path with the expected arguments.
    8.  Covered Date Edge Cases: We explicitly tested edge cases for date formatting, ensuring that null or invalid date strings do not crash the app and display appropriate fallback text ("N/A" or "Invalid date").
    9. Improved Code Quality: We refactored hardcoded string keys into constants (e.g., kAddGroupBtnKey) to prevent typos and corrected the ViewModel injection logic to ensure the test widget uses the properly initialized model from BaseView.

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [✓] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [✓] Have you ensured that the PR aligns with the repository’s contribution guidelines?


### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated GitHub Actions workflows for PR review validation, issue management, auto-assignment, and stale issue handling.
  * Introduced Python-based code quality tools for documentation checking, docstring validation, and translation comparison.

* **Bug Fixes**
  * Enhanced PR and issue template guidance with structured sections and requirements.

* **Refactor**
  * Migrated documentation infrastructure from Sphinx to Docusaurus.
  * Updated Android build system and Gradle wrapper to latest versions.
  * Reorganized GitHub workflow architecture for improved maintainability.

* **Documentation**
  * Added GitHub workflow guidelines and best practices.
  * Created structured issue and PR templates.

* **Chores**
  * Added linting and code quality configuration files (Flake8, Pydocstyle).
  * Updated project dependencies and build configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->