### PR TITLE
test: achieve 100% coverage for volunteer groups screen

### DIFF
--- a/test/views/after_auth_screens/events/volunteer_groups_screen_test.dart
+++ b/test/views/after_auth_screens/events/volunteer_groups_screen_test.dart
@@ -32,7 +32,6 @@ const Key _volunteersRequiredFieldKey = Key("volunteers_required_field");
 
 Event getTestEvent({
   bool isPublic = false,
-  bool viewOnMap = true,
   bool asAdmin = false,
 }) {
   return Event(
@@ -66,11 +65,7 @@ Event getTestEvent({
   );
 }
 
-Widget volunteerGroupsScreen({
-  bool isPublic = true,
-  bool viewOnMap = true,
-  bool asAdmin = true,
-}) {
+Widget volunteerGroupsScreen() {
   return BaseView<AppLanguage>(
     onModelReady: (model) => model.initialize(),
     builder: (context, langModel, child) {
@@ -106,7 +101,18 @@ Widget volunteerGroupsScreen({
   );
 }
 
-/// Helper to setup mocks and pump widget with groups
+/// Helper to setup mocks and pump widget with groups.
+///
+/// Configures EventService mocks for fetching groups, agenda categories,
+/// and agenda items to avoid null errors in ViewModel initialization.
+///
+/// **params**:
+/// * `tester`: The widget tester instance
+/// * `groups`: List of mock EventVolunteerGroup objects to be returned
+/// * `additionalSetup`: Optional callback for per-test mock configuration
+///
+/// **returns**:
+///   None
 Future<void> setupAndPumpWithGroups(
   WidgetTester tester,
   List<EventVolunteerGroup> groups, {
@@ -523,6 +529,22 @@ void main() {
         EventVolunteerGroup(
           name: "Srikar's Team",
           createdAt: null,
+          volunteersRequired: 5,
+        ),
+      ];
+
+      await setupAndPumpWithGroups(tester, mockGroups);
+
+      expect(find.byType(VolunteerGroupsScreen), findsOneWidget);
+      expect(find.text("N/A"), findsOneWidget);
+    });
+
+    testWidgets("Check if null group name is handled correctly",
+        (tester) async {
+      final mockGroups = [
+        EventVolunteerGroup(
+          name: null, // Test null name
+          createdAt: "2027-09-08",
           volunteersRequired: 5,
         ),
       ];


### PR DESCRIPTION
### What kind of change does this PR introduce?

feat(tests): Implemented tests for 100% coverage of volunteer_groups_screen.dart

### Issue Number:

Fixes #2907

### Did you add tests for your changes?
Yes
    •  Tests are written for all changes made in this PR.
    •  Test coverage meets or exceeds the current coverage (~90/95%).


Snapshots/Videos:
<img width="2832" height="1203" alt="Screenshot from 2025-12-18 21-58-10" src="https://github.com/user-attachments/assets/7ebc2ab4-c57a-4752-a4e8-edec534f5a86" />


### If relevant, did you update the documentation?

<!--Add link to Talawa-Docs.-->

### Summary

    1. Created a Helper Function: We implemented 
       setupAndPumpWithGroups to encapsulate the repetitive logic of setting up mocks and initializing the widget, drastically reducing boilerplate code.
    2. Flexible Test Configuration: The helper includes an 
       additionalSetup
        callback, allowing individual tests to inject specific behaviors (like mocking a successful creation or an error) without rewriting the main setup.
    3. Simplified Test Structure: Tests are now cleaner and easier to read; complex setup logic is abstracted away, leaving only the test-specific assertions and interactions visible.
    4. Verified Empty States: We ensured the UI correctly displays "There aren't any volunteer groups" when the list is empty by passing an empty list to the helper.
    5. Validated Data Entry: We confirmed that the "Create Group" dialog correctly validates inputs, showing error messages for empty names or invalid volunteer counts.
    6. Tested Error Handling: We covered failure scenarios, such as the backend throwing an exception or returning 
       null
       , ensuring the user sees the "Failed to create group" message.
    7. Ensured Correct Navigation: We verified that tapping the edit icon or successfully creating a group triggers the correct navigation path with the expected arguments.
    8.  Covered Date Edge Cases: We explicitly tested edge cases for date formatting, ensuring that null or invalid date strings do not crash the app and display appropriate fallback text ("N/A" or "Invalid date").
    9. Improved Code Quality: We refactored hardcoded string keys into constants (e.g., kAddGroupBtnKey) to prevent typos and corrected the ViewModel injection logic to ensure the test widget uses the properly initialized model from BaseView.

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [✓] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [✓] Have you ensured that the PR aligns with the repository’s contribution guidelines?


### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for volunteer group management: creation, editing, validation, error paths, handling invalid/null dates, pull-to-refresh, and navigation flows.
  * Added shared test scaffolding and helpers with reusable identifiers to centralize widget setup, mock service interactions, and improve consistency, readability, and maintainability across volunteer group tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->