### PR TITLE
feat: MobileFix - Resilience: Background retry policy for failed -- p…

### DIFF
--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -150,6 +150,12 @@ SecureStorageService get secureStorage => locator<SecureStorageService>();
 AppConfigService get appConfig => locator<AppConfigService>();
 
 /// GetIt for RetryQueue.
+///
+/// **params**:
+///   None
+///
+/// **returns**:
+/// * `RetryQueue`: The RetryQueue service instance.
 RetryQueue get retryQueue => locator<RetryQueue>();
 
 /// This function registers the widgets/objects in "GetIt".

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -16,6 +16,7 @@ import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/org_service.dart';
 import 'package:talawa/services/pinned_post_service.dart';
 import 'package:talawa/services/post_service.dart';
+import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/services/secure_storage_service.dart';
 import 'package:talawa/services/security_service.dart';
 import 'package:talawa/services/session_manager.dart';
@@ -148,6 +149,9 @@ SecureStorageService get secureStorage => locator<SecureStorageService>();
 /// * `AppConfigService`: The AppConfigService instance.
 AppConfigService get appConfig => locator<AppConfigService>();
 
+/// GetIt for RetryQueue.
+RetryQueue get retryQueue => locator<RetryQueue>();
+
 /// This function registers the widgets/objects in "GetIt".
 ///
 /// **params**:
@@ -179,6 +183,8 @@ Future<void> setupLocator() async {
   locator.registerSingleton(SecureStorageService());
 
   locator.registerSingleton(CacheService());
+
+  locator.registerSingleton(RetryQueue());
 
   //Services
   locator.registerLazySingleton(() => PostService());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:talawa/constants/quick_actions.dart';
 import 'package:talawa/locator.dart';
 import 'package:talawa/router.dart' as router;
 import 'package:talawa/services/hive_manager.dart';
+import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/utils/app_localization.dart';
 import 'package:talawa/view_model/connectivity_view_model.dart';
 import 'package:talawa/view_model/lang_view_model.dart';
@@ -52,7 +53,7 @@ class MyApp extends StatefulWidget {
 /// The _MyAppState class extends the State.
 ///
 /// All the coding related to state updation is inside this class.
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   /// Initializing the Quickactions to enable them on long press of app icon in device.
   final quickActions = const QuickActions();
 
@@ -65,6 +66,7 @@ class _MyAppState extends State<MyApp> {
     // we need to do some sort of initialization work like
     // registering a listener because, unlike build(), this method is called once.
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
 
     initQuickActions();
 
@@ -74,6 +76,20 @@ class _MyAppState extends State<MyApp> {
         fs.DeviceOrientation.portraitDown,
       ],
     );
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.detached) {
+      locator<RetryQueue>().cancelAll();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    locator<RetryQueue>().cancelAll();
+    super.dispose();
   }
 
   /// It allows to manage and interact with the application’s home screen quick actions.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,14 +81,18 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.detached) {
-      locator<RetryQueue>().cancelAll();
+      if (locator.isRegistered<RetryQueue>()) {
+        locator<RetryQueue>().cancelAll();
+      }
     }
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    locator<RetryQueue>().cancelAll();
+    if (locator.isRegistered<RetryQueue>()) {
+      locator<RetryQueue>().cancelAll();
+    }
     super.dispose();
   }
 

--- a/lib/models/post/post_model.dart
+++ b/lib/models/post/post_model.dart
@@ -121,52 +121,6 @@ class Post {
   /// Image service instance to handle file operations
   static final ImageService _imageService = locator<ImageService>();
 
-  /// Retry count for failed post operations.
-  ///
-  /// This field tracks the number of retry attempts for operations
-  /// like creating, updating, or deleting the post. It is not persisted
-  /// in Hive as it's only relevant during runtime retry logic.
-  int retryCount = 0;
-
-  /// Last retry timestamp.
-  ///
-  /// Records when the last retry attempt was made for this post's
-  /// operations. Used for debugging and retry delay calculations.
-  DateTime? lastRetryAt;
-
-  /// Increment retry count.
-  ///
-  /// **params**:
-  ///   None
-  ///
-  /// **returns**:
-  ///   None
-  void incrementRetry() {
-    retryCount++;
-    lastRetryAt = DateTime.now();
-  }
-
-  /// Check if max retries exceeded.
-  ///
-  /// **params**:
-  /// * `max`: Maximum number of retries allowed (default: 3).
-  ///
-  /// **returns**:
-  /// * `bool`: True if retry count has reached or exceeded the maximum.
-  bool hasExceededMaxRetries({int max = 3}) => retryCount >= max;
-
-  /// Reset retry state.
-  ///
-  /// **params**:
-  ///   None
-  ///
-  /// **returns**:
-  ///   None
-  void resetRetryState() {
-    retryCount = 0;
-    lastRetryAt = null;
-  }
-
   /// this is to get duration of post.
   ///
   /// **params**:

--- a/lib/models/post/post_model.dart
+++ b/lib/models/post/post_model.dart
@@ -121,6 +121,52 @@ class Post {
   /// Image service instance to handle file operations
   static final ImageService _imageService = locator<ImageService>();
 
+  /// Retry count for failed post operations.
+  ///
+  /// This field tracks the number of retry attempts for operations
+  /// like creating, updating, or deleting the post. It is not persisted
+  /// in Hive as it's only relevant during runtime retry logic.
+  int retryCount = 0;
+
+  /// Last retry timestamp.
+  ///
+  /// Records when the last retry attempt was made for this post's
+  /// operations. Used for debugging and retry delay calculations.
+  DateTime? lastRetryAt;
+
+  /// Increment retry count.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  ///   None
+  void incrementRetry() {
+    retryCount++;
+    lastRetryAt = DateTime.now();
+  }
+
+  /// Check if max retries exceeded.
+  ///
+  /// **params**:
+  /// * `max`: Maximum number of retries allowed (default: 3).
+  ///
+  /// **returns**:
+  /// * `bool`: True if retry count has reached or exceeded the maximum.
+  bool hasExceededMaxRetries({int max = 3}) => retryCount >= max;
+
+  /// Reset retry state.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  ///   None
+  void resetRetryState() {
+    retryCount = 0;
+    lastRetryAt = null;
+  }
+
   /// this is to get duration of post.
   ///
   /// **params**:

--- a/lib/plugin/plugin_injector.dart
+++ b/lib/plugin/plugin_injector.dart
@@ -83,7 +83,7 @@ class PluginInjector extends StatelessWidget {
     try {
       return injector.builder(context, data: data);
     } catch (e) {
-      print('Error rendering plugin injector "${injector.name}": $e');
+      debugPrint('Error rendering plugin injector "${injector.name}": $e');
       return const SizedBox.shrink();
     }
   }

--- a/lib/plugin/readme/files.md
+++ b/lib/plugin/readme/files.md
@@ -294,3 +294,45 @@ PluginManager.instance.initialize(
 ```
 
 ---
+
+### 5. Retry Queue Integration
+
+**Purpose**: Plugins can access the app's `RetryQueue` service for resilient network operations with exponential backoff.
+
+**Access Pattern**:
+```dart
+// Via the plugin registry
+final services = registry.getAvailableServices();
+final retryQueue = services['RetryQueue'] as RetryQueue;
+```
+
+**Usage Example**:
+```dart
+final result = await retryQueue.execute(
+  () => myNetworkCall(),
+  key: 'my-plugin-operation',
+  customConfig: const RetryConfig(
+    maxAttempts: 5,
+    initialDelay: Duration(milliseconds: 500),
+    maxDelay: Duration(seconds: 30),
+  ),
+  onRetry: (attempt, error) {
+    debugPrint('Retry attempt $attempt: $error');
+  },
+  shouldRetry: (error) => !error.toString().contains('auth'),
+);
+
+if (result.succeeded) {
+  // Use result.data
+} else {
+  // Handle result.error
+}
+```
+
+**RetryConfig Options**:
+- `maxAttempts` — Maximum number of retry attempts (default: 3)
+- `initialDelay` — Initial delay before first retry (default: 300ms)
+- `maxDelay` — Maximum delay between retries (default: 30s)
+- `backoffMultiplier` — Multiplier for exponential backoff (default: 2.0)
+
+---

--- a/lib/plugin/readme/files.md
+++ b/lib/plugin/readme/files.md
@@ -322,10 +322,13 @@ final result = await retryQueue.execute(
   shouldRetry: (error) => !error.toString().contains('auth'),
 );
 
-if (result.succeeded) {
-  // Use result.data
-} else {
-  // Handle result.error
+switch (result) {
+  case RetryResultSuccess(:final data):
+    // Use data (non-nullable)
+    break;
+  case RetryResultFailure(:final error):
+    // Handle error (non-nullable)
+    break;
 }
 ```
 

--- a/lib/plugin/readme/files.md
+++ b/lib/plugin/readme/files.md
@@ -311,7 +311,7 @@ final retryQueue = services['RetryQueue'] as RetryQueue;
 final result = await retryQueue.execute(
   () => myNetworkCall(),
   key: 'my-plugin-operation',
-  customConfig: const RetryConfig(
+  customConfig: RetryConfig(
     maxAttempts: 5,
     initialDelay: Duration(milliseconds: 500),
     maxDelay: Duration(seconds: 30),

--- a/lib/plugin/registry.dart
+++ b/lib/plugin/registry.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/widgets.dart';
+import 'package:talawa/locator.dart';
 import 'package:talawa/plugin/types.dart';
+import 'package:talawa/services/database_mutation_functions.dart';
+import 'package:talawa/services/navigation_service.dart';
+import 'package:talawa/services/retry_queue.dart';
 
 /// A very small in-memory registry for activated plugins.
 ///
@@ -73,6 +77,21 @@ class PluginRegistry {
   /// * `List<PluginMenuItem>`: Menu items for UI.
   List<PluginMenuItem> collectMenuItems(BuildContext context) {
     return all.expand((p) => p.getMenuItems(context)).toList(growable: false);
+  }
+
+  /// Returns core services available for plugin use.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  /// * `Map<String, dynamic>`: Map of service name to service instance.
+  Map<String, dynamic> getAvailableServices() {
+    return {
+      'RetryQueue': locator<RetryQueue>(),
+      'NavigationService': locator<NavigationService>(),
+      'DatabaseMutationFunctions': locator<DataBaseMutationFunctions>(),
+    };
   }
 
   /// Collects injectors for a specific type.

--- a/lib/plugin/registry.dart
+++ b/lib/plugin/registry.dart
@@ -88,9 +88,8 @@ class PluginRegistry {
   /// * `Map<String, Object?>`: Map of service name to service instance (null if not registered).
   Map<String, Object?> getAvailableServices() {
     return {
-      'RetryQueue': locator.isRegistered<RetryQueue>()
-          ? locator<RetryQueue>()
-          : null,
+      'RetryQueue':
+          locator.isRegistered<RetryQueue>() ? locator<RetryQueue>() : null,
       'NavigationService': locator.isRegistered<NavigationService>()
           ? locator<NavigationService>()
           : null,

--- a/lib/plugin/registry.dart
+++ b/lib/plugin/registry.dart
@@ -85,12 +85,19 @@ class PluginRegistry {
   ///   None
   ///
   /// **returns**:
-  /// * `Map<String, dynamic>`: Map of service name to service instance.
-  Map<String, dynamic> getAvailableServices() {
+  /// * `Map<String, Object?>`: Map of service name to service instance (null if not registered).
+  Map<String, Object?> getAvailableServices() {
     return {
-      'RetryQueue': locator<RetryQueue>(),
-      'NavigationService': locator<NavigationService>(),
-      'DatabaseMutationFunctions': locator<DataBaseMutationFunctions>(),
+      'RetryQueue': locator.isRegistered<RetryQueue>()
+          ? locator<RetryQueue>()
+          : null,
+      'NavigationService': locator.isRegistered<NavigationService>()
+          ? locator<NavigationService>()
+          : null,
+      'DatabaseMutationFunctions':
+          locator.isRegistered<DataBaseMutationFunctions>()
+              ? locator<DataBaseMutationFunctions>()
+              : null,
     };
   }
 

--- a/lib/services/caching/base_feed_manager.dart
+++ b/lib/services/caching/base_feed_manager.dart
@@ -156,12 +156,13 @@ abstract class BaseFeedManager<T> {
       },
     );
 
-    if (result.succeeded && result.data != null) {
-      await saveDataToCache(result.data!);
-      return result.data!;
+    switch (result) {
+      case RetryResultSuccess(:final data):
+        await saveDataToCache(data);
+        return data;
+      case RetryResultFailure():
+        debugPrint('BaseFeedManager: All retries failed, loading cached data');
+        return loadCachedData();
     }
-
-    debugPrint('BaseFeedManager: All retries failed, loading cached data');
-    return loadCachedData();
   }
 }

--- a/lib/services/caching/base_feed_manager.dart
+++ b/lib/services/caching/base_feed_manager.dart
@@ -134,16 +134,20 @@ abstract class BaseFeedManager<T> {
   /// **params**:
   /// * `retryKey`: Optional unique key for the retry operation. If not
   ///   provided, a key is generated based on the cache key and timestamp.
+  /// * `params`: Optional parameters for the API request.
   ///
   /// **returns**:
   /// * `Future<List<T>>`: A Future containing a list of data.
-  Future<List<T>> fetchWithRetry({String? retryKey}) async {
+  Future<List<T>> fetchWithRetry({
+    String? retryKey,
+    Map<String, dynamic>? params,
+  }) async {
     final key =
         retryKey ?? 'feed-$cacheKey-${DateTime.now().millisecondsSinceEpoch}';
     final queue = locator<RetryQueue>();
 
     final result = await queue.execute(
-      () => fetchDataFromApi(),
+      () => fetchDataFromApi(params: params),
       key: key,
       onRetry: (attempt, error) {
         debugPrint(

--- a/lib/services/caching/offline_action_queue.dart
+++ b/lib/services/caching/offline_action_queue.dart
@@ -167,19 +167,19 @@ class OfflineActionQueue {
   ///
   /// **returns**:
   /// * `Future<bool>`: returns true if the action was updated successfully, otherwise false.
-  Future<bool> updateAction(CachedUserAction action) async {
-    return await addAction(action);
+  Future<bool> updateAction(CachedUserAction action) {
+    return addAction(action);
   }
 
   /// Helper to check if an action is pending (not expired and has pending status).
   ///
   /// **params**:
   /// * `action`: the action to check.
+  /// * `now`: the timestamp to compare against.
   ///
   /// **returns**:
   /// * `bool`: true if the action is pending.
-  bool _isPendingAction(CachedUserAction action) {
-    final now = DateTime.now();
+  bool _isPendingAction(CachedUserAction action, DateTime now) {
     return action.expiry.isAfter(now) &&
         action.status == CachedUserActionStatus.pending;
   }
@@ -196,7 +196,8 @@ class OfflineActionQueue {
   /// * `List<CachedUserAction>`: a list of pending actions sorted by timestamp.
   List<CachedUserAction> getPendingActions() {
     try {
-      return _actionsBox.values.where(_isPendingAction).toList()
+      final now = DateTime.now();
+      return _actionsBox.values.where((a) => _isPendingAction(a, now)).toList()
         ..sort((a, b) => a.timeStamp.compareTo(b.timeStamp));
     } catch (e) {
       debugPrint('Failed to get pending actions: $e');
@@ -211,8 +212,8 @@ class OfflineActionQueue {
   ///
   /// **returns**:
   /// * `Future<bool>`: returns true if the action was marked completed successfully, otherwise false.
-  Future<bool> markCompleted(String actionId) async {
-    return await removeAction(actionId);
+  Future<bool> markCompleted(String actionId) {
+    return removeAction(actionId);
   }
 
   /// Gets the count of pending actions.
@@ -224,7 +225,8 @@ class OfflineActionQueue {
   /// * `int`: the number of pending actions.
   int getPendingCount() {
     try {
-      return _actionsBox.values.where(_isPendingAction).length;
+      final now = DateTime.now();
+      return _actionsBox.values.where((a) => _isPendingAction(a, now)).length;
     } catch (e) {
       debugPrint('Failed to get pending count: $e');
       return 0;

--- a/lib/services/caching/offline_action_queue.dart
+++ b/lib/services/caching/offline_action_queue.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import 'package:talawa/constants/constants.dart';
 import 'package:talawa/enums/enums.dart';

--- a/lib/services/chat_subscription_service.dart
+++ b/lib/services/chat_subscription_service.dart
@@ -8,8 +8,8 @@ import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/utils/chat_queries.dart';
 
 /// Pattern for detecting authentication errors that should not be retried.
-final RegExp _authErrorPattern =
-    RegExp(r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
+final RegExp _authErrorPattern = RegExp(
+    r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
 
 /// Provides real-time subscription services for chat messages.
 ///
@@ -143,7 +143,8 @@ class ChatSubscriptionService {
 
     // Handle failure result
     if (!result.succeeded && result.error != null) {
-      debugPrint('Chat subscription for $chatId failed permanently: ${result.error}');
+      debugPrint(
+          'Chat subscription for $chatId failed permanently: ${result.error}');
       if (!_chatMessageController.isClosed) {
         _chatMessageController.addError(result.error!);
       }

--- a/lib/services/chat_subscription_service.dart
+++ b/lib/services/chat_subscription_service.dart
@@ -106,7 +106,7 @@ class ChatSubscriptionService {
         }
       },
       key: 'chat-subscription-$chatId',
-      customConfig: const RetryConfig(
+      customConfig: RetryConfig(
         maxAttempts: 5,
         initialDelay: Duration(milliseconds: 500),
         maxDelay: Duration(seconds: 30),

--- a/lib/services/chat_subscription_service.dart
+++ b/lib/services/chat_subscription_service.dart
@@ -7,6 +7,10 @@ import 'package:talawa/services/database_mutation_functions.dart';
 import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/utils/chat_queries.dart';
 
+/// Pattern for detecting authentication errors that should not be retried.
+final RegExp _authErrorPattern =
+    RegExp(r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
+
 /// Provides real-time subscription services for chat messages.
 ///
 /// Services include:
@@ -131,11 +135,9 @@ class ChatSubscriptionService {
         );
       },
       shouldRetry: (error) {
-        // Do not retry on auth errors - check for specific auth error patterns
+        // Do not retry on auth errors
         final errorStr = error.toString().toLowerCase();
-        // Match whole words to avoid false positives like "author"
-        final authErrorPattern = RegExp(r'\b(auth|authentication|unauthorized)\b');
-        return !authErrorPattern.hasMatch(errorStr);
+        return !_authErrorPattern.hasMatch(errorStr);
       },
     );
 

--- a/lib/services/chat_subscription_service.dart
+++ b/lib/services/chat_subscription_service.dart
@@ -125,8 +125,8 @@ class ChatSubscriptionService {
       key: 'chat-subscription-$chatId',
       customConfig: RetryConfig(
         maxAttempts: 5,
-        initialDelay: Duration(milliseconds: 500),
-        maxDelay: Duration(seconds: 30),
+        initialDelay: const Duration(milliseconds: 500),
+        maxDelay: const Duration(seconds: 30),
       ),
       onRetry: (attempt, error) {
         debugPrint(

--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -12,7 +12,8 @@ import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/utils/comment_queries.dart';
 
 /// Pattern for detecting authentication/authorization errors that should not be retried.
-final RegExp _authErrorPattern = RegExp(r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
+final RegExp _authErrorPattern = RegExp(
+    r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
 
 /// CommentService class have different member functions which provides service in the context of commenting.
 ///

--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -11,6 +11,9 @@ import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/utils/comment_queries.dart';
 
+/// Pattern for detecting authentication/authorization errors that should not be retried.
+final RegExp _authErrorPattern = RegExp(r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
+
 /// CommentService class have different member functions which provides service in the context of commenting.
 ///
 /// Services include:
@@ -72,9 +75,7 @@ class CommentService {
       shouldRetry: (error) {
         // Do not retry on auth/authz errors
         final errorStr = error.toString().toLowerCase();
-        // Check for authentication/authorization error patterns
-        final authErrorPattern = RegExp(r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
-        return !authErrorPattern.hasMatch(errorStr);
+        return !_authErrorPattern.hasMatch(errorStr);
       },
     );
 

--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -69,6 +69,13 @@ class CommentService {
           'CommentService: Retry attempt $attempt for comment on post $postId: $error',
         );
       },
+      shouldRetry: (error) {
+        // Do not retry on auth/authz errors
+        final errorStr = error.toString().toLowerCase();
+        // Check for authentication/authorization error patterns
+        final authErrorPattern = RegExp(r'\b(auth|authentication|authorization|unauthorized|unauthenticated|forbidden)\b');
+        return !authErrorPattern.hasMatch(errorStr);
+      },
     );
 
     if (result.succeeded) {

--- a/lib/services/database_mutation_functions.dart
+++ b/lib/services/database_mutation_functions.dart
@@ -296,7 +296,8 @@ class DataBaseMutationFunctions {
 
     final result = await queue.execute(
       () async {
-        final queryResult = await gqlAuthMutation(mutation, variables: variables);
+        final queryResult =
+            await gqlAuthMutation(mutation, variables: variables);
         // Re-throw the original OperationException so RetryQueue can trigger
         // retries while preserving the full GraphQL error context.
         if (queryResult.hasException && queryResult.exception != null) {

--- a/lib/services/database_mutation_functions.dart
+++ b/lib/services/database_mutation_functions.dart
@@ -295,7 +295,14 @@ class DataBaseMutationFunctions {
     final queue = locator<RetryQueue>();
 
     final result = await queue.execute(
-      () => gqlAuthMutation(mutation, variables: variables),
+      () async {
+        final queryResult = await gqlAuthMutation(mutation, variables: variables);
+        // Throw on null data so RetryQueue can trigger retries
+        if (queryResult.data == null || queryResult.hasException) {
+          throw Exception('Mutation failed: ${queryResult.exception?.toString() ?? "No data returned"}');
+        }
+        return queryResult;
+      },
       key: key,
     );
 

--- a/lib/services/retry_queue.dart
+++ b/lib/services/retry_queue.dart
@@ -1,0 +1,246 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+/// Type definition for retry tasks.
+typedef Task<T> = Future<T> Function();
+
+/// Configuration for retry behavior.
+///
+/// This class provides the following configuration options:
+/// * `maxAttempts` : Maximum number of retry attempts.
+/// * `initialDelay` : Initial delay before first retry.
+/// * `maxDelay` : Maximum delay between retries.
+/// * `backoffMultiplier` : Multiplier for exponential backoff.
+class RetryConfig {
+  /// Creates a RetryConfig with the specified parameters.
+  ///
+  /// **params**:
+  /// * `maxAttempts`: Maximum number of retry attempts (default: 3).
+  /// * `initialDelay`: Initial delay before first retry (default: 300ms).
+  /// * `maxDelay`: Maximum delay between retries (default: 30s).
+  /// * `backoffMultiplier`: Multiplier for exponential backoff (default: 2.0).
+  const RetryConfig({
+    this.maxAttempts = 3,
+    this.initialDelay = const Duration(milliseconds: 300),
+    this.maxDelay = const Duration(seconds: 30),
+    this.backoffMultiplier = 2.0,
+  });
+
+  /// Maximum number of retry attempts.
+  final int maxAttempts;
+
+  /// Initial delay before first retry.
+  final Duration initialDelay;
+
+  /// Maximum delay between retries.
+  final Duration maxDelay;
+
+  /// Multiplier for exponential backoff.
+  final double backoffMultiplier;
+}
+
+/// Result wrapper for retry operations.
+///
+/// This class wraps the result of a retry operation, providing:
+/// * `data` : The result data if successful.
+/// * `error` : The error if failed.
+/// * `succeeded` : Boolean indicating success or failure.
+class RetryResult<T> {
+  /// Creates a successful result with data.
+  ///
+  /// **params**:
+  /// * `data`: The result data.
+  RetryResult.success(this.data)
+      : error = null,
+        succeeded = true;
+
+  /// Creates a failure result with error.
+  ///
+  /// **params**:
+  /// * `error`: The error that occurred.
+  RetryResult.failure(this.error)
+      : data = null,
+        succeeded = false;
+
+  /// The result data if successful.
+  final T? data;
+
+  /// The error if failed.
+  final Exception? error;
+
+  /// Boolean indicating success or failure.
+  final bool succeeded;
+}
+
+/// Service for handling retries with exponential backoff.
+///
+/// This class provides the following functionalities:
+/// * `enqueue` : Static method to enqueue and execute task with retry logic.
+/// * `execute` : Instance method to execute task with full result wrapper.
+/// * `isRetrying` : Check if a task is currently being retried.
+/// * `getAttemptCount` : Get current attempt count for a task.
+/// * `cancel` : Cancel a pending retry operation.
+/// * `cancelAll` : Cancel all pending operations.
+class RetryQueue {
+  /// Creates a RetryQueue with the specified configuration.
+  ///
+  /// **params**:
+  /// * `config`: The retry configuration (default: RetryConfig()).
+  RetryQueue({this.config = const RetryConfig()});
+
+  /// The retry configuration.
+  final RetryConfig config;
+
+  /// Map of pending tasks.
+  static final Map<String, Task<dynamic>> _q = {};
+
+  /// Map of attempt counts.
+  final Map<String, int> _attemptCounts = {};
+
+  /// Check if a task is currently being retried.
+  ///
+  /// **params**:
+  /// * `key`: The unique key for the task.
+  ///
+  /// **returns**:
+  /// * `bool`: True if the task is being retried.
+  bool isRetrying(String key) => _q.containsKey(key);
+
+  /// Get current attempt count for a task.
+  ///
+  /// **params**:
+  /// * `key`: The unique key for the task.
+  ///
+  /// **returns**:
+  /// * `int`: The current attempt count.
+  int getAttemptCount(String key) => _attemptCounts[key] ?? 0;
+
+  /// Enqueue and execute task with retry logic (static method).
+  ///
+  /// This method matches the starter code signature from the issue.
+  ///
+  /// **params**:
+  /// * `task`: The task to execute.
+  /// * `key`: Unique key for the task.
+  /// * `initial`: Initial delay before first retry (default: 300ms).
+  /// * `maxAttempts`: Maximum number of retry attempts (default: 3).
+  ///
+  /// **returns**:
+  /// * `Future<T>`: The result of the task.
+  static Future<T> enqueue<T>(
+    Task<T> task, {
+    required String key,
+    Duration initial = const Duration(milliseconds: 300),
+    int maxAttempts = 3,
+  }) async {
+    _q[key] = task;
+    var delay = initial;
+    for (var i = 0; i < maxAttempts; i++) {
+      try {
+        final r = await task();
+        _q.remove(key);
+        return r;
+      } catch (_) {
+        if (i < maxAttempts - 1) {
+          await Future.delayed(delay);
+          delay *= 2;
+        }
+      }
+    }
+    _q.remove(key);
+    throw Exception('Max retries exceeded for task: $key');
+  }
+
+  /// Execute task with full result wrapper.
+  ///
+  /// **params**:
+  /// * `task`: The task to execute.
+  /// * `key`: Unique key for the task.
+  /// * `customConfig`: Optional custom retry configuration.
+  /// * `onRetry`: Optional callback called on each retry attempt.
+  /// * `shouldRetry`: Optional callback to determine if error should be retried.
+  ///
+  /// **returns**:
+  /// * `Future<RetryResult<T>>`: The result wrapper.
+  Future<RetryResult<T>> execute<T>(
+    Task<T> task, {
+    required String key,
+    RetryConfig? customConfig,
+    void Function(int attempt, Exception error)? onRetry,
+    bool Function(Exception)? shouldRetry,
+  }) async {
+    final cfg = customConfig ?? config;
+    if (_q.containsKey(key)) {
+      return RetryResult.failure(Exception('Task $key already executing'));
+    }
+
+    _q[key] = task;
+    _attemptCounts[key] = 0;
+    Duration currentDelay = cfg.initialDelay;
+    Exception? lastError;
+
+    try {
+      for (int attempt = 1; attempt <= cfg.maxAttempts; attempt++) {
+        _attemptCounts[key] = attempt;
+        try {
+          final result = await task();
+          _cleanup(key);
+          return RetryResult.success(result);
+        } catch (e) {
+          lastError = e is Exception ? e : Exception(e.toString());
+          final canRetry = shouldRetry?.call(lastError) ?? true;
+          if (!canRetry || attempt >= cfg.maxAttempts) break;
+
+          onRetry?.call(attempt, lastError);
+          debugPrint(
+            'RetryQueue: Attempt $attempt failed for $key, '
+            'retrying in $currentDelay',
+          );
+          await Future.delayed(currentDelay);
+
+          currentDelay = Duration(
+            milliseconds:
+                (currentDelay.inMilliseconds * cfg.backoffMultiplier).toInt(),
+          );
+          if (currentDelay > cfg.maxDelay) currentDelay = cfg.maxDelay;
+        }
+      }
+    } finally {
+      _cleanup(key);
+    }
+    return RetryResult.failure(lastError ?? Exception('Unknown error'));
+  }
+
+  /// Clean up task from maps.
+  ///
+  /// **params**:
+  /// * `key`: The unique key for the task.
+  ///
+  /// **returns**:
+  ///   None
+  void _cleanup(String key) {
+    _q.remove(key);
+    _attemptCounts.remove(key);
+  }
+
+  /// Cancel a pending retry operation.
+  ///
+  /// **params**:
+  /// * `key`: The unique key for the task.
+  ///
+  /// **returns**:
+  ///   None
+  void cancel(String key) => _cleanup(key);
+
+  /// Cancel all pending operations.
+  ///
+  /// **params**:
+  ///   None
+  ///
+  /// **returns**:
+  ///   None
+  void cancelAll() {
+    _q.clear();
+    _attemptCounts.clear();
+  }
+}

--- a/lib/services/retry_queue.dart
+++ b/lib/services/retry_queue.dart
@@ -25,9 +25,11 @@ class RetryConfig {
     this.maxDelay = const Duration(seconds: 30),
     this.backoffMultiplier = 2.0,
   })  : assert(maxAttempts >= 1, 'maxAttempts must be at least 1'),
-        assert(initialDelay.inMicroseconds >= 0, 'initialDelay cannot be negative'),
+        assert(initialDelay.inMicroseconds >= 0,
+            'initialDelay cannot be negative'),
         assert(maxDelay.inMicroseconds >= 0, 'maxDelay cannot be negative'),
-        assert(maxDelay.inMicroseconds >= initialDelay.inMicroseconds, 'maxDelay must be >= initialDelay'),
+        assert(maxDelay.inMicroseconds >= initialDelay.inMicroseconds,
+            'maxDelay must be >= initialDelay'),
         assert(backoffMultiplier > 0.0, 'backoffMultiplier must be positive');
 
   /// Maximum number of retry attempts.
@@ -158,9 +160,10 @@ class RetryQueue {
   }) async {
     // Create custom config from parameters
     // Ensure maxDelay is at least as large as initialDelay
-    final effectiveMaxDelay = config.maxDelay.inMicroseconds >= initial.inMicroseconds
-        ? config.maxDelay
-        : initial;
+    final effectiveMaxDelay =
+        config.maxDelay.inMicroseconds >= initial.inMicroseconds
+            ? config.maxDelay
+            : initial;
 
     final customConfig = RetryConfig(
       maxAttempts: maxAttempts,

--- a/lib/services/retry_queue.dart
+++ b/lib/services/retry_queue.dart
@@ -86,6 +86,7 @@ final class RetryResultSuccess<T> extends RetryResult<T> {
   const RetryResultSuccess(this.data);
 
   /// The result data (guaranteed non-null).
+  @override
   final T data;
 }
 
@@ -94,6 +95,7 @@ final class RetryResultFailure<T> extends RetryResult<T> {
   const RetryResultFailure(this.error);
 
   /// The error that occurred.
+  @override
   final Exception error;
 }
 

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -4,9 +4,9 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i9;
-import 'dart:convert' as _i63;
+import 'dart:convert' as _i64;
 import 'dart:io' as _i29;
-import 'dart:typed_data' as _i64;
+import 'dart:typed_data' as _i65;
 import 'dart:ui' as _i12;
 
 import 'package:app_links/src/app_links.dart' as _i70;
@@ -17,28 +17,28 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i13;
 import 'package:graphql/src/cache/_optimistic_transactions.dart' as _i69;
 import 'package:graphql/src/utilities/helpers.dart' as _i68;
 import 'package:graphql_flutter/graphql_flutter.dart' as _i3;
-import 'package:http/http.dart' as _i66;
-import 'package:image_cropper/image_cropper.dart' as _i59;
+import 'package:http/http.dart' as _i46;
+import 'package:image_cropper/image_cropper.dart' as _i60;
 import 'package:image_cropper_platform_interface/image_cropper_platform_interface.dart'
-    as _i60;
+    as _i61;
 import 'package:image_picker/image_picker.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i2;
 import 'package:mockito/src/dummies.dart' as _i27;
 import 'package:normalize/normalize.dart' as _i67;
-import 'package:qr_code_scanner_plus/src/qr_code_scanner.dart' as _i46;
-import 'package:qr_code_scanner_plus/src/types/barcode.dart' as _i47;
-import 'package:qr_code_scanner_plus/src/types/camera.dart' as _i48;
+import 'package:qr_code_scanner_plus/src/qr_code_scanner.dart' as _i47;
+import 'package:qr_code_scanner_plus/src/types/barcode.dart' as _i48;
+import 'package:qr_code_scanner_plus/src/types/camera.dart' as _i49;
 import 'package:qr_code_scanner_plus/src/types/features.dart' as _i14;
 import 'package:syncfusion_flutter_calendar/calendar.dart' as _i20;
 import 'package:syncfusion_flutter_datepicker/datepicker.dart' as _i21;
 import 'package:talawa/enums/enums.dart' as _i23;
 import 'package:talawa/models/attachments/attachment_model.dart' as _i41;
 import 'package:talawa/models/chats/chat.dart' as _i33;
-import 'package:talawa/models/chats/chat_list_tile_data_model.dart' as _i55;
+import 'package:talawa/models/chats/chat_list_tile_data_model.dart' as _i56;
 import 'package:talawa/models/chats/chat_message.dart' as _i34;
-import 'package:talawa/models/comment/comment_model.dart' as _i50;
+import 'package:talawa/models/comment/comment_model.dart' as _i51;
 import 'package:talawa/models/events/event_model.dart' as _i30;
-import 'package:talawa/models/events/event_venue.dart' as _i53;
+import 'package:talawa/models/events/event_venue.dart' as _i54;
 import 'package:talawa/models/events/event_volunteer_group.dart' as _i31;
 import 'package:talawa/models/funds/fund.dart' as _i36;
 import 'package:talawa/models/funds/fund_campaign.dart' as _i37;
@@ -51,35 +51,35 @@ import 'package:talawa/services/chat_core_service.dart' as _i71;
 import 'package:talawa/services/chat_membership_service.dart' as _i72;
 import 'package:talawa/services/chat_message_service.dart' as _i73;
 import 'package:talawa/services/chat_service.dart' as _i32;
-import 'package:talawa/services/comment_service.dart' as _i49;
+import 'package:talawa/services/comment_service.dart' as _i50;
 import 'package:talawa/services/database_mutation_functions.dart' as _i11;
 import 'package:talawa/services/event_service.dart' as _i16;
 import 'package:talawa/services/fund_service.dart' as _i35;
 import 'package:talawa/services/graphql_config.dart' as _i24;
-import 'package:talawa/services/image_service.dart' as _i61;
+import 'package:talawa/services/image_service.dart' as _i62;
 import 'package:talawa/services/navigation_service.dart' as _i6;
 import 'package:talawa/services/org_service.dart' as _i42;
 import 'package:talawa/services/pinned_post_service.dart' as _i75;
 import 'package:talawa/services/post_service.dart' as _i25;
 import 'package:talawa/services/third_party_service/connectivity_service.dart'
-    as _i65;
+    as _i66;
 import 'package:talawa/services/third_party_service/multi_media_pick_service.dart'
     as _i15;
-import 'package:talawa/services/user_action_handler.dart' as _i62;
+import 'package:talawa/services/user_action_handler.dart' as _i63;
 import 'package:talawa/services/user_config.dart' as _i17;
 import 'package:talawa/services/user_profile_service.dart' as _i74;
 import 'package:talawa/utils/pair.dart' as _i8;
 import 'package:talawa/utils/validators.dart' as _i45;
 import 'package:talawa/view_model/after_auth_view_models/chat_view_models/direct_chat_view_model.dart'
-    as _i54;
+    as _i55;
 import 'package:talawa/view_model/after_auth_view_models/chat_view_models/group_chat_view_model.dart'
-    as _i56;
-import 'package:talawa/view_model/after_auth_view_models/chat_view_models/select_contact_view_model.dart'
     as _i57;
+import 'package:talawa/view_model/after_auth_view_models/chat_view_models/select_contact_view_model.dart'
+    as _i58;
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/base_event_view_model.dart'
     as _i77;
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/create_event_view_model.dart'
-    as _i52;
+    as _i53;
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/edit_event_view_model.dart'
     as _i76;
 import 'package:talawa/view_model/after_auth_view_models/event_view_models/event_calendar_view_model.dart'
@@ -89,12 +89,12 @@ import 'package:talawa/view_model/after_auth_view_models/feed_view_models/organi
 import 'package:talawa/view_model/after_auth_view_models/fund_view_model/fund_view_model.dart'
     as _i44;
 import 'package:talawa/view_model/after_auth_view_models/settings_view_models/app_setting_view_model.dart'
-    as _i58;
+    as _i59;
 import 'package:talawa/view_model/lang_view_model.dart' as _i39;
 import 'package:talawa/view_model/main_screen_view_model.dart' as _i79;
 import 'package:talawa/view_model/pre_auth_view_models/signup_details_view_model.dart'
     as _i40;
-import 'package:talawa/view_model/theme_view_model.dart' as _i51;
+import 'package:talawa/view_model/theme_view_model.dart' as _i52;
 import 'package:talawa/view_model/widgets_view_models/custom_drawer_view_model.dart'
     as _i78;
 import 'package:talawa/widgets/custom_alert_dialog.dart' as _i7;
@@ -1456,6 +1456,19 @@ class MockPostService extends _i2.Mock implements _i25.PostService {
         returnValueForMissingStub:
             _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
       ) as _i9.Future<List<_i26.Post>>);
+
+  @override
+  _i9.Future<List<_i26.Post>> fetchWithRetry({String? retryKey}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchWithRetry,
+          [],
+          {#retryKey: retryKey},
+        ),
+        returnValue: _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
+        returnValueForMissingStub:
+            _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
+      ) as _i9.Future<List<_i26.Post>>);
 }
 
 /// A class which mocks [MultiMediaPickerService].
@@ -2059,6 +2072,19 @@ class MockEventService extends _i2.Mock implements _i16.EventService {
           #getNewFeedAndRefreshCache,
           [],
           {#params: params},
+        ),
+        returnValue: _i9.Future<List<_i30.Event>>.value(<_i30.Event>[]),
+        returnValueForMissingStub:
+            _i9.Future<List<_i30.Event>>.value(<_i30.Event>[]),
+      ) as _i9.Future<List<_i30.Event>>);
+
+  @override
+  _i9.Future<List<_i30.Event>> fetchWithRetry({String? retryKey}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchWithRetry,
+          [],
+          {#retryKey: retryKey},
         ),
         returnValue: _i9.Future<List<_i30.Event>>.value(<_i30.Event>[]),
         returnValueForMissingStub:
@@ -3360,6 +3386,60 @@ class MockPost extends _i2.Mock implements _i26.Post {
       );
 
   @override
+  int get retryCount => (super.noSuchMethod(
+        Invocation.getter(#retryCount),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as int);
+
+  @override
+  set retryCount(int? _retryCount) => super.noSuchMethod(
+        Invocation.setter(
+          #retryCount,
+          _retryCount,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set lastRetryAt(DateTime? _lastRetryAt) => super.noSuchMethod(
+        Invocation.setter(
+          #lastRetryAt,
+          _lastRetryAt,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void incrementRetry() => super.noSuchMethod(
+        Invocation.method(
+          #incrementRetry,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool hasExceededMaxRetries({int? max = 3}) => (super.noSuchMethod(
+        Invocation.method(
+          #hasExceededMaxRetries,
+          [],
+          {#max: max},
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void resetRetryState() => super.noSuchMethod(
+        Invocation.method(
+          #resetRetryState,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   String getPostCreatedDuration() => (super.noSuchMethod(
         Invocation.method(
           #getPostCreatedDuration,
@@ -3643,6 +3723,47 @@ class MockDataBaseMutationFunctions extends _i2.Mock
             #gqlNonAuthQuery,
             [query],
             {#variables: variables},
+          ),
+        )),
+      ) as _i9.Future<_i3.QueryResult<Object?>>);
+
+  @override
+  _i9.Future<_i3.QueryResult<Object?>> gqlAuthMutationWithRetry(
+    String? mutation, {
+    Map<String, dynamic>? variables,
+    String? retryKey,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #gqlAuthMutationWithRetry,
+          [mutation],
+          {
+            #variables: variables,
+            #retryKey: retryKey,
+          },
+        ),
+        returnValue: _i9.Future<_i3.QueryResult<Object?>>.value(
+            _FakeQueryResult_8<Object?>(
+          this,
+          Invocation.method(
+            #gqlAuthMutationWithRetry,
+            [mutation],
+            {
+              #variables: variables,
+              #retryKey: retryKey,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i9.Future<_i3.QueryResult<Object?>>.value(
+            _FakeQueryResult_8<Object?>(
+          this,
+          Invocation.method(
+            #gqlAuthMutationWithRetry,
+            [mutation],
+            {
+              #variables: variables,
+              #retryKey: retryKey,
+            },
           ),
         )),
       ) as _i9.Future<_i3.QueryResult<Object?>>);
@@ -4329,7 +4450,7 @@ class MockValidator extends _i2.Mock implements _i45.Validator {
   @override
   _i9.Future<bool> validateUrlExistence(
     String? url, {
-    _i66.Client? client,
+    _i46.Client? client,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4345,7 +4466,7 @@ class MockValidator extends _i2.Mock implements _i45.Validator {
 /// A class which mocks [QRViewController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockQRViewController extends _i2.Mock implements _i46.QRViewController {
+class MockQRViewController extends _i2.Mock implements _i47.QRViewController {
   @override
   bool get disposed => (super.noSuchMethod(
         Invocation.getter(#disposed),
@@ -4363,11 +4484,11 @@ class MockQRViewController extends _i2.Mock implements _i46.QRViewController {
       );
 
   @override
-  _i9.Stream<_i47.Barcode> get scannedDataStream => (super.noSuchMethod(
+  _i9.Stream<_i48.Barcode> get scannedDataStream => (super.noSuchMethod(
         Invocation.getter(#scannedDataStream),
-        returnValue: _i9.Stream<_i47.Barcode>.empty(),
-        returnValueForMissingStub: _i9.Stream<_i47.Barcode>.empty(),
-      ) as _i9.Stream<_i47.Barcode>);
+        returnValue: _i9.Stream<_i48.Barcode>.empty(),
+        returnValueForMissingStub: _i9.Stream<_i48.Barcode>.empty(),
+      ) as _i9.Stream<_i48.Barcode>);
 
   @override
   bool get hasPermissions => (super.noSuchMethod(
@@ -4377,28 +4498,28 @@ class MockQRViewController extends _i2.Mock implements _i46.QRViewController {
       ) as bool);
 
   @override
-  _i9.Future<_i48.CameraFacing> getCameraInfo() => (super.noSuchMethod(
+  _i9.Future<_i49.CameraFacing> getCameraInfo() => (super.noSuchMethod(
         Invocation.method(
           #getCameraInfo,
           [],
         ),
         returnValue:
-            _i9.Future<_i48.CameraFacing>.value(_i48.CameraFacing.back),
+            _i9.Future<_i49.CameraFacing>.value(_i49.CameraFacing.back),
         returnValueForMissingStub:
-            _i9.Future<_i48.CameraFacing>.value(_i48.CameraFacing.back),
-      ) as _i9.Future<_i48.CameraFacing>);
+            _i9.Future<_i49.CameraFacing>.value(_i49.CameraFacing.back),
+      ) as _i9.Future<_i49.CameraFacing>);
 
   @override
-  _i9.Future<_i48.CameraFacing> flipCamera() => (super.noSuchMethod(
+  _i9.Future<_i49.CameraFacing> flipCamera() => (super.noSuchMethod(
         Invocation.method(
           #flipCamera,
           [],
         ),
         returnValue:
-            _i9.Future<_i48.CameraFacing>.value(_i48.CameraFacing.back),
+            _i9.Future<_i49.CameraFacing>.value(_i49.CameraFacing.back),
         returnValueForMissingStub:
-            _i9.Future<_i48.CameraFacing>.value(_i48.CameraFacing.back),
-      ) as _i9.Future<_i48.CameraFacing>);
+            _i9.Future<_i49.CameraFacing>.value(_i49.CameraFacing.back),
+      ) as _i9.Future<_i49.CameraFacing>);
 
   @override
   _i9.Future<bool?> getFlashStatus() => (super.noSuchMethod(
@@ -4497,9 +4618,9 @@ class MockQRViewController extends _i2.Mock implements _i46.QRViewController {
 /// A class which mocks [CommentService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCommentService extends _i2.Mock implements _i49.CommentService {
+class MockCommentService extends _i2.Mock implements _i50.CommentService {
   @override
-  _i9.Future<_i50.Comment?> createComments(
+  _i9.Future<_i51.Comment?> createComments(
     String? postId,
     String? body,
   ) =>
@@ -4511,9 +4632,9 @@ class MockCommentService extends _i2.Mock implements _i49.CommentService {
             body,
           ],
         ),
-        returnValue: _i9.Future<_i50.Comment?>.value(),
-        returnValueForMissingStub: _i9.Future<_i50.Comment?>.value(),
-      ) as _i9.Future<_i50.Comment?>);
+        returnValue: _i9.Future<_i51.Comment?>.value(),
+        returnValueForMissingStub: _i9.Future<_i51.Comment?>.value(),
+      ) as _i9.Future<_i51.Comment?>);
 
   @override
   _i9.Future<Map<String, dynamic>> getCommentsForPost({
@@ -4583,7 +4704,7 @@ class MockCommentService extends _i2.Mock implements _i49.CommentService {
 /// A class which mocks [AppTheme].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAppTheme extends _i2.Mock implements _i51.AppTheme {
+class MockAppTheme extends _i2.Mock implements _i52.AppTheme {
   @override
   String get key => (super.noSuchMethod(
         Invocation.getter(#key),
@@ -4707,7 +4828,7 @@ class MockAppTheme extends _i2.Mock implements _i51.AppTheme {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCreateEventViewModel extends _i2.Mock
-    implements _i52.CreateEventViewModel {
+    implements _i53.CreateEventViewModel {
   @override
   List<_i10.User> get orgMembersList => (super.noSuchMethod(
         Invocation.getter(#orgMembersList),
@@ -5317,15 +5438,15 @@ class MockCreateEventViewModel extends _i2.Mock
       );
 
   @override
-  _i9.Future<List<_i53.Venue>> fetchVenues() => (super.noSuchMethod(
+  _i9.Future<List<_i54.Venue>> fetchVenues() => (super.noSuchMethod(
         Invocation.method(
           #fetchVenues,
           [],
         ),
-        returnValue: _i9.Future<List<_i53.Venue>>.value(<_i53.Venue>[]),
+        returnValue: _i9.Future<List<_i54.Venue>>.value(<_i54.Venue>[]),
         returnValueForMissingStub:
-            _i9.Future<List<_i53.Venue>>.value(<_i53.Venue>[]),
-      ) as _i9.Future<List<_i53.Venue>>);
+            _i9.Future<List<_i54.Venue>>.value(<_i54.Venue>[]),
+      ) as _i9.Future<List<_i54.Venue>>);
 
   @override
   void clearFormState() => super.noSuchMethod(
@@ -5344,6 +5465,16 @@ class MockCreateEventViewModel extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i9.Future<void> executeIfLoggedIn() => (super.noSuchMethod(
+        Invocation.method(
+          #executeIfLoggedIn,
+          [],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
 
   @override
   void resetRecurrenceSettings() => super.noSuchMethod(
@@ -5469,6 +5600,15 @@ class MockCreateEventViewModel extends _i2.Mock
       );
 
   @override
+  void navigateBack() => super.noSuchMethod(
+        Invocation.method(
+          #navigateBack,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
           #dispose,
@@ -5518,7 +5658,7 @@ class MockCreateEventViewModel extends _i2.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDirectChatViewModel extends _i2.Mock
-    implements _i54.DirectChatViewModel {
+    implements _i55.DirectChatViewModel {
   @override
   _i17.UserConfig get userConfig => (super.noSuchMethod(
         Invocation.getter(#userConfig),
@@ -5571,11 +5711,11 @@ class MockDirectChatViewModel extends _i2.Mock
       );
 
   @override
-  List<_i55.ChatListTileDataModel> get chats => (super.noSuchMethod(
+  List<_i56.ChatListTileDataModel> get chats => (super.noSuchMethod(
         Invocation.getter(#chats),
-        returnValue: <_i55.ChatListTileDataModel>[],
-        returnValueForMissingStub: <_i55.ChatListTileDataModel>[],
-      ) as List<_i55.ChatListTileDataModel>);
+        returnValue: <_i56.ChatListTileDataModel>[],
+        returnValueForMissingStub: <_i56.ChatListTileDataModel>[],
+      ) as List<_i56.ChatListTileDataModel>);
 
   @override
   Map<String, List<_i34.ChatMessage>> get chatMessagesByUser =>
@@ -5741,7 +5881,7 @@ class MockDirectChatViewModel extends _i2.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGroupChatViewModel extends _i2.Mock
-    implements _i56.GroupChatViewModel {
+    implements _i57.GroupChatViewModel {
   @override
   _i17.UserConfig get userConfig => (super.noSuchMethod(
         Invocation.getter(#userConfig),
@@ -5794,11 +5934,11 @@ class MockGroupChatViewModel extends _i2.Mock
       );
 
   @override
-  List<_i55.ChatListTileDataModel> get groupChats => (super.noSuchMethod(
+  List<_i56.ChatListTileDataModel> get groupChats => (super.noSuchMethod(
         Invocation.getter(#groupChats),
-        returnValue: <_i55.ChatListTileDataModel>[],
-        returnValueForMissingStub: <_i55.ChatListTileDataModel>[],
-      ) as List<_i55.ChatListTileDataModel>);
+        returnValue: <_i56.ChatListTileDataModel>[],
+        returnValueForMissingStub: <_i56.ChatListTileDataModel>[],
+      ) as List<_i56.ChatListTileDataModel>);
 
   @override
   Map<String, List<_i34.ChatMessage>> get chatMessagesByUser =>
@@ -6158,7 +6298,7 @@ class MockGroupChatViewModel extends _i2.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSelectContactViewModel extends _i2.Mock
-    implements _i57.SelectContactViewModel {
+    implements _i58.SelectContactViewModel {
   @override
   _i17.UserConfig get userConfig => (super.noSuchMethod(
         Invocation.getter(#userConfig),
@@ -6300,7 +6440,7 @@ class MockSelectContactViewModel extends _i2.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockAppSettingViewModel extends _i2.Mock
-    implements _i58.AppSettingViewModel {
+    implements _i59.AppSettingViewModel {
   @override
   _i23.ViewState get state => (super.noSuchMethod(
         Invocation.getter(#state),
@@ -6391,16 +6531,16 @@ class MockAppSettingViewModel extends _i2.Mock
 /// A class which mocks [ImageCropper].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockImageCropper extends _i2.Mock implements _i59.ImageCropper {
+class MockImageCropper extends _i2.Mock implements _i60.ImageCropper {
   @override
-  _i9.Future<_i60.CroppedFile?> cropImage({
+  _i9.Future<_i61.CroppedFile?> cropImage({
     required String? sourcePath,
     int? maxWidth,
     int? maxHeight,
-    _i60.CropAspectRatio? aspectRatio,
-    _i60.ImageCompressFormat? compressFormat = _i60.ImageCompressFormat.jpg,
+    _i61.CropAspectRatio? aspectRatio,
+    _i61.ImageCompressFormat? compressFormat = _i61.ImageCompressFormat.jpg,
     int? compressQuality = 90,
-    List<_i60.PlatformUiSettings>? uiSettings,
+    List<_i61.PlatformUiSettings>? uiSettings,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6416,19 +6556,19 @@ class MockImageCropper extends _i2.Mock implements _i59.ImageCropper {
             #uiSettings: uiSettings,
           },
         ),
-        returnValue: _i9.Future<_i60.CroppedFile?>.value(),
-        returnValueForMissingStub: _i9.Future<_i60.CroppedFile?>.value(),
-      ) as _i9.Future<_i60.CroppedFile?>);
+        returnValue: _i9.Future<_i61.CroppedFile?>.value(),
+        returnValueForMissingStub: _i9.Future<_i61.CroppedFile?>.value(),
+      ) as _i9.Future<_i61.CroppedFile?>);
 
   @override
-  _i9.Future<_i60.CroppedFile?> recoverImage() => (super.noSuchMethod(
+  _i9.Future<_i61.CroppedFile?> recoverImage() => (super.noSuchMethod(
         Invocation.method(
           #recoverImage,
           [],
         ),
-        returnValue: _i9.Future<_i60.CroppedFile?>.value(),
-        returnValueForMissingStub: _i9.Future<_i60.CroppedFile?>.value(),
-      ) as _i9.Future<_i60.CroppedFile?>);
+        returnValue: _i9.Future<_i61.CroppedFile?>.value(),
+        returnValueForMissingStub: _i9.Future<_i61.CroppedFile?>.value(),
+      ) as _i9.Future<_i61.CroppedFile?>);
 }
 
 /// A class which mocks [ImagePicker].
@@ -6610,7 +6750,7 @@ class MockImagePicker extends _i2.Mock implements _i18.ImagePicker {
 /// A class which mocks [ImageService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockImageService extends _i2.Mock implements _i61.ImageService {
+class MockImageService extends _i2.Mock implements _i62.ImageService {
   @override
   _i9.Future<_i29.File?> cropImage({required _i29.File? imageFile}) =>
       (super.noSuchMethod(
@@ -6754,7 +6894,7 @@ class MockImageService extends _i2.Mock implements _i61.ImageService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockActionHandlerService extends _i2.Mock
-    implements _i62.ActionHandlerService {
+    implements _i63.ActionHandlerService {
   @override
   _i9.Future<bool?> executeApiCall({
     required _i9.Future<_i3.QueryResult<Object?>?> Function()? action,
@@ -6861,7 +7001,7 @@ class MockXFile extends _i2.Mock implements _i28.XFile {
 
   @override
   _i9.Future<String> readAsString(
-          {_i63.Encoding? encoding = const _i63.Utf8Codec()}) =>
+          {_i64.Encoding? encoding = const _i64.Utf8Codec()}) =>
       (super.noSuchMethod(
         Invocation.method(
           #readAsString,
@@ -6888,18 +7028,18 @@ class MockXFile extends _i2.Mock implements _i28.XFile {
       ) as _i9.Future<String>);
 
   @override
-  _i9.Future<_i64.Uint8List> readAsBytes() => (super.noSuchMethod(
+  _i9.Future<_i65.Uint8List> readAsBytes() => (super.noSuchMethod(
         Invocation.method(
           #readAsBytes,
           [],
         ),
-        returnValue: _i9.Future<_i64.Uint8List>.value(_i64.Uint8List(0)),
+        returnValue: _i9.Future<_i65.Uint8List>.value(_i65.Uint8List(0)),
         returnValueForMissingStub:
-            _i9.Future<_i64.Uint8List>.value(_i64.Uint8List(0)),
-      ) as _i9.Future<_i64.Uint8List>);
+            _i9.Future<_i65.Uint8List>.value(_i65.Uint8List(0)),
+      ) as _i9.Future<_i65.Uint8List>);
 
   @override
-  _i9.Stream<_i64.Uint8List> openRead([
+  _i9.Stream<_i65.Uint8List> openRead([
     int? start,
     int? end,
   ]) =>
@@ -6911,9 +7051,9 @@ class MockXFile extends _i2.Mock implements _i28.XFile {
             end,
           ],
         ),
-        returnValue: _i9.Stream<_i64.Uint8List>.empty(),
-        returnValueForMissingStub: _i9.Stream<_i64.Uint8List>.empty(),
-      ) as _i9.Stream<_i64.Uint8List>);
+        returnValue: _i9.Stream<_i65.Uint8List>.empty(),
+        returnValueForMissingStub: _i9.Stream<_i65.Uint8List>.empty(),
+      ) as _i9.Stream<_i65.Uint8List>);
 
   @override
   _i9.Future<DateTime> lastModified() => (super.noSuchMethod(
@@ -6942,7 +7082,7 @@ class MockXFile extends _i2.Mock implements _i28.XFile {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockConnectivityService extends _i2.Mock
-    implements _i65.ConnectivityService {
+    implements _i66.ConnectivityService {
   @override
   _i19.Connectivity get connectivityInstance => (super.noSuchMethod(
         Invocation.getter(#connectivityInstance),
@@ -7018,7 +7158,7 @@ class MockConnectivityService extends _i2.Mock
       ) as _i9.Future<List<_i19.ConnectivityResult>>);
 
   @override
-  _i9.Future<void> initConnectivity({required _i66.Client? client}) =>
+  _i9.Future<void> initConnectivity({required _i46.Client? client}) =>
       (super.noSuchMethod(
         Invocation.method(
           #initConnectivity,
@@ -7041,7 +7181,7 @@ class MockConnectivityService extends _i2.Mock
 
   @override
   _i9.Future<bool> isReachable({
-    _i66.Client? client,
+    _i46.Client? client,
     String? uriString,
   }) =>
       (super.noSuchMethod(
@@ -8094,6 +8234,19 @@ class MockPinnedPostService extends _i2.Mock implements _i75.PinnedPostService {
         returnValueForMissingStub:
             _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
       ) as _i9.Future<List<_i26.Post>>);
+
+  @override
+  _i9.Future<List<_i26.Post>> fetchWithRetry({String? retryKey}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchWithRetry,
+          [],
+          {#retryKey: retryKey},
+        ),
+        returnValue: _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
+        returnValueForMissingStub:
+            _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
+      ) as _i9.Future<List<_i26.Post>>);
 }
 
 /// A class which mocks [User].
@@ -9031,6 +9184,16 @@ class MockEditEventViewModel extends _i2.Mock
       );
 
   @override
+  _i9.Future<void> executeIfLoggedIn() => (super.noSuchMethod(
+        Invocation.method(
+          #executeIfLoggedIn,
+          [],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
   void resetRecurrenceSettings() => super.noSuchMethod(
         Invocation.method(
           #resetRecurrenceSettings,
@@ -9148,6 +9311,15 @@ class MockEditEventViewModel extends _i2.Mock
   void updateRecurrenceLabel() => super.noSuchMethod(
         Invocation.method(
           #updateRecurrenceLabel,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void navigateBack() => super.noSuchMethod(
+        Invocation.method(
+          #navigateBack,
           [],
         ),
         returnValueForMissingStub: null,
@@ -9762,6 +9934,16 @@ class MockBaseEventViewModel extends _i2.Mock
       ) as _i9.Future<void>);
 
   @override
+  _i9.Future<void> executeIfLoggedIn() => (super.noSuchMethod(
+        Invocation.method(
+          #executeIfLoggedIn,
+          [],
+        ),
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+
+  @override
   void resetRecurrenceSettings() => super.noSuchMethod(
         Invocation.method(
           #resetRecurrenceSettings,
@@ -9879,6 +10061,15 @@ class MockBaseEventViewModel extends _i2.Mock
   void updateRecurrenceLabel() => super.noSuchMethod(
         Invocation.method(
           #updateRecurrenceLabel,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void navigateBack() => super.noSuchMethod(
+        Invocation.method(
+          #navigateBack,
           [],
         ),
         returnValueForMissingStub: null,

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -1458,12 +1458,18 @@ class MockPostService extends _i2.Mock implements _i25.PostService {
       ) as _i9.Future<List<_i26.Post>>);
 
   @override
-  _i9.Future<List<_i26.Post>> fetchWithRetry({String? retryKey}) =>
+  _i9.Future<List<_i26.Post>> fetchWithRetry({
+    String? retryKey,
+    Map<String, dynamic>? params,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchWithRetry,
           [],
-          {#retryKey: retryKey},
+          {
+            #retryKey: retryKey,
+            #params: params,
+          },
         ),
         returnValue: _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
         returnValueForMissingStub:
@@ -2079,12 +2085,18 @@ class MockEventService extends _i2.Mock implements _i16.EventService {
       ) as _i9.Future<List<_i30.Event>>);
 
   @override
-  _i9.Future<List<_i30.Event>> fetchWithRetry({String? retryKey}) =>
+  _i9.Future<List<_i30.Event>> fetchWithRetry({
+    String? retryKey,
+    Map<String, dynamic>? params,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchWithRetry,
           [],
-          {#retryKey: retryKey},
+          {
+            #retryKey: retryKey,
+            #params: params,
+          },
         ),
         returnValue: _i9.Future<List<_i30.Event>>.value(<_i30.Event>[]),
         returnValueForMissingStub:
@@ -8236,12 +8248,18 @@ class MockPinnedPostService extends _i2.Mock implements _i75.PinnedPostService {
       ) as _i9.Future<List<_i26.Post>>);
 
   @override
-  _i9.Future<List<_i26.Post>> fetchWithRetry({String? retryKey}) =>
+  _i9.Future<List<_i26.Post>> fetchWithRetry({
+    String? retryKey,
+    Map<String, dynamic>? params,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchWithRetry,
           [],
-          {#retryKey: retryKey},
+          {
+            #retryKey: retryKey,
+            #params: params,
+          },
         ),
         returnValue: _i9.Future<List<_i26.Post>>.value(<_i26.Post>[]),
         returnValueForMissingStub:

--- a/test/helpers/test_locator.dart
+++ b/test/helpers/test_locator.dart
@@ -19,6 +19,7 @@ import 'package:talawa/services/navigation_service.dart';
 import 'package:talawa/services/org_service.dart';
 import 'package:talawa/services/pinned_post_service.dart';
 import 'package:talawa/services/post_service.dart';
+import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/services/secure_storage_service.dart';
 import 'package:talawa/services/security_service.dart';
 import 'package:talawa/services/session_manager.dart';
@@ -99,6 +100,8 @@ AppConfigService get appConfig => locator<AppConfigService>();
 void testSetupLocator() {
   locator.allowReassignment = true;
   locator.registerSingleton(CacheService());
+
+  locator.registerSingleton(RetryQueue());
 
   locator.registerSingleton(DataBaseMutationFunctions());
 

--- a/test/plugin_tests/plugin_registry_test.dart
+++ b/test/plugin_tests/plugin_registry_test.dart
@@ -231,6 +231,25 @@ void main() {
         throwsUnsupportedError,
       );
     });
+
+    test('getAvailableServices should return core services', () {
+      final services = registry.getAvailableServices();
+
+      expect(services, isNotNull);
+      expect(services, isA<Map<String, dynamic>>());
+      expect(services.containsKey('RetryQueue'), isTrue);
+      expect(services.containsKey('NavigationService'), isTrue);
+      expect(services.containsKey('DatabaseMutationFunctions'), isTrue);
+    });
+
+    test('getAvailableServices should return correct service types', () {
+      final services = registry.getAvailableServices();
+
+      // Verify services are of correct types
+      expect(services['RetryQueue'], isNotNull);
+      expect(services['NavigationService'], isNotNull);
+      expect(services['DatabaseMutationFunctions'], isNotNull);
+    });
   });
 }
 

--- a/test/service_tests/base_feed_manager_test.dart
+++ b/test/service_tests/base_feed_manager_test.dart
@@ -173,7 +173,8 @@ void main() {
       expect(cached.length, 3);
     });
 
-    test('getNewFeedAndRefreshCache returns cached data when offline', () async {
+    test('getNewFeedAndRefreshCache returns cached data when offline',
+        () async {
       // Pre-populate cache
       await feedManager.saveDataToCache(['offline1', 'offline2']);
 

--- a/test/service_tests/base_feed_manager_test.dart
+++ b/test/service_tests/base_feed_manager_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
-import 'package:mockito/mockito.dart';
 import 'package:talawa/services/caching/base_feed_manager.dart';
 import 'package:talawa/services/retry_queue.dart';
 import 'package:talawa/view_model/connectivity_view_model.dart';
@@ -29,6 +28,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late TestFeedManager feedManager;
+  // ignore: unused_local_variable
   late Box<String> mockBox;
 
   setUpAll(() {

--- a/test/service_tests/base_feed_manager_test.dart
+++ b/test/service_tests/base_feed_manager_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mockito/mockito.dart';
+import 'package:talawa/services/caching/base_feed_manager.dart';
+import 'package:talawa/services/retry_queue.dart';
+import 'package:talawa/view_model/connectivity_view_model.dart';
+import '../helpers/test_helpers.dart';
+import '../helpers/test_locator.dart';
+
+// Concrete implementation of BaseFeedManager for testing
+class TestFeedManager extends BaseFeedManager<String> {
+  TestFeedManager(super.cacheKey);
+
+  int fetchCallCount = 0;
+  int failCount = 0; // Number of calls that should fail before succeeding
+
+  @override
+  Future<List<String>> fetchDataFromApi({Map<String, dynamic>? params}) async {
+    fetchCallCount++;
+    if (failCount > 0) {
+      failCount--;
+      throw Exception('API fetch failed (remaining failures: $failCount)');
+    }
+    return ['item1', 'item2', 'item3'];
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TestFeedManager feedManager;
+  late Box<String> mockBox;
+
+  setUpAll(() {
+    testSetupLocator();
+    registerServices();
+    Hive.init('./test/fixtures/core');
+  });
+
+  setUp(() async {
+    // Register the box adapter and open the box
+    if (!Hive.isBoxOpen('test_feed_cache')) {
+      mockBox = await Hive.openBox<String>('test_feed_cache');
+    } else {
+      mockBox = Hive.box<String>('test_feed_cache');
+    }
+
+    feedManager = TestFeedManager('test_feed_cache');
+    feedManager.fetchCallCount = 0;
+    feedManager.failCount = 0;
+    await feedManager.clearCache();
+  });
+
+  tearDown(() async {
+    await feedManager.clearCache();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    unregisterServices();
+  });
+
+  group('BaseFeedManager - fetchWithRetry Tests', () {
+    test('fetchWithRetry succeeds on first attempt', () async {
+      AppConnectivity.isOnline = true;
+
+      final result = await feedManager.fetchWithRetry(
+        retryKey: 'test-fetch-success',
+      );
+
+      expect(result, isNotEmpty);
+      expect(result.length, 3);
+      expect(result[0], 'item1');
+      expect(feedManager.fetchCallCount, 1);
+
+      // Verify data was cached
+      final cached = await feedManager.loadCachedData();
+      expect(cached.length, 3);
+    });
+
+    test('fetchWithRetry retries on failure then succeeds', () async {
+      AppConnectivity.isOnline = true;
+
+      // Fail first call, succeed on retry
+      feedManager.failCount = 1;
+
+      final result = await feedManager.fetchWithRetry(
+        retryKey: 'test-fetch-retry',
+      );
+
+      expect(result, isNotEmpty);
+      expect(feedManager.fetchCallCount, greaterThan(1));
+    });
+
+    test('fetchWithRetry falls back to cache when all retries fail', () async {
+      AppConnectivity.isOnline = true;
+
+      // Pre-populate cache
+      await feedManager.saveDataToCache(['cached1', 'cached2']);
+
+      // Make all API calls fail (more than retry attempts)
+      feedManager.failCount = 10; // Will exhaust all retries
+
+      final result = await feedManager.fetchWithRetry(
+        retryKey: 'test-fetch-fallback',
+      );
+
+      // Should return cached data
+      expect(result, isNotEmpty);
+      expect(result.length, 2);
+      expect(result[0], 'cached1');
+    });
+
+    test('fetchWithRetry uses custom retry key', () async {
+      AppConnectivity.isOnline = true;
+      final customKey = 'custom-retry-key-123';
+
+      final result = await feedManager.fetchWithRetry(
+        retryKey: customKey,
+      );
+
+      expect(result, isNotEmpty);
+      // Verify the retry queue was used with the custom key
+      final retryQueue = locator<RetryQueue>();
+      expect(retryQueue.isRetrying(customKey), false); // Should be done
+    });
+
+    test('fetchWithRetry generates key when not provided', () async {
+      AppConnectivity.isOnline = true;
+
+      final result = await feedManager.fetchWithRetry();
+
+      expect(result, isNotEmpty);
+      expect(feedManager.fetchCallCount, 1);
+    });
+
+    test('fetchWithRetry saves data to cache on success', () async {
+      AppConnectivity.isOnline = true;
+
+      // Clear cache first
+      await feedManager.clearCache();
+
+      final result = await feedManager.fetchWithRetry(
+        retryKey: 'test-cache-save',
+      );
+
+      expect(result.length, 3);
+
+      // Verify data was saved to cache
+      final cached = await feedManager.loadCachedData();
+      expect(cached.length, 3);
+      expect(cached[0], 'item1');
+    });
+  });
+
+  group('BaseFeedManager - getNewFeedAndRefreshCache Tests', () {
+    test('getNewFeedAndRefreshCache fetches and caches when online', () async {
+      AppConnectivity.isOnline = true;
+
+      final result = await feedManager.getNewFeedAndRefreshCache();
+
+      expect(result, isNotEmpty);
+      expect(result.length, 3);
+
+      // Verify caching
+      final cached = await feedManager.loadCachedData();
+      expect(cached.length, 3);
+    });
+
+    test('getNewFeedAndRefreshCache returns cached data when offline', () async {
+      // Pre-populate cache
+      await feedManager.saveDataToCache(['offline1', 'offline2']);
+
+      AppConnectivity.isOnline = false;
+
+      final result = await feedManager.getNewFeedAndRefreshCache();
+
+      expect(result.length, 2);
+      expect(result[0], 'offline1');
+      expect(feedManager.fetchCallCount, 0); // Should not fetch
+    });
+
+    test('getNewFeedAndRefreshCache falls back to cache on error', () async {
+      AppConnectivity.isOnline = true;
+
+      // Pre-populate cache
+      await feedManager.saveDataToCache(['fallback1', 'fallback2']);
+
+      // Make API fail
+      feedManager.failCount = 10;
+
+      final result = await feedManager.getNewFeedAndRefreshCache();
+
+      // Should return cached data
+      expect(result.length, 2);
+      expect(result[0], 'fallback1');
+    });
+  });
+
+  group('BaseFeedManager - Basic Operations', () {
+    test('loadCachedData returns empty list when cache is empty', () async {
+      final cached = await feedManager.loadCachedData();
+      expect(cached, isEmpty);
+    });
+
+    test('saveDataToCache stores data correctly', () async {
+      final testData = ['test1', 'test2', 'test3'];
+      await feedManager.saveDataToCache(testData);
+
+      final cached = await feedManager.loadCachedData();
+      expect(cached.length, 3);
+      expect(cached, testData);
+    });
+
+    test('clearCache removes all cached data', () async {
+      await feedManager.saveDataToCache(['data1', 'data2']);
+
+      final beforeClear = await feedManager.loadCachedData();
+      expect(beforeClear.length, 2);
+
+      await feedManager.clearCache();
+
+      final afterClear = await feedManager.loadCachedData();
+      expect(afterClear, isEmpty);
+    });
+  });
+}

--- a/test/service_tests/base_feed_manager_test.dart
+++ b/test/service_tests/base_feed_manager_test.dart
@@ -33,11 +33,12 @@ void main() {
 
   setUpAll(() {
     testSetupLocator();
-    registerServices();
     Hive.init('./test/fixtures/core');
   });
 
   setUp(() async {
+    registerServices();
+
     // Register the box adapter and open the box
     if (!Hive.isBoxOpen('test_feed_cache')) {
       mockBox = await Hive.openBox<String>('test_feed_cache');
@@ -53,11 +54,12 @@ void main() {
 
   tearDown(() async {
     await feedManager.clearCache();
+    locator<RetryQueue>().cancelAll();
+    unregisterServices();
   });
 
   tearDownAll(() async {
     await Hive.close();
-    unregisterServices();
   });
 
   group('BaseFeedManager - fetchWithRetry Tests', () {
@@ -89,6 +91,10 @@ void main() {
       );
 
       expect(result, isNotEmpty);
+      expect(result.length, 3);
+      expect(result[0], 'item1');
+      expect(result[1], 'item2');
+      expect(result[2], 'item3');
       expect(feedManager.fetchCallCount, greaterThan(1));
     });
 

--- a/test/service_tests/caching/offline_action_queue_test.dart
+++ b/test/service_tests/caching/offline_action_queue_test.dart
@@ -28,7 +28,7 @@ void main() {
         expect(result, true);
       });
 
-      test('getActions success', () {
+      test('getActions success', () async {
         final now = DateTime.now();
         final CachedUserAction validAction = CachedUserAction(
           id: '123',
@@ -47,8 +47,8 @@ void main() {
           operationType: CachedOperationType.gqlAuthQuery,
         );
 
-        queue.addAction(validAction);
-        queue.addAction(expiredAction);
+        await queue.addAction(validAction);
+        await queue.addAction(expiredAction);
 
         final actions = queue.getActions();
 
@@ -289,6 +289,34 @@ void main() {
       test('_removeExpiredActions failure', () async {
         final result = await queue.removeExpiredActions();
 
+        expect(result, false);
+      });
+
+      test('getPendingActions failure', () {
+        final actions = queue.getPendingActions();
+        expect(actions, isEmpty);
+      });
+
+      test('getPendingCount failure', () {
+        final count = queue.getPendingCount();
+        expect(count, 0);
+      });
+
+      test('markCompleted failure', () async {
+        final result = await queue.markCompleted('any-id');
+        expect(result, false);
+      });
+
+      test('updateAction failure', () async {
+        final action = CachedUserAction(
+          id: 'fail-test',
+          operation: 'op',
+          timeStamp: DateTime.now(),
+          expiry: DateTime.now().add(const Duration(days: 1)),
+          status: CachedUserActionStatus.pending,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+        final result = await queue.updateAction(action);
         expect(result, false);
       });
     });

--- a/test/service_tests/caching/offline_action_queue_test.dart
+++ b/test/service_tests/caching/offline_action_queue_test.dart
@@ -72,6 +72,194 @@ void main() {
 
         expect(result, true);
       });
+
+      test('getPendingActions filters by status and expiry, returns FIFO', () async {
+        // Clear any existing actions
+        await queue.clearActions();
+
+        final now = DateTime.now();
+
+        // Create actions with different timestamps
+        final oldAction = CachedUserAction(
+          id: 'old-1',
+          operation: 'oldOp',
+          timeStamp: now.subtract(const Duration(hours: 2)),
+          expiry: now.add(const Duration(days: 1)),
+          status: CachedUserActionStatus.pending,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+
+        final newAction = CachedUserAction(
+          id: 'new-1',
+          operation: 'newOp',
+          timeStamp: now.subtract(const Duration(hours: 1)),
+          expiry: now.add(const Duration(days: 1)),
+          status: CachedUserActionStatus.pending,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+
+        final expiredAction = CachedUserAction(
+          id: 'expired-1',
+          operation: 'expiredOp',
+          timeStamp: now.subtract(const Duration(hours: 3)),
+          expiry: now.subtract(const Duration(hours: 1)),
+          status: CachedUserActionStatus.pending,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+
+        final completedAction = CachedUserAction(
+          id: 'completed-1',
+          operation: 'completedOp',
+          timeStamp: now.subtract(const Duration(hours: 1)),
+          expiry: now.add(const Duration(days: 1)),
+          status: CachedUserActionStatus.completed,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+
+        // Add in random order
+        await queue.addAction(newAction);
+        await queue.addAction(expiredAction);
+        await queue.addAction(oldAction);
+        await queue.addAction(completedAction);
+
+        final pending = queue.getPendingActions();
+
+        // Should only return non-expired pending actions, sorted oldest first (FIFO)
+        expect(pending.length, 2);
+        expect(pending[0].id, 'old-1'); // Oldest first
+        expect(pending[1].id, 'new-1');
+      });
+
+      test('getPendingCount returns correct count', () async {
+        // Clear any existing actions
+        await queue.clearActions();
+
+        final now = DateTime.now();
+
+        // Add 3 pending, 1 expired, 1 completed
+        await queue.addAction(
+          CachedUserAction(
+            id: 'pending-1',
+            operation: 'op1',
+            timeStamp: now,
+            expiry: now.add(const Duration(days: 1)),
+            status: CachedUserActionStatus.pending,
+            operationType: CachedOperationType.gqlAuthMutation,
+          ),
+        );
+
+        await queue.addAction(
+          CachedUserAction(
+            id: 'pending-2',
+            operation: 'op2',
+            timeStamp: now,
+            expiry: now.add(const Duration(days: 1)),
+            status: CachedUserActionStatus.pending,
+            operationType: CachedOperationType.gqlAuthMutation,
+          ),
+        );
+
+        await queue.addAction(
+          CachedUserAction(
+            id: 'pending-3',
+            operation: 'op3',
+            timeStamp: now,
+            expiry: now.add(const Duration(days: 1)),
+            status: CachedUserActionStatus.pending,
+            operationType: CachedOperationType.gqlAuthMutation,
+          ),
+        );
+
+        await queue.addAction(
+          CachedUserAction(
+            id: 'expired',
+            operation: 'expiredOp',
+            timeStamp: now,
+            expiry: now.subtract(const Duration(hours: 1)),
+            status: CachedUserActionStatus.pending,
+            operationType: CachedOperationType.gqlAuthMutation,
+          ),
+        );
+
+        await queue.addAction(
+          CachedUserAction(
+            id: 'completed',
+            operation: 'completedOp',
+            timeStamp: now,
+            expiry: now.add(const Duration(days: 1)),
+            status: CachedUserActionStatus.completed,
+            operationType: CachedOperationType.gqlAuthMutation,
+          ),
+        );
+
+        final count = queue.getPendingCount();
+
+        // Should only count non-expired pending actions
+        expect(count, 3);
+        expect(count, queue.getPendingActions().length);
+      });
+
+      test('markCompleted removes action from queue', () async {
+        // Clear any existing actions
+        await queue.clearActions();
+
+        final now = DateTime.now();
+        final testAction = CachedUserAction(
+          id: 'mark-completed-test',
+          operation: 'testOp',
+          timeStamp: now,
+          expiry: now.add(const Duration(days: 1)),
+          status: CachedUserActionStatus.pending,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+
+        await queue.addAction(testAction);
+
+        // Verify action exists
+        expect(queue.getPendingCount(), 1);
+
+        // Mark as completed
+        final result = await queue.markCompleted('mark-completed-test');
+
+        expect(result, true);
+        expect(queue.getPendingCount(), 0);
+        expect(queue.getActions(), isEmpty);
+      });
+
+      test('updateAction updates existing action', () async {
+        // Clear any existing actions
+        await queue.clearActions();
+
+        final now = DateTime.now();
+        final originalAction = CachedUserAction(
+          id: 'update-test',
+          operation: 'originalOp',
+          timeStamp: now,
+          expiry: now.add(const Duration(days: 1)),
+          status: CachedUserActionStatus.pending,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+
+        await queue.addAction(originalAction);
+
+        // Update with new data
+        final updatedAction = CachedUserAction(
+          id: 'update-test',
+          operation: 'updatedOp',
+          timeStamp: now,
+          expiry: now.add(const Duration(days: 1)),
+          status: CachedUserActionStatus.pending,
+          operationType: CachedOperationType.gqlAuthMutation,
+        );
+
+        final result = await queue.updateAction(updatedAction);
+
+        expect(result, true);
+
+        final actions = queue.getPendingActions();
+        expect(actions.length, 1);
+        expect(actions[0].operation, 'updatedOp');
+      });
     });
 
     group('failure', () {

--- a/test/service_tests/caching/offline_action_queue_test.dart
+++ b/test/service_tests/caching/offline_action_queue_test.dart
@@ -73,7 +73,8 @@ void main() {
         expect(result, true);
       });
 
-      test('getPendingActions filters by status and expiry, returns FIFO', () async {
+      test('getPendingActions filters by status and expiry, returns FIFO',
+          () async {
         // Clear any existing actions
         await queue.clearActions();
 

--- a/test/service_tests/chat_subscription_service_test.dart
+++ b/test/service_tests/chat_subscription_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/mockito.dart';
@@ -237,58 +238,62 @@ void main() {
     });
 
     group('retry behavior', () {
-      test('retries subscription when initial connection fails', () async {
-        const chatId = 'chat-retry-test';
-        var callCount = 0;
-        final controller = StreamController<QueryResult>();
+      test('retries subscription when initial connection fails', () {
+        fakeAsync((async) {
+          const chatId = 'chat-retry-test';
+          var callCount = 0;
+          final controller = StreamController<QueryResult>();
 
-        when(
-          mockDbFunctions.gqlAuthSubscription(
-            any,
-            variables: anyNamed('variables'),
-          ),
-        ).thenAnswer((_) {
-          callCount++;
-          if (callCount < 3) {
-            throw Exception('Connection failed');
-          }
-          return controller.stream;
+          when(
+            mockDbFunctions.gqlAuthSubscription(
+              any,
+              variables: anyNamed('variables'),
+            ),
+          ).thenAnswer((_) {
+            callCount++;
+            if (callCount < 3) {
+              throw Exception('Connection failed');
+            }
+            return controller.stream;
+          });
+
+          // Start subscription - retry queue will retry on failure
+          chatSubscriptionService.subscribeToChatMessages(chatId);
+
+          // Advance time for retry attempts (initial: 500ms, backoff: 1s, 2s...)
+          async.elapse(const Duration(seconds: 3));
+
+          // The subscription should have retried exactly 3 times
+          expect(callCount, equals(3));
+
+          controller.close();
         });
-
-        // Start subscription - retry queue will retry on failure
-        chatSubscriptionService.subscribeToChatMessages(chatId);
-
-        // Allow time for retry attempts
-        await Future.delayed(const Duration(seconds: 3));
-
-        // The subscription should have retried multiple times
-        expect(callCount, greaterThanOrEqualTo(2));
-
-        controller.close();
       });
 
-      test('does not retry on auth errors', () async {
-        const chatId = 'chat-auth-error';
-        var callCount = 0;
+      test('does not retry on auth errors', () {
+        fakeAsync((async) {
+          const chatId = 'chat-auth-error';
+          var callCount = 0;
 
-        when(
-          mockDbFunctions.gqlAuthSubscription(
-            any,
-            variables: anyNamed('variables'),
-          ),
-        ).thenAnswer((_) {
-          callCount++;
-          throw Exception('auth token expired');
+          when(
+            mockDbFunctions.gqlAuthSubscription(
+              any,
+              variables: anyNamed('variables'),
+            ),
+          ).thenAnswer((_) {
+            callCount++;
+            throw Exception('auth token expired');
+          });
+
+          // Start subscription - should not retry because of auth error
+          chatSubscriptionService.subscribeToChatMessages(chatId);
+
+          // Advance time for potential retries
+          async.elapse(const Duration(seconds: 2));
+
+          // Should only have been called once due to auth error
+          expect(callCount, 1);
         });
-
-        // Start subscription - should not retry because of auth error
-        chatSubscriptionService.subscribeToChatMessages(chatId);
-
-        // Allow time for potential retries
-        await Future.delayed(const Duration(seconds: 2));
-
-        // Should only have been called once due to auth error
-        expect(callCount, 1);
       });
     });
 

--- a/test/service_tests/comment_service_test.dart
+++ b/test/service_tests/comment_service_test.dart
@@ -298,7 +298,8 @@ void main() {
       ).called(1);
     });
 
-    test('createComments respects shouldRetry callback for auth errors', () async {
+    test('createComments respects shouldRetry callback for auth errors',
+        () async {
       final db = locator<DataBaseMutationFunctions>();
       final query = CommentQueries().createComment();
 
@@ -325,7 +326,8 @@ void main() {
       expect(result, isNull);
     });
 
-    test('createComments shows success message on successful creation', () async {
+    test('createComments shows success message on successful creation',
+        () async {
       final db = locator<DataBaseMutationFunctions>();
       final query = CommentQueries().createComment();
       final mockData = {

--- a/test/service_tests/comment_service_test.dart
+++ b/test/service_tests/comment_service_test.dart
@@ -20,7 +20,7 @@ void main() {
         locator.unregister<RetryQueue>();
       }
       retryQueue = RetryQueue(
-        config: const RetryConfig(
+        config: RetryConfig(
           maxAttempts: 2,
           initialDelay: Duration(milliseconds: 1),
           maxDelay: Duration(milliseconds: 5),

--- a/test/service_tests/comment_service_test.dart
+++ b/test/service_tests/comment_service_test.dart
@@ -347,6 +347,8 @@ void main() {
       final result = await service.createComments('pid', 'body');
 
       expect(result, isNotNull);
+      // Note: showTalawaErrorSnackBar is the app's general-purpose snackbar
+      // method used for all message types (info, error, etc.), not just errors.
       verify(
         navigationService.showTalawaErrorSnackBar(
           "Comment sent",

--- a/test/service_tests/comment_service_test.dart
+++ b/test/service_tests/comment_service_test.dart
@@ -22,8 +22,8 @@ void main() {
       retryQueue = RetryQueue(
         config: RetryConfig(
           maxAttempts: 2,
-          initialDelay: Duration(milliseconds: 1),
-          maxDelay: Duration(milliseconds: 5),
+          initialDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 5),
         ),
       );
       locator.registerSingleton(retryQueue);

--- a/test/service_tests/database_mutation_functions_test.dart
+++ b/test/service_tests/database_mutation_functions_test.dart
@@ -826,7 +826,8 @@ void main() {
       final String mutation = Queries().fetchOrgById('XYZ');
 
       when(
-        locator<GraphQLClient>().mutate(MutationOptions(document: gql(mutation))),
+        locator<GraphQLClient>()
+            .mutate(MutationOptions(document: gql(mutation))),
       ).thenAnswer(
         (_) async => QueryResult(
           options: MutationOptions(document: gql(mutation)),
@@ -854,7 +855,8 @@ void main() {
       int callCount = 0;
 
       when(
-        locator<GraphQLClient>().mutate(MutationOptions(document: gql(mutation))),
+        locator<GraphQLClient>()
+            .mutate(MutationOptions(document: gql(mutation))),
       ).thenAnswer((_) async {
         callCount++;
         if (callCount < 2) {
@@ -889,7 +891,8 @@ void main() {
       final String mutation = Queries().fetchOrgById('XYZ');
 
       when(
-        locator<GraphQLClient>().mutate(MutationOptions(document: gql(mutation))),
+        locator<GraphQLClient>()
+            .mutate(MutationOptions(document: gql(mutation))),
       ).thenAnswer(
         (_) async => QueryResult(
           options: MutationOptions(document: gql(mutation)),

--- a/test/service_tests/retry_queue_functional_test.dart
+++ b/test/service_tests/retry_queue_functional_test.dart
@@ -136,7 +136,7 @@ void main() {
       'retry queue wraps a mutation call and recovers from transient failure',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 3,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -167,7 +167,7 @@ void main() {
       'retry returns noData equivalent when all attempts fail',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 2,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -196,7 +196,7 @@ void main() {
       'delays increase exponentially between retries',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 4,
             initialDelay: Duration(milliseconds: 50),
             maxDelay: Duration(seconds: 10),
@@ -240,7 +240,7 @@ void main() {
       'backoff delay is capped at maxDelay',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 5,
             initialDelay: Duration(milliseconds: 50),
             maxDelay: Duration(milliseconds: 80),
@@ -275,7 +275,7 @@ void main() {
       'multiple independent retry operations run without interfering',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 3,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 100),
@@ -333,7 +333,7 @@ void main() {
       'one failing task does not block others from succeeding',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 2,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -364,7 +364,7 @@ void main() {
       'cancelAll stops tracking for all in-flight tasks',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 10,
             initialDelay: Duration(milliseconds: 50),
             maxDelay: Duration(seconds: 5),
@@ -404,7 +404,7 @@ void main() {
       'after cancelAll, same key can be re-used for new execution',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 3,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -445,7 +445,7 @@ void main() {
       'auth errors bypass retry entirely',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 5,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -472,7 +472,7 @@ void main() {
       'network errors are retried while auth errors are not',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 5,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -504,7 +504,7 @@ void main() {
       'shouldRetry receives the actual error for inspection',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 3,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -538,7 +538,7 @@ void main() {
       'onRetry receives correct attempt number and error for each retry',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 4,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -578,7 +578,7 @@ void main() {
       'second execute with same key returns failure while first is running',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 3,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -617,7 +617,7 @@ void main() {
       'same key can be used again after first task completes',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 2,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -647,7 +647,7 @@ void main() {
       'enqueue throws on exhaustion while execute returns failure',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 2,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 50),
@@ -682,7 +682,7 @@ void main() {
       'subscription connection retries on failure then succeeds',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 5,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 100),
@@ -721,7 +721,7 @@ void main() {
       'subscription does not retry auth errors',
       () async {
         final queue = RetryQueue(
-          config: const RetryConfig(
+          config: RetryConfig(
             maxAttempts: 5,
             initialDelay: Duration(milliseconds: 10),
             maxDelay: Duration(milliseconds: 100),

--- a/test/service_tests/retry_queue_functional_test.dart
+++ b/test/service_tests/retry_queue_functional_test.dart
@@ -1,0 +1,743 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mockito/mockito.dart';
+import 'package:talawa/services/comment_service.dart';
+import 'package:talawa/services/retry_queue.dart';
+
+import '../helpers/test_helpers.dart';
+import '../helpers/test_helpers.mocks.dart';
+
+/// Functional tests that simulate end-to-end background retry policies
+/// for failed mutations, verifying timing, ordering, concurrency,
+/// and cancellation behaviour across real service integrations.
+void main() {
+  setUp(() {
+    registerServices();
+  });
+
+  tearDown(() {
+    unregisterServices();
+  });
+
+  group('Functional - CommentService mutation retry', () {
+    late CommentService commentService;
+    late MockDataBaseMutationFunctions mockDbFunctions;
+    late MockNavigationService mockNavService;
+
+    setUp(() {
+      mockDbFunctions = getAndRegisterDatabaseMutationFunctions()
+          as MockDataBaseMutationFunctions;
+      mockNavService =
+          getAndRegisterNavigationService() as MockNavigationService;
+      commentService = CommentService();
+    });
+
+    test(
+      'mutation fails twice then succeeds on third attempt',
+      () async {
+        var callCount = 0;
+        final successResult = QueryResult(
+          options: QueryOptions(document: gql('mutation { test }')),
+          data: {
+            'createComment': {
+              'id': 'cmt-1',
+              'body': 'Hello',
+              'createdAt': '2024-01-01T00:00:00Z',
+              'upVotesCount': 0,
+              'downVotesCount': 0,
+              'creator': {'name': 'Alice', 'avatarURL': null},
+              'post': {'id': 'post-1'},
+            },
+          },
+          source: QueryResultSource.network,
+        );
+
+        when(
+          mockDbFunctions.gqlAuthMutation(any, variables: anyNamed('variables')),
+        ).thenAnswer((_) async {
+          callCount++;
+          if (callCount < 3) {
+            throw Exception('Network timeout');
+          }
+          return successResult;
+        });
+
+        final comment = await commentService.createComments('post-1', 'Hello');
+
+        expect(comment, isNotNull);
+        expect(comment!.id, 'cmt-1');
+        expect(comment.body, 'Hello');
+        expect(callCount, 3);
+
+        verify(
+          mockNavService.showTalawaErrorSnackBar('Comment sent', any),
+        ).called(1);
+      },
+    );
+
+    test(
+      'mutation exhausts all retries and returns null with error snackbar',
+      () async {
+        var callCount = 0;
+
+        when(
+          mockDbFunctions.gqlAuthMutation(any, variables: anyNamed('variables')),
+        ).thenAnswer((_) async {
+          callCount++;
+          throw Exception('Server down');
+        });
+
+        final comment = await commentService.createComments('post-1', 'Hi');
+
+        expect(comment, isNull);
+        // Default config is 3 attempts
+        expect(callCount, 3);
+
+        verify(
+          mockNavService.showTalawaErrorSnackBar(
+            'Failed to send comment after retries',
+            any,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'mutation returns null data — triggers retry then fails gracefully',
+      () async {
+        var callCount = 0;
+        final noDataResult = QueryResult(
+          options: QueryOptions(document: gql('mutation { test }')),
+          data: null,
+          source: QueryResultSource.network,
+        );
+
+        when(
+          mockDbFunctions.gqlAuthMutation(any, variables: anyNamed('variables')),
+        ).thenAnswer((_) async {
+          callCount++;
+          return noDataResult;
+        });
+
+        final comment =
+            await commentService.createComments('post-2', 'No data');
+
+        expect(comment, isNull);
+        // Each call throws "No data returned" which is retried
+        expect(callCount, 3);
+      },
+    );
+  });
+
+  group('Functional - gqlAuthMutationWithRetry pattern', () {
+    test(
+      'retry queue wraps a mutation call and recovers from transient failure',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 3,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        var callCount = 0;
+        final successData = {'testField': 'testValue'};
+
+        final result = await queue.execute(
+          () async {
+            callCount++;
+            if (callCount < 2) {
+              throw Exception('Transient network error');
+            }
+            return successData;
+          },
+          key: 'func-test-mutation',
+        );
+
+        expect(result.succeeded, true);
+        expect(result.data, successData);
+        expect(callCount, 2);
+      },
+    );
+
+    test(
+      'retry returns noData equivalent when all attempts fail',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 2,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        var callCount = 0;
+
+        final result = await queue.execute(
+          () async {
+            callCount++;
+            throw Exception('Server unreachable');
+          },
+          key: 'func-test-nodata',
+        );
+
+        expect(result.succeeded, false);
+        expect(result.data, isNull);
+        expect(callCount, 2);
+      },
+    );
+  });
+
+  group('Functional - Exponential backoff timing', () {
+    test(
+      'delays increase exponentially between retries',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 4,
+            initialDelay: Duration(milliseconds: 50),
+            maxDelay: Duration(seconds: 10),
+            backoffMultiplier: 2.0,
+          ),
+        );
+
+        final timestamps = <DateTime>[];
+
+        await queue.execute(
+          () async {
+            timestamps.add(DateTime.now());
+            if (timestamps.length < 4) {
+              throw Exception('fail');
+            }
+            return 'done';
+          },
+          key: 'backoff-timing',
+        );
+
+        expect(timestamps.length, 4);
+
+        // Verify each gap is larger than the previous
+        final gap1 =
+            timestamps[1].difference(timestamps[0]).inMilliseconds;
+        final gap2 =
+            timestamps[2].difference(timestamps[1]).inMilliseconds;
+        final gap3 =
+            timestamps[3].difference(timestamps[2]).inMilliseconds;
+
+        // gap2 should be roughly 2x gap1, gap3 roughly 2x gap2
+        // (use generous tolerance for CI flakiness)
+        expect(gap2, greaterThan(gap1 * 1.5));
+        expect(gap3, greaterThan(gap2 * 1.5));
+      },
+    );
+
+    test(
+      'backoff delay is capped at maxDelay',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 5,
+            initialDelay: Duration(milliseconds: 50),
+            maxDelay: Duration(milliseconds: 80),
+            backoffMultiplier: 3.0,
+          ),
+        );
+
+        final timestamps = <DateTime>[];
+
+        await queue.execute(
+          () async {
+            timestamps.add(DateTime.now());
+            throw Exception('always fail');
+          },
+          key: 'cap-test',
+        );
+
+        // After initial 50ms, next would be 150ms but capped to 80ms
+        // Check that later gaps don't exceed maxDelay + tolerance
+        for (int i = 2; i < timestamps.length; i++) {
+          final gap =
+              timestamps[i].difference(timestamps[i - 1]).inMilliseconds;
+          // Allow 40ms tolerance for scheduling jitter
+          expect(gap, lessThan(120));
+        }
+      },
+    );
+  });
+
+  group('Functional - Concurrent independent mutations', () {
+    test(
+      'multiple independent retry operations run without interfering',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 3,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 100),
+          ),
+        );
+
+        var task1Calls = 0;
+        var task2Calls = 0;
+        var task3Calls = 0;
+
+        // All three tasks fail once then succeed
+        final future1 = queue.execute(
+          () async {
+            task1Calls++;
+            if (task1Calls < 2) throw Exception('t1');
+            return 'result-1';
+          },
+          key: 'concurrent-1',
+        );
+
+        final future2 = queue.execute(
+          () async {
+            task2Calls++;
+            if (task2Calls < 2) throw Exception('t2');
+            return 'result-2';
+          },
+          key: 'concurrent-2',
+        );
+
+        final future3 = queue.execute(
+          () async {
+            task3Calls++;
+            if (task3Calls < 2) throw Exception('t3');
+            return 'result-3';
+          },
+          key: 'concurrent-3',
+        );
+
+        final results = await Future.wait([future1, future2, future3]);
+
+        expect(results[0].succeeded, true);
+        expect(results[0].data, 'result-1');
+        expect(results[1].succeeded, true);
+        expect(results[1].data, 'result-2');
+        expect(results[2].succeeded, true);
+        expect(results[2].data, 'result-3');
+
+        expect(task1Calls, 2);
+        expect(task2Calls, 2);
+        expect(task3Calls, 2);
+      },
+    );
+
+    test(
+      'one failing task does not block others from succeeding',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 2,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        final successFuture = queue.execute(
+          () async => 'ok',
+          key: 'success-task',
+        );
+
+        final failFuture = queue.execute(
+          () async => throw Exception('permanent'),
+          key: 'fail-task',
+        );
+
+        final results = await Future.wait([successFuture, failFuture]);
+
+        expect(results[0].succeeded, true);
+        expect(results[0].data, 'ok');
+        expect(results[1].succeeded, false);
+      },
+    );
+  });
+
+  group('Functional - cancelAll during active retries', () {
+    test(
+      'cancelAll stops tracking for all in-flight tasks',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 10,
+            initialDelay: Duration(milliseconds: 50),
+            maxDelay: Duration(seconds: 5),
+          ),
+        );
+
+        var callCount = 0;
+        final completer = Completer<void>();
+
+        // Launch a task that will keep retrying
+        // ignore: unawaited_futures
+        queue.execute(
+          () async {
+            callCount++;
+            if (callCount == 2) {
+              // Signal the main test to cancel after 2nd attempt
+              completer.complete();
+            }
+            throw Exception('keep failing');
+          },
+          key: 'cancel-during-retry',
+        );
+
+        // Wait for 2nd attempt
+        await completer.future;
+
+        expect(queue.isRetrying('cancel-during-retry'), true);
+
+        queue.cancelAll();
+
+        expect(queue.isRetrying('cancel-during-retry'), false);
+        expect(queue.getAttemptCount('cancel-during-retry'), 0);
+      },
+    );
+
+    test(
+      'after cancelAll, same key can be re-used for new execution',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 3,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        // Start and immediately cancel
+        final completer = Completer<void>();
+        // ignore: unawaited_futures
+        queue.execute(
+          () async {
+            completer.complete();
+            await Future.delayed(const Duration(seconds: 10));
+            return 'never';
+          },
+          key: 'reuse-key',
+        );
+
+        await completer.future;
+        queue.cancelAll();
+
+        // Now re-use the same key
+        final result = await queue.execute(
+          () async => 'reused-success',
+          key: 'reuse-key',
+        );
+
+        expect(result.succeeded, true);
+        expect(result.data, 'reused-success');
+      },
+    );
+  });
+
+  group('Functional - shouldRetry error filtering', () {
+    test(
+      'auth errors bypass retry entirely',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 5,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        var callCount = 0;
+
+        final result = await queue.execute(
+          () async {
+            callCount++;
+            throw Exception('authentication token expired');
+          },
+          key: 'auth-error-test',
+          shouldRetry: (error) => !error.toString().contains('auth'),
+        );
+
+        expect(result.succeeded, false);
+        expect(callCount, 1); // Only one attempt, no retries
+      },
+    );
+
+    test(
+      'network errors are retried while auth errors are not',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 5,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        var callCount = 0;
+
+        final result = await queue.execute(
+          () async {
+            callCount++;
+            if (callCount < 3) {
+              throw Exception('Network timeout');
+            }
+            // After network retries succeed, we never see auth error
+            return 'recovered';
+          },
+          key: 'mixed-errors',
+          shouldRetry: (error) => !error.toString().contains('auth'),
+        );
+
+        expect(result.succeeded, true);
+        expect(result.data, 'recovered');
+        expect(callCount, 3);
+      },
+    );
+
+    test(
+      'shouldRetry receives the actual error for inspection',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 3,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        final capturedErrors = <Exception>[];
+
+        await queue.execute(
+          () async {
+            throw Exception('error-${capturedErrors.length}');
+          },
+          key: 'error-inspect',
+          shouldRetry: (error) {
+            capturedErrors.add(error);
+            return true;
+          },
+        );
+
+        // shouldRetry is called for every failed attempt
+        expect(capturedErrors.length, 3);
+        expect(capturedErrors[0].toString(), contains('error-0'));
+        expect(capturedErrors[1].toString(), contains('error-1'));
+        expect(capturedErrors[2].toString(), contains('error-2'));
+      },
+    );
+  });
+
+  group('Functional - onRetry callback ordering and data', () {
+    test(
+      'onRetry receives correct attempt number and error for each retry',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 4,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        final retryAttempts = <int>[];
+        final retryErrors = <String>[];
+        var callCount = 0;
+
+        await queue.execute(
+          () async {
+            callCount++;
+            if (callCount < 4) {
+              throw Exception('attempt-$callCount');
+            }
+            return 'ok';
+          },
+          key: 'onretry-test',
+          onRetry: (attempt, error) {
+            retryAttempts.add(attempt);
+            retryErrors.add(error.toString());
+          },
+        );
+
+        // onRetry fires for attempts 1, 2, 3 (not for the final success)
+        expect(retryAttempts, [1, 2, 3]);
+        expect(retryErrors[0], contains('attempt-1'));
+        expect(retryErrors[1], contains('attempt-2'));
+        expect(retryErrors[2], contains('attempt-3'));
+      },
+    );
+  });
+
+  group('Functional - duplicate key rejection', () {
+    test(
+      'second execute with same key returns failure while first is running',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 3,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        final gate = Completer<void>();
+
+        // Start a long-running task
+        final firstFuture = queue.execute(
+          () async {
+            await gate.future;
+            return 'first';
+          },
+          key: 'dup-key',
+        );
+
+        // Immediately try to run a second task with the same key
+        final secondResult = await queue.execute(
+          () async => 'second',
+          key: 'dup-key',
+        );
+
+        expect(secondResult.succeeded, false);
+        expect(secondResult.error.toString(), contains('already executing'));
+
+        // Let the first task finish
+        gate.complete();
+        final firstResult = await firstFuture;
+        expect(firstResult.succeeded, true);
+        expect(firstResult.data, 'first');
+      },
+    );
+
+    test(
+      'same key can be used again after first task completes',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 2,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        final result1 = await queue.execute(
+          () async => 'first-run',
+          key: 'seq-key',
+        );
+
+        final result2 = await queue.execute(
+          () async => 'second-run',
+          key: 'seq-key',
+        );
+
+        expect(result1.succeeded, true);
+        expect(result1.data, 'first-run');
+        expect(result2.succeeded, true);
+        expect(result2.data, 'second-run');
+      },
+    );
+  });
+
+  group('Functional - static enqueue vs instance execute', () {
+    test(
+      'static enqueue throws on exhaustion while instance returns failure',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 2,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 50),
+          ),
+        );
+
+        // Static enqueue — throws
+        expect(
+          () => RetryQueue.enqueue(
+            () async => throw Exception('static-fail'),
+            key: 'static-throw',
+            initial: const Duration(milliseconds: 10),
+            maxAttempts: 2,
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        // Instance execute — returns RetryResult.failure
+        final result = await queue.execute(
+          () async => throw Exception('instance-fail'),
+          key: 'instance-fail',
+        );
+
+        expect(result.succeeded, false);
+        expect(result.error, isA<Exception>());
+      },
+    );
+  });
+
+  group('Functional - Chat subscription retry with service mock', () {
+    test(
+      'subscription connection retries on failure then succeeds',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 5,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 100),
+          ),
+        );
+
+        var connectionAttempts = 0;
+
+        // Simulate the pattern used in ChatSubscriptionService:
+        // The task establishes a connection (which may throw), then
+        // listens to the stream. We test the connection phase retry.
+        final result = await queue.execute(
+          () async {
+            connectionAttempts++;
+            if (connectionAttempts < 3) {
+              throw Exception('WebSocket connection failed');
+            }
+            // Connection established — return immediately
+            // (in real code this would start the stream listener)
+            return 'connected';
+          },
+          key: 'chat-subscription-chat-42',
+          shouldRetry: (error) => !error.toString().contains('auth'),
+          onRetry: (attempt, error) {
+            // Matches the pattern in ChatSubscriptionService
+          },
+        );
+
+        expect(result.succeeded, true);
+        expect(result.data, 'connected');
+        expect(connectionAttempts, 3);
+      },
+    );
+
+    test(
+      'subscription does not retry auth errors',
+      () async {
+        final queue = RetryQueue(
+          config: const RetryConfig(
+            maxAttempts: 5,
+            initialDelay: Duration(milliseconds: 10),
+            maxDelay: Duration(milliseconds: 100),
+          ),
+        );
+
+        var connectionAttempts = 0;
+
+        final result = await queue.execute(
+          () async {
+            connectionAttempts++;
+            throw Exception('auth token invalid');
+          },
+          key: 'chat-subscription-auth-fail',
+          shouldRetry: (error) => !error.toString().contains('auth'),
+        );
+
+        expect(result.succeeded, false);
+        expect(connectionAttempts, 1);
+      },
+    );
+  });
+}

--- a/test/service_tests/retry_queue_functional_test.dart
+++ b/test/service_tests/retry_queue_functional_test.dart
@@ -86,7 +86,7 @@ void main() {
         when(
           mockDbFunctions.gqlAuthMutation(any,
               variables: anyNamed('variables')),
-        ).thenAnswer((_) async {
+        ).thenAnswer((_) {
           callCount++;
           throw Exception('Server down');
         });
@@ -141,8 +141,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 3,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -172,15 +172,15 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 2,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
         var callCount = 0;
 
         final result = await queue.execute(
-          () async {
+          () {
             callCount++;
             throw Exception('Server unreachable');
           },
@@ -201,8 +201,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 4,
-            initialDelay: Duration(milliseconds: 50),
-            maxDelay: Duration(seconds: 10),
+            initialDelay: const Duration(milliseconds: 50),
+            maxDelay: const Duration(seconds: 10),
             backoffMultiplier: 2.0,
           ),
         );
@@ -242,8 +242,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 5,
-            initialDelay: Duration(milliseconds: 50),
-            maxDelay: Duration(milliseconds: 80),
+            initialDelay: const Duration(milliseconds: 50),
+            maxDelay: const Duration(milliseconds: 80),
             backoffMultiplier: 3.0,
           ),
         );
@@ -251,7 +251,7 @@ void main() {
         final timestamps = <DateTime>[];
 
         await queue.execute(
-          () async {
+          () {
             timestamps.add(DateTime.now());
             throw Exception('always fail');
           },
@@ -277,8 +277,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 3,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 100),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 100),
           ),
         );
 
@@ -335,8 +335,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 2,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -366,8 +366,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 10,
-            initialDelay: Duration(milliseconds: 50),
-            maxDelay: Duration(seconds: 5),
+            initialDelay: const Duration(milliseconds: 50),
+            maxDelay: const Duration(seconds: 5),
           ),
         );
 
@@ -413,8 +413,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 3,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -455,15 +455,15 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 5,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
         var callCount = 0;
 
         final result = await queue.execute(
-          () async {
+          () {
             callCount++;
             throw Exception('authentication token expired');
           },
@@ -482,8 +482,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 5,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -514,15 +514,15 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 3,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
         final capturedErrors = <Exception>[];
 
         await queue.execute(
-          () async {
+          () {
             throw Exception('error-${capturedErrors.length}');
           },
           key: 'error-inspect',
@@ -548,8 +548,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 4,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -588,8 +588,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 3,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -627,8 +627,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 2,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -657,8 +657,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 2,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 50),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 50),
           ),
         );
 
@@ -692,8 +692,8 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 5,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 100),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 100),
           ),
         );
 
@@ -731,15 +731,15 @@ void main() {
         final queue = RetryQueue(
           config: RetryConfig(
             maxAttempts: 5,
-            initialDelay: Duration(milliseconds: 10),
-            maxDelay: Duration(milliseconds: 100),
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 100),
           ),
         );
 
         var connectionAttempts = 0;
 
         final result = await queue.execute(
-          () async {
+          () {
             connectionAttempts++;
             throw Exception('auth token invalid');
           },

--- a/test/service_tests/retry_queue_functional_test.dart
+++ b/test/service_tests/retry_queue_functional_test.dart
@@ -55,7 +55,8 @@ void main() {
         );
 
         when(
-          mockDbFunctions.gqlAuthMutation(any, variables: anyNamed('variables')),
+          mockDbFunctions.gqlAuthMutation(any,
+              variables: anyNamed('variables')),
         ).thenAnswer((_) async {
           callCount++;
           if (callCount < 3) {
@@ -83,7 +84,8 @@ void main() {
         var callCount = 0;
 
         when(
-          mockDbFunctions.gqlAuthMutation(any, variables: anyNamed('variables')),
+          mockDbFunctions.gqlAuthMutation(any,
+              variables: anyNamed('variables')),
         ).thenAnswer((_) async {
           callCount++;
           throw Exception('Server down');
@@ -115,7 +117,8 @@ void main() {
         );
 
         when(
-          mockDbFunctions.gqlAuthMutation(any, variables: anyNamed('variables')),
+          mockDbFunctions.gqlAuthMutation(any,
+              variables: anyNamed('variables')),
         ).thenAnswer((_) async {
           callCount++;
           return noDataResult;
@@ -222,12 +225,9 @@ void main() {
         // Verify each gap meets conservative minimums based on config
         // (initialDelay: 50ms, backoffMultiplier: 2.0)
         // Expected delays: 50ms, 100ms, 200ms with 80% tolerance for CI
-        final gap1 =
-            timestamps[1].difference(timestamps[0]).inMilliseconds;
-        final gap2 =
-            timestamps[2].difference(timestamps[1]).inMilliseconds;
-        final gap3 =
-            timestamps[3].difference(timestamps[2]).inMilliseconds;
+        final gap1 = timestamps[1].difference(timestamps[0]).inMilliseconds;
+        final gap2 = timestamps[2].difference(timestamps[1]).inMilliseconds;
+        final gap3 = timestamps[3].difference(timestamps[2]).inMilliseconds;
 
         // Check each gap meets minimum threshold (80% of expected)
         expect(gap1, greaterThanOrEqualTo((50 * 0.8).toInt())); // ~40ms
@@ -425,7 +425,8 @@ void main() {
         queue.execute(
           () async {
             startCompleter.complete();
-            return await taskCompleter.future; // Wait indefinitely until completed
+            return await taskCompleter
+                .future; // Wait indefinitely until completed
           },
           key: 'reuse-key',
         );

--- a/test/service_tests/retry_queue_test.dart
+++ b/test/service_tests/retry_queue_test.dart
@@ -400,8 +400,8 @@ void main() {
     });
 
     test('throws after max retries', () async {
-      expect(
-        () async => retryQueue.enqueue(
+      await expectLater(
+        retryQueue.enqueue(
           () async {
             throw Exception('Always fail');
           },

--- a/test/service_tests/retry_queue_test.dart
+++ b/test/service_tests/retry_queue_test.dart
@@ -352,7 +352,8 @@ void main() {
       // Total delay should be around 350ms (50 + 100 + 100 + 100)
       expect(callCount, 5);
       // Verify minimum elapsed time to ensure backoff occurred (with margin)
-      expect(stopwatch.elapsed, greaterThanOrEqualTo(const Duration(milliseconds: 300)));
+      expect(stopwatch.elapsed,
+          greaterThanOrEqualTo(const Duration(milliseconds: 300)));
     });
   });
 

--- a/test/service_tests/retry_queue_test.dart
+++ b/test/service_tests/retry_queue_test.dart
@@ -6,7 +6,7 @@ import 'package:talawa/services/retry_queue.dart';
 void main() {
   group('RetryConfig', () {
     test('should have correct default values', () {
-      const config = RetryConfig();
+      final config = RetryConfig();
 
       expect(config.maxAttempts, 3);
       expect(config.initialDelay, const Duration(milliseconds: 300));
@@ -15,7 +15,7 @@ void main() {
     });
 
     test('should accept custom values', () {
-      const config = RetryConfig(
+      final config = RetryConfig(
         maxAttempts: 5,
         initialDelay: Duration(milliseconds: 100),
         maxDelay: Duration(seconds: 60),
@@ -53,7 +53,7 @@ void main() {
 
     setUp(() {
       retryQueue = RetryQueue(
-        config: const RetryConfig(
+        config: RetryConfig(
           maxAttempts: 3,
           initialDelay: Duration(milliseconds: 10),
           maxDelay: Duration(milliseconds: 100),
@@ -301,7 +301,7 @@ void main() {
           throw Exception('Error');
         },
         key: 'custom-config',
-        customConfig: const RetryConfig(
+        customConfig: RetryConfig(
           maxAttempts: 5,
           initialDelay: Duration(milliseconds: 5),
         ),
@@ -327,7 +327,7 @@ void main() {
       // This test verifies the delay capping logic works
       // We use a short config to speed up the test
       final fastQueue = RetryQueue(
-        config: const RetryConfig(
+        config: RetryConfig(
           maxAttempts: 5,
           initialDelay: Duration(milliseconds: 50),
           maxDelay: Duration(milliseconds: 100),
@@ -361,7 +361,7 @@ void main() {
 
     setUp(() {
       retryQueue = RetryQueue(
-        config: const RetryConfig(
+        config: RetryConfig(
           maxAttempts: 3,
           initialDelay: Duration(milliseconds: 10),
           maxDelay: Duration(milliseconds: 100),

--- a/test/service_tests/retry_queue_test.dart
+++ b/test/service_tests/retry_queue_test.dart
@@ -1,0 +1,421 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talawa/services/retry_queue.dart';
+
+void main() {
+  group('RetryConfig', () {
+    test('should have correct default values', () {
+      const config = RetryConfig();
+
+      expect(config.maxAttempts, 3);
+      expect(config.initialDelay, const Duration(milliseconds: 300));
+      expect(config.maxDelay, const Duration(seconds: 30));
+      expect(config.backoffMultiplier, 2.0);
+    });
+
+    test('should accept custom values', () {
+      const config = RetryConfig(
+        maxAttempts: 5,
+        initialDelay: Duration(milliseconds: 100),
+        maxDelay: Duration(seconds: 60),
+        backoffMultiplier: 3.0,
+      );
+
+      expect(config.maxAttempts, 5);
+      expect(config.initialDelay, const Duration(milliseconds: 100));
+      expect(config.maxDelay, const Duration(seconds: 60));
+      expect(config.backoffMultiplier, 3.0);
+    });
+  });
+
+  group('RetryResult', () {
+    test('success constructor sets correct values', () {
+      final result = RetryResult<String>.success('test data');
+
+      expect(result.succeeded, true);
+      expect(result.data, 'test data');
+      expect(result.error, null);
+    });
+
+    test('failure constructor sets correct values', () {
+      final exception = Exception('test error');
+      final result = RetryResult<String>.failure(exception);
+
+      expect(result.succeeded, false);
+      expect(result.data, null);
+      expect(result.error, exception);
+    });
+  });
+
+  group('RetryQueue', () {
+    late RetryQueue retryQueue;
+
+    setUp(() {
+      retryQueue = RetryQueue(
+        config: const RetryConfig(
+          maxAttempts: 3,
+          initialDelay: Duration(milliseconds: 10),
+          maxDelay: Duration(milliseconds: 100),
+        ),
+      );
+    });
+
+    test('successful task returns immediately', () async {
+      int callCount = 0;
+      final result = await retryQueue.execute(
+        () async {
+          callCount++;
+          return 'success';
+        },
+        key: 'test-1',
+      );
+
+      expect(result.succeeded, true);
+      expect(result.data, 'success');
+      expect(callCount, 1);
+    });
+
+    test('retries on failure and succeeds', () async {
+      int callCount = 0;
+      final result = await retryQueue.execute(
+        () async {
+          callCount++;
+          if (callCount < 3) {
+            throw Exception('Temporary error');
+          }
+          return 'success';
+        },
+        key: 'test-2',
+      );
+
+      expect(result.succeeded, true);
+      expect(result.data, 'success');
+      expect(callCount, 3);
+    });
+
+    test('fails after max attempts exceeded', () async {
+      int callCount = 0;
+      final result = await retryQueue.execute(
+        () async {
+          callCount++;
+          throw Exception('Permanent error');
+        },
+        key: 'test-3',
+      );
+
+      expect(result.succeeded, false);
+      expect(result.error, isA<Exception>());
+      expect(callCount, 3);
+    });
+
+    test('respects shouldRetry callback returning false', () async {
+      int callCount = 0;
+      final result = await retryQueue.execute(
+        () async {
+          callCount++;
+          throw Exception('No retry error');
+        },
+        key: 'test-4',
+        shouldRetry: (_) => false,
+      );
+
+      expect(result.succeeded, false);
+      expect(callCount, 1);
+    });
+
+    test('respects shouldRetry callback returning true', () async {
+      int callCount = 0;
+      final result = await retryQueue.execute(
+        () async {
+          callCount++;
+          if (callCount < 2) {
+            throw Exception('Retry this error');
+          }
+          return 'success';
+        },
+        key: 'test-5',
+        shouldRetry: (_) => true,
+      );
+
+      expect(result.succeeded, true);
+      expect(callCount, 2);
+    });
+
+    test('calls onRetry callback on each retry', () async {
+      final attempts = <int>[];
+      final errors = <Exception>[];
+
+      await retryQueue.execute(
+        () async {
+          if (attempts.length < 2) {
+            throw Exception('Error ${attempts.length}');
+          }
+          return 'ok';
+        },
+        key: 'test-6',
+        onRetry: (attempt, error) {
+          attempts.add(attempt);
+          errors.add(error);
+        },
+      );
+
+      expect(attempts, [1, 2]);
+      expect(errors.length, 2);
+    });
+
+    test('prevents duplicate executions with same key', () async {
+      final completer = Completer<void>();
+
+      // Start a task that won't complete until we signal it
+      final future1 = retryQueue.execute(
+        () async {
+          await completer.future;
+          return 'first';
+        },
+        key: 'dup-test',
+      );
+
+      // Try to start another task with the same key
+      final result2 = await retryQueue.execute(
+        () async => 'second',
+        key: 'dup-test',
+      );
+
+      // Second task should fail immediately
+      expect(result2.succeeded, false);
+      expect(result2.error.toString(), contains('already executing'));
+
+      // Complete the first task
+      completer.complete();
+      final result1 = await future1;
+      expect(result1.succeeded, true);
+      expect(result1.data, 'first');
+    });
+
+    test('isRetrying tracks execution state correctly', () async {
+      final completer = Completer<void>();
+
+      expect(retryQueue.isRetrying('state-key'), false);
+
+      final future = retryQueue.execute(
+        () async {
+          await completer.future;
+          return 'done';
+        },
+        key: 'state-key',
+      );
+
+      expect(retryQueue.isRetrying('state-key'), true);
+
+      completer.complete();
+      await future;
+
+      expect(retryQueue.isRetrying('state-key'), false);
+    });
+
+    test('getAttemptCount returns correct count during execution', () async {
+      int maxAttemptSeen = 0;
+
+      await retryQueue.execute(
+        () async {
+          maxAttemptSeen = retryQueue.getAttemptCount('count-key');
+          if (maxAttemptSeen < 2) {
+            throw Exception('Need more attempts');
+          }
+          return 'done';
+        },
+        key: 'count-key',
+      );
+
+      expect(maxAttemptSeen, 2);
+    });
+
+    test('getAttemptCount returns 0 for non-existent key', () {
+      expect(retryQueue.getAttemptCount('non-existent'), 0);
+    });
+
+    test('cancel removes task from queue', () async {
+      final completer = Completer<void>();
+
+      // ignore: unawaited_futures
+      retryQueue.execute(
+        () async {
+          await completer.future;
+          return 'done';
+        },
+        key: 'cancel-key',
+      );
+
+      expect(retryQueue.isRetrying('cancel-key'), true);
+
+      retryQueue.cancel('cancel-key');
+
+      expect(retryQueue.isRetrying('cancel-key'), false);
+
+      // Complete to avoid pending future issues
+      completer.complete();
+      // Note: The task may still complete since cancel only clears tracking
+    });
+
+    test('cancelAll removes all tasks', () async {
+      final completer1 = Completer<void>();
+      final completer2 = Completer<void>();
+
+      retryQueue.execute(
+        () async {
+          await completer1.future;
+          return 'task1';
+        },
+        key: 'cancel-all-1',
+      );
+
+      retryQueue.execute(
+        () async {
+          await completer2.future;
+          return 'task2';
+        },
+        key: 'cancel-all-2',
+      );
+
+      expect(retryQueue.isRetrying('cancel-all-1'), true);
+      expect(retryQueue.isRetrying('cancel-all-2'), true);
+
+      retryQueue.cancelAll();
+
+      expect(retryQueue.isRetrying('cancel-all-1'), false);
+      expect(retryQueue.isRetrying('cancel-all-2'), false);
+
+      // Complete to avoid pending future issues
+      completer1.complete();
+      completer2.complete();
+    });
+
+    test('respects custom config override', () async {
+      int callCount = 0;
+      final result = await retryQueue.execute(
+        () async {
+          callCount++;
+          throw Exception('Error');
+        },
+        key: 'custom-config',
+        customConfig: const RetryConfig(
+          maxAttempts: 5,
+          initialDelay: Duration(milliseconds: 5),
+        ),
+      );
+
+      expect(result.succeeded, false);
+      expect(callCount, 5); // Should use custom maxAttempts
+    });
+
+    test('handles non-Exception errors gracefully', () async {
+      final result = await retryQueue.execute(
+        () async {
+          throw 'String error'; // Not an Exception
+        },
+        key: 'string-error',
+      );
+
+      expect(result.succeeded, false);
+      expect(result.error, isA<Exception>());
+    });
+
+    test('exponential backoff respects maxDelay', () async {
+      // This test verifies the delay capping logic works
+      // We use a short config to speed up the test
+      final fastQueue = RetryQueue(
+        config: const RetryConfig(
+          maxAttempts: 5,
+          initialDelay: Duration(milliseconds: 50),
+          maxDelay: Duration(milliseconds: 100),
+          backoffMultiplier: 3.0,
+        ),
+      );
+
+      final stopwatch = Stopwatch()..start();
+      int callCount = 0;
+
+      await fastQueue.execute(
+        () async {
+          callCount++;
+          throw Exception('Error');
+        },
+        key: 'backoff-test',
+      );
+
+      stopwatch.stop();
+
+      // With 5 attempts, delays would be: 50, 150 (capped to 100), 300 (capped to 100), 900 (capped to 100)
+      // Total delay should be around 350ms (50 + 100 + 100 + 100)
+      // But accounting for execution time, we just verify it completed
+      expect(callCount, 5);
+    });
+  });
+
+  group('RetryQueue.enqueue (static method)', () {
+    test('successful execution returns result', () async {
+      int count = 0;
+      final result = await RetryQueue.enqueue(
+        () async {
+          count++;
+          return 'static-success';
+        },
+        key: 'static-test-1',
+      );
+
+      expect(result, 'static-success');
+      expect(count, 1);
+    });
+
+    test('retries and succeeds', () async {
+      int count = 0;
+      final result = await RetryQueue.enqueue(
+        () async {
+          count++;
+          if (count < 2) throw Exception('Temp');
+          return 'success';
+        },
+        key: 'static-test-2',
+        initial: const Duration(milliseconds: 10),
+      );
+
+      expect(result, 'success');
+      expect(count, 2);
+    });
+
+    test('throws after max retries', () async {
+      expect(
+        () async => RetryQueue.enqueue(
+          () async {
+            throw Exception('Always fail');
+          },
+          key: 'static-test-3',
+          initial: const Duration(milliseconds: 10),
+          maxAttempts: 3,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('respects custom maxAttempts', () async {
+      int count = 0;
+
+      try {
+        await RetryQueue.enqueue(
+          () async {
+            count++;
+            throw Exception('Fail');
+          },
+          key: 'static-test-4',
+          initial: const Duration(milliseconds: 5),
+          maxAttempts: 5,
+        );
+      } catch (_) {
+        // Expected
+      }
+
+      expect(count, 5);
+    });
+  });
+}

--- a/test/service_tests/retry_queue_test.dart
+++ b/test/service_tests/retry_queue_test.dart
@@ -17,8 +17,8 @@ void main() {
     test('should accept custom values', () {
       final config = RetryConfig(
         maxAttempts: 5,
-        initialDelay: Duration(milliseconds: 100),
-        maxDelay: Duration(seconds: 60),
+        initialDelay: const Duration(milliseconds: 100),
+        maxDelay: const Duration(seconds: 60),
         backoffMultiplier: 3.0,
       );
 
@@ -55,8 +55,8 @@ void main() {
       retryQueue = RetryQueue(
         config: RetryConfig(
           maxAttempts: 3,
-          initialDelay: Duration(milliseconds: 10),
-          maxDelay: Duration(milliseconds: 100),
+          initialDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 100),
         ),
       );
     });
@@ -97,7 +97,7 @@ void main() {
     test('fails after max attempts exceeded', () async {
       int callCount = 0;
       final result = await retryQueue.execute(
-        () async {
+        () {
           callCount++;
           throw Exception('Permanent error');
         },
@@ -112,7 +112,7 @@ void main() {
     test('respects shouldRetry callback returning false', () async {
       int callCount = 0;
       final result = await retryQueue.execute(
-        () async {
+        () {
           callCount++;
           throw Exception('No retry error');
         },
@@ -235,7 +235,7 @@ void main() {
       expect(retryQueue.getAttemptCount('non-existent'), 0);
     });
 
-    test('cancel removes task from queue', () async {
+    test('cancel removes task from queue', () {
       final completer = Completer<void>();
 
       // ignore: unawaited_futures
@@ -258,7 +258,7 @@ void main() {
       // Note: The task may still complete since cancel only clears tracking
     });
 
-    test('cancelAll removes all tasks', () async {
+    test('cancelAll removes all tasks', () {
       final completer1 = Completer<void>();
       final completer2 = Completer<void>();
 
@@ -296,14 +296,14 @@ void main() {
     test('respects custom config override', () async {
       int callCount = 0;
       final result = await retryQueue.execute(
-        () async {
+        () {
           callCount++;
           throw Exception('Error');
         },
         key: 'custom-config',
         customConfig: RetryConfig(
           maxAttempts: 5,
-          initialDelay: Duration(milliseconds: 5),
+          initialDelay: const Duration(milliseconds: 5),
         ),
       );
 
@@ -313,7 +313,7 @@ void main() {
 
     test('handles non-Exception errors gracefully', () async {
       final result = await retryQueue.execute(
-        () async {
+        () {
           throw 'String error'; // Not an Exception
         },
         key: 'string-error',
@@ -329,8 +329,8 @@ void main() {
       final fastQueue = RetryQueue(
         config: RetryConfig(
           maxAttempts: 5,
-          initialDelay: Duration(milliseconds: 50),
-          maxDelay: Duration(milliseconds: 100),
+          initialDelay: const Duration(milliseconds: 50),
+          maxDelay: const Duration(milliseconds: 100),
           backoffMultiplier: 3.0,
         ),
       );
@@ -339,7 +339,7 @@ void main() {
       int callCount = 0;
 
       await fastQueue.execute(
-        () async {
+        () {
           callCount++;
           throw Exception('Error');
         },
@@ -364,8 +364,8 @@ void main() {
       retryQueue = RetryQueue(
         config: RetryConfig(
           maxAttempts: 3,
-          initialDelay: Duration(milliseconds: 10),
-          maxDelay: Duration(milliseconds: 100),
+          initialDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 100),
         ),
       );
     });
@@ -403,7 +403,7 @@ void main() {
     test('throws after max retries', () async {
       await expectLater(
         retryQueue.enqueue(
-          () async {
+          () {
             throw Exception('Always fail');
           },
           key: 'enqueue-test-3',
@@ -419,7 +419,7 @@ void main() {
 
       try {
         await retryQueue.enqueue(
-          () async {
+          () {
             count++;
             throw Exception('Fail');
           },


### PR DESCRIPTION
### What kind of change does this PR introduce?

Feature — adds a background retry queue with exponential backoff for failed GraphQL mutations and subscriptions.

### Issue Number:

Fixes #3203

### Did you add tests for your changes?

- [x] Tests are written for all changes made in this PR.
- [x] Test coverage exceeds 95% for all new/changed files.

**Comprehensive test suite (116 tests total):**
- `test/service_tests/retry_queue_test.dart` — unit tests for `RetryQueue`, `RetryConfig`, `RetryResult` (23 cases)
- `test/service_tests/retry_queue_functional_test.dart` — integration/functional tests (20 cases, 743 lines)
- `test/service_tests/chat_subscription_service_test.dart` — retry behavior for chat subscriptions
- `test/service_tests/comment_service_test.dart` — retry-wrapped mutations with auth error handling (13 cases)
- `test/service_tests/caching/offline_action_queue_test.dart` — pending actions, FIFO ordering, expiry handling (14 cases)
- `test/service_tests/database_mutation_functions_test.dart` — retry mutation tests (25 cases)
- `test/service_tests/base_feed_manager_test.dart` — retry feed fetching tests (8 cases)
- `test/plugin_tests/plugin_registry_test.dart` — service availability tests (13 cases)

**Coverage for new/changed files:**
| File | Coverage | Tests |
|------|---------|-------|
| `retry_queue.dart` | **100%** | 43 tests |
| `chat_subscription_service.dart` | **100%** | Full retry + cleanup coverage |
| `comment_service.dart` | **~98%** ↑ | Error paths + shouldRetry logic |
| `database_mutation_functions.dart` | **~98%** ↑ | `gqlAuthMutationWithRetry` fully tested |
| `base_feed_manager.dart` | **~98%** ↑ | `fetchWithRetry` fully tested |
| `offline_action_queue.dart` | **~95%** ↑ | FIFO, expiry, pending actions |
| `registry.dart` | **~95%** ↑ | `getAvailableServices` tested |

**All files meet >95% coverage target** ✅

Snapshots/Videos:

N/A (service-layer only, no UI changes)

### If relevant, did you update the documentation?

Yes — `lib/plugin/readme/files.md` updated with retry queue integration guide for plugins.

### Summary

This is **Part 1 of 6** implementing a resilient background retry policy for failed mutations.

#### Core infrastructure (`lib/services/retry_queue.dart`):
- **`RetryQueue`** service with:
  - `enqueue()` method (thin wrapper around `execute` for backward compatibility)
  - `execute()` method with full `RetryResult<T>` wrapper for type-safe success/failure handling
  - Duplicate task prevention via unique keys
  - Attempt tracking and cancellation support
  - Pattern matching for null-safe result unwrapping

- **`RetryConfig`** with validation:
  - Configurable max attempts, initial delay, max delay, backoff multiplier
  - Runtime assertions: `maxAttempts >= 1`, delays non-negative, `maxDelay >= initialDelay`, `backoffMultiplier > 0`
  - Smart `maxDelay` adjustment in `enqueue` to prevent assertion failures

- **`RetryResult<T>`** sealed class:
  - Type-safe discriminated union (`RetryResultSuccess<T>` | `RetryResultFailure<T>`)
  - Supports nullable return values from tasks
  - Pattern matching for elegant error handling

#### Error handling improvements:
- **Exception vs Error distinction**: Only catches `Exception` in retry loop; `Error` types rethrow immediately
- **Original error preservation**: Captures and includes original exception in "max retries exceeded" messages
- **Auth error detection**: `shouldRetry` callbacks skip retry for authentication/authorization failures
- **Graceful degradation**: Falls back to cached data when all retries fail

#### Service integrations:

**`CommentService`** (`lib/services/comment_service.dart`):
- `createComments()` wrapped with retry + deterministic retry keys (hash of postId + body)
- `shouldRetry` callback skips auth/authz errors (pattern: `/\b(auth|authentication|authorization|...)\b/`)
- User feedback on success/failure via `NavigationService`
- Error handling in `toggleUpVoteComment` and `toggleDownVoteComment`

**`ChatSubscriptionService`** (`lib/services/chat_subscription_service.dart`):
- Subscription initialization wrapped with retry (5 attempts, 500ms initial, 30s max)
- Proper cleanup: `_activeChatId` tracking + `retryQueue.cancel()` on `stopSubscription()`
- Prevents orphaned retry tasks when switching chats or disposing
- `RetryResult` inspection instead of unreachable `catchError`

**`DatabaseMutationFunctions`** (`lib/services/database_mutation_functions.dart`):
- Added `gqlAuthMutationWithRetry()` helper method
- `_buildRetryKey()` private helper for deterministic retry keys (SHA1 hash of mutation + variables)
- Replaces IIFE pattern with clear, testable function

**`BaseFeedManager`** (`lib/services/caching/base_feed_manager.dart`):
- Added `fetchWithRetry()` for resilient feed fetching
- Saves successful results to cache
- Falls back to cached data on retry exhaustion

**`OfflineActionQueue`** (`lib/services/caching/offline_action_queue.dart`):
- **DateTime drift fix**: Capture single timestamp before iteration in `getPendingActions` / `getPendingCount`
- `_isPendingAction(action, now)` accepts timestamp parameter for consistent time comparisons
- **Redundant await cleanup**: `updateAction` and `markCompleted` directly return Future (no `async`/`await`)
- New methods: `getPendingActions()` (FIFO sorted), `getPendingCount()`, `markCompleted()`, `updateAction()`

**App lifecycle** (`lib/main.dart`):
- Added `WidgetsBindingObserver` to cancel pending retries on app detach/dispose

**Plugin system**:
- `PluginRegistry` (`lib/plugin/registry.dart`) — exposed `getAvailableServices()` including `RetryQueue` for plugin use
- `PluginInjector` — fixed `print` → `debugPrint` for consistency
- Plugin docs updated with retry queue usage examples

**Model updates**:
- `PostModel` — added `retryKey` field for retry tracking on post mutations

#### Code quality improvements:
- **Import optimization**: Replaced `package:flutter/material.dart` with `package:flutter/foundation.dart` in files only needing `debugPrint`
- **Consolidated retry logic**: `enqueue()` now wraps `execute()` to avoid duplication
- **Test improvements**: Added 8 new tests for edge cases (error handling, FIFO ordering, null returns, auth errors)

### Does this PR introduce a breaking change?

No. All changes are additive or refinements:
- Existing service APIs remain unchanged
- Retry behavior is opt-in via the new `RetryQueue` service
- `RetryConfig` constructor is no longer `const` (required for runtime validation), but all usages updated
- Default behavior preserved; retries only active when explicitly used

### Checklist for Repository Standards
- [x] Have you reviewed and implemented all applicable code review suggestions?
- [x] Have you ensured that the PR aligns with the repository's contribution guidelines?
- [x] Test coverage >95% for all new/changed files
- [x] All 116 tests pass
- [x] No new lint warnings introduced

### Other information

**Architecture decisions:**
- `RetryQueue` registered as singleton in GetIt (`lib/locator.dart`) for app-wide access
- Exponential backoff with configurable multiplier and max delay cap
- Deterministic retry keys (SHA1 hashes) prevent duplicate retry tasks
- Sealed class pattern for type-safe result handling

**Future work (Parts 2–6):**
- Integrate retry into remaining services (`EventService`, `PostService`, `ChatService`, etc.)
- Add retry UI indicators for user awareness
- Implement retry analytics/monitoring

**Dependencies:**
- Blocked by: #3183
- Blocks: #3204

**Test execution:**
```bash
# All tests pass
fvm flutter test test/service_tests/retry_queue_test.dart \
  test/service_tests/retry_queue_functional_test.dart \
  test/service_tests/caching/offline_action_queue_test.dart \
  test/service_tests/comment_service_test.dart \
  test/service_tests/database_mutation_functions_test.dart \
  test/service_tests/base_feed_manager_test.dart \
  test/plugin_tests/plugin_registry_test.dart

# Result: 116 tests passed ✅
```

### Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a global retry framework with configurable backoff, cancellation, and per-task tracking.
  * Chat subscriptions, comment posting, and database mutations now retry automatically; data fetches retry then fall back to cache.
  * Offline action queue: pending-action listing, completion marking, and pending count.

* **Documentation**
  * Plugin guide updated with Retry Queue integration and usage examples.

* **Tests**
  * Large suite validating retry behaviors, caching fallbacks, subscriptions, and offline queue semantics.

* **Chores**
  * Improved debug-friendly logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->