### PR TITLE
Refactor: Extract GraphQL fragments and update tests

### DIFF
--- a/lib/utils/gql_fragments.dart
+++ b/lib/utils/gql_fragments.dart
@@ -1,0 +1,58 @@
+/// Fragment for User fields.
+const String userFieldsFragment = '''
+fragment UserFields on User {
+  id
+  name
+  avatarURL
+  emailAddress
+  description
+}
+''';
+
+/// Fragment for Organization fields.
+const String organizationFieldsFragment = '''
+fragment OrganizationFields on Organization {
+  id
+  name
+  addressLine1
+  addressLine2
+  avatarMimeType
+  avatarURL
+  postalCode
+  countryCode
+  description
+  isUserRegistrationRequired
+  state
+}
+''';
+
+/// Fragment for Author fields.
+const String authorFragment = '''
+fragment AuthorFields on User {
+  id
+  name
+  avatarURL
+}
+''';
+
+/// Fragment for Post fields.
+// Note: Post fields often include author
+const String postFragment = '''
+fragment PostFields on Post {
+  id
+  title
+  author {
+    ...AuthorFields
+  }
+}
+''';
+
+/// Fragment for Plugin fields.
+const String pluginFieldsFragment = '''
+fragment PluginFields on Plugin {
+  id
+  pluginId
+  isActivated
+  isInstalled
+}
+''';

--- a/lib/utils/queries.dart
+++ b/lib/utils/queries.dart
@@ -1,3 +1,5 @@
+import 'package:talawa/utils/gql_fragments.dart';
+
 ///This class returns some queries for the application.
 class Queries {
   //Returns a query to register a user.
@@ -30,23 +32,11 @@ class Queries {
               }) {
                 authenticationToken,
                 user{
-                  id
-                  name,
-                  avatarURL,
-                  emailAddress,
+                  ...UserFields
                   organizationsWhereMember(first:32){
                     edges{
                       node{
-                        id,
-                        name,
-                        addressLine1,
-                        addressLine2,
-                        avatarMimeType,
-                        avatarURL,
-                        postalCode,
-                        countryCode,
-                        description,
-                        isUserRegistrationRequired,
+                        ...OrganizationFields
                         members(first:32){
                           edges{
                             node{
@@ -62,6 +52,8 @@ class Queries {
                 
               }
             }
+    $userFieldsFragment
+    $organizationFieldsFragment
     """;
   }
 
@@ -80,25 +72,12 @@ class Queries {
       signIn(input: { emailAddress: "$email", password: "$password" }) {
         authenticationToken,
         user {
-          id,
-          name,
-          emailAddress,
-          name,
-          avatarURL,
-          orgIdWhereMembershipRequested,
+          ...UserFields
+          orgIdWhereMembershipRequested
           organizationsWhereMember(first:32){
             edges{
               node{
-                id,
-                name,
-                addressLine1,
-                addressLine2,
-                avatarMimeType,
-                avatarURL,
-                postalCode,
-                countryCode,
-                description,
-                isUserRegistrationRequired
+                ...OrganizationFields
                 members(first:32){
                   edges{
                     node{
@@ -114,6 +93,8 @@ class Queries {
         }
       }
     }
+    $userFieldsFragment
+    $organizationFieldsFragment
     """;
   }
 
@@ -168,17 +149,10 @@ class Queries {
     return """
     query {
       organizations{
-        id,
-        name,
-        addressLine1,
-        addressLine2,
-        description,
-        avatarURL,
-        countryCode,
-        state,
-        isUserRegistrationRequired,
+        ...OrganizationFields
       }
     }
+    $organizationFieldsFragment
     """;
   }
 
@@ -267,29 +241,19 @@ class Queries {
         \$id: String!
       ) {
         user(input: {id: \$id}) {
-          id
-          name
-          avatarURL
-          emailAddress
+          ...UserFields
           orgIdWhereMembershipRequested,
           organizationsWhereMember(first: 32) {
             edges {
               node {
-                id
-                name
-                addressLine1
-                addressLine2
-                avatarMimeType
-                avatarURL
-                postalCode
-                countryCode
-                description
-                isUserRegistrationRequired
+               ...OrganizationFields
               }
             }
           }
         }
       }
+      $userFieldsFragment
+      $organizationFieldsFragment
     ''';
   }
 
@@ -323,18 +287,10 @@ class Queries {
     return '''
     query{
       organization(input:{id:"$orgId"}){
-        id,
-        name,
-        addressLine1,
-        addressLine2,
-        avatarMimeType,
-        avatarURL,
-        postalCode,
-        countryCode,
-        description,
-        isUserRegistrationRequired,
+        ...OrganizationFields
       }
     }
+    $organizationFieldsFragment
     ''';
   }
 
@@ -440,13 +396,10 @@ class Queries {
     return '''
     query {
       usersByOrganizationId(organizationId: "$orgId") {
-        id
-        name
-        avatarURL
-        description
-        emailAddress
+        ...UserFields
       }
     }
+    $userFieldsFragment
     ''';
   }
 }

--- a/lib/views/after_auth_screens/menu/menu_page.dart
+++ b/lib/views/after_auth_screens/menu/menu_page.dart
@@ -7,6 +7,7 @@ import 'package:talawa/plugin/manager.dart';
 import 'package:talawa/plugin/plugin_injector.dart';
 import 'package:talawa/plugin/types.dart';
 import 'package:talawa/utils/app_localization.dart';
+import 'package:talawa/utils/gql_fragments.dart';
 
 /// MenuPage returns a widget that renders a menu page with vertical stack of links.
 class MenuPage extends StatelessWidget {
@@ -102,12 +103,10 @@ class MenuPage extends StatelessWidget {
           document: gql('''
             query GetAllPlugins {
               getPlugins(input: {}) {
-                id
-                pluginId
-                isActivated
-                isInstalled
+                ...PluginFields
               }
             }
+            $pluginFieldsFragment
           '''),
           fetchPolicy: FetchPolicy.networkOnly,
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -656,7 +656,7 @@ packages:
     source: hosted
     version: "2.1.3"
   gql:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: gql
       sha256: "67c32325eb55c15f526f0f5e7d8b38a463dbff2ec3c2e046be4a1a95f0dc93d1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,6 +92,7 @@ dev_dependencies:
   file: ^7.0.1
   flutter_test:
     sdk: flutter
+  gql: ^1.0.1
   graphql: ^5.2.3
   hive_generator: ^2.0.1
 

--- a/test/unit/utils/gql_fragments_test.dart
+++ b/test/unit/utils/gql_fragments_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gql/ast.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:talawa/utils/gql_fragments.dart';
+
+void main() {
+  group('GraphQL Fragments Validity', () {
+    test('UserFields fragment should be valid GraphQL', () {
+      final doc = gql(userFieldsFragment);
+      expect(doc, isA<DocumentNode>());
+      expect(doc.definitions.first, isA<FragmentDefinitionNode>());
+      expect((doc.definitions.first as FragmentDefinitionNode).name.value,
+          'UserFields');
+    });
+
+    test('OrganizationFields fragment should be valid GraphQL', () {
+      final doc = gql(organizationFieldsFragment);
+      expect(doc, isA<DocumentNode>());
+      expect(doc.definitions.first, isA<FragmentDefinitionNode>());
+      expect((doc.definitions.first as FragmentDefinitionNode).name.value,
+          'OrganizationFields');
+    });
+
+    test('AuthorFields fragment should be valid GraphQL', () {
+      final doc = gql(authorFragment);
+      expect(doc, isA<DocumentNode>());
+      expect(doc.definitions.first, isA<FragmentDefinitionNode>());
+      expect((doc.definitions.first as FragmentDefinitionNode).name.value,
+          'AuthorFields');
+    });
+
+    test('PostFields fragment should be valid GraphQL', () {
+      // PostFields depends on AuthorFields, so we might need to verify the structure differently
+      // or just ensure strict parsing works.
+      // Note: gql() parses the string, but doesn't validate schema references without a schema.
+      // It mainly checks syntax.
+      final doc = gql(postFragment);
+      expect(doc, isA<DocumentNode>());
+      expect(doc.definitions.first, isA<FragmentDefinitionNode>());
+      expect((doc.definitions.first as FragmentDefinitionNode).name.value,
+          'PostFields');
+    });
+
+    test('PluginFields fragment should be valid GraphQL', () {
+      final doc = gql(pluginFieldsFragment);
+      expect(doc, isA<DocumentNode>());
+      expect(doc.definitions.first, isA<FragmentDefinitionNode>());
+      expect((doc.definitions.first as FragmentDefinitionNode).name.value,
+          'PluginFields');
+    });
+  });
+}

--- a/test/utils_tests/queries_test.dart
+++ b/test/utils_tests/queries_test.dart
@@ -84,19 +84,25 @@ void main() {
       const data = """
     query {
       organizations{
-        id,
-        name,
-        addressLine1,
-        addressLine2,
-        description,
-        avatarURL,
-        countryCode,
-        state,
-        isUserRegistrationRequired,
+        ...OrganizationFields
       }
     }
-    """;
-      expect(data, ff);
+    fragment OrganizationFields on Organization {
+  id
+  name
+  addressLine1
+  addressLine2
+  avatarMimeType
+  avatarURL
+  postalCode
+  countryCode
+  description
+  isUserRegistrationRequired
+  state
+}
+""";
+      expect(ff.replaceAll(RegExp(r'\s+'), ' ').trim(),
+          data.replaceAll(RegExp(r'\s+'), ' ').trim());
     });
     test("Check if fetchJoinInOrgByName works correctly", () {
       var mutation = false;

--- a/test/views/after_auth_screens/join_org_after_auth_test/join_organisation_after_auth_test.dart
+++ b/test/views/after_auth_screens/join_org_after_auth_test/join_organisation_after_auth_test.dart
@@ -54,6 +54,8 @@ void main() {
           "description": "Test Description",
           "countryCode": "US",
           "state": "NY",
+          "avatarMimeType": "image/png",
+          "postalCode": "10001",
         }
       ]
     });

--- a/test/views/demo_screens/profile_page_demo_test.dart
+++ b/test/views/demo_screens/profile_page_demo_test.dart
@@ -44,23 +44,25 @@ Widget createDemoProfileScreen({MainScreenViewModel? homeModel}) {
 }
 
 void main() {
-  setUpAll(() {
-    TestWidgetsFlutterBinding.ensureInitialized();
-    testSetupLocator();
-    registerServices();
-    locator<SizeConfig>().test();
-    locator<GraphqlConfig>().test();
-  });
-
-  tearDownAll(() {
-    unregisterServices();
-  });
+  // tearDownAll removed
 
   group('Demo Profile Page tests', () {
     late MockMainScreenViewModel mockHomeModel;
 
     setUp(() {
       mockHomeModel = MockMainScreenViewModel();
+      locator.reset();
+      testSetupLocator();
+      registerServices();
+      SizeConfig.screenHeight = 800;
+      SizeConfig.screenWidth = 600;
+      locator<SizeConfig>().test();
+      locator<GraphqlConfig>().test();
+      when(userConfig.loggedIn).thenReturn(true);
+    });
+
+    tearDown(() {
+      locator.reset();
     });
 
     testWidgets('renders DemoProfilePage correctly', (tester) async {


### PR DESCRIPTION
### What kind of change does this PR introduce?

Refactoring

### Issue Number:

Fixes #3209 

### Did you add tests for your changes?

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage meets or exceeds the current coverage (~90/95%).

Snapshots/Videos:
N/A (Refactoring logic only, no UI changes)

### If relevant, did you update the documentation?

N/A (Internal code refactoring)

### Summary

This PR addresses the issue of duplicated GraphQL fields by extracting them into reusable fragments.

**Key Changes:**
*   **Created [lib/utils/gql_fragments.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/lib/utils/gql_fragments.dart:0:0-0:0)**: Defines shared fragments for `UserFields`, `OrganizationFields`, `AuthorFields`, `PostFields`, and `PluginFields`.
*   **Refactored `lib/utils/queries.dart`**: Updated all queries to use the imported fragments, significantly reducing code duplication and improving maintainability.
*   **Refactored `lib/views/after_auth_screens/menu/menu_page.dart`**: Updated the inline `getPlugins` query to use the `PluginFields` fragment.
*   **Updated Tests**:
    *   Added [test/unit/utils/gql_fragments_test.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/test/unit/utils/gql_fragments_test.dart:0:0-0:0) to ensure fragments are valid GraphQL.
    *   Updated [test/utils_tests/queries_test.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/test/utils_tests/queries_test.dart:0:0-0:0) to match the new query structure.
    *   Updated [test/views/after_auth_screens/join_org_after_auth_test/join_organisation_after_auth_test.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/test/views/after_auth_screens/join_org_after_auth_test/join_organisation_after_auth_test.dart:0:0-0:0) to support the additional fields fetched by the `OrganizationFields` fragment (e.g., `avatarMimeType`).
    *   Hardened [test/views/demo_screens/profile_page_demo_test.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/test/views/demo_screens/profile_page_demo_test.dart:0:0-0:0) to fix test pollution and ensure a clean CI run.

**Note on Detected Files:**
Verified that [cache_service.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/lib/services/caching/cache_service.dart:0:0-0:0), [database_mutation_functions.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/lib/services/database_mutation_functions.dart:0:0-0:0), [user_config.dart](cci:7://file:///home/anurag/GSoC/talawa/talawa/lib/services/user_config.dart:0:0-0:0), `organization_list.dart`, and `profile_page.dart` did not require direct modification as they utilize the `Queries` class (which was refactored) or generic executors, thus automatically inheriting the changes.

### Does this PR introduce a breaking change?

No

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable `coderaabbitai` review suggestions?
- [x] Have you ensured that the PR aligns with the repository’s contribution guidelines?

### Other information

Verified local tests pass with `flutter test --coverage`.
Rebased on `develop` branch.

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored GraphQL queries to use reusable fragments for improved code maintainability and consistency.
  * Reorganized test setup and initialization structure for better test isolation.

* **Tests**
  * Added comprehensive unit tests validating GraphQL fragment definitions.
  * Enhanced test data with additional fields for improved coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->