### PR TITLE
docs: fix 'succesfully' typo in NavigationService dartdocs

### DIFF
--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/popAndPushScreen.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/popAndPushScreen.md
@@ -24,7 +24,7 @@ navigator.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully
+-   `Future<dynamic>`: resolves if the Screen was successfully
     popAndPushed.
 
 

--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/pushReplacementScreen.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/pushReplacementScreen.md
@@ -24,7 +24,7 @@ This function push the route and replace the screen.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully
+-   `Future<dynamic>`: resolves if the Screen was successfully
     pushedReplacementScreen.
 
 

--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/pushScreen.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/pushScreen.md
@@ -23,7 +23,7 @@ Pushes a Screen.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully pushed.
+-   `Future<dynamic>`: resolves if the Screen was successfully pushed.
 
 
 

--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/removeAllAndPush.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/removeAllAndPush.md
@@ -27,7 +27,7 @@ new route.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully
+-   `Future<dynamic>`: resolves if the Screen was successfully
     removeAllAndPushed.
 
 

--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -29,7 +29,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully pushed.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully pushed.
   Future<dynamic> pushScreen(String routeName, {dynamic arguments}) {
     return navigatorKey.currentState!
         .pushNamed(routeName, arguments: arguments);
@@ -42,7 +42,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully popAndPushed.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully popAndPushed.
   Future<dynamic> popAndPushScreen(String routeName, {dynamic arguments}) {
     navigatorKey.currentState!.pop();
     return pushScreen(routeName, arguments: arguments);
@@ -55,7 +55,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully pushedReplacementScreen.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully pushedReplacementScreen.
   Future<dynamic> pushReplacementScreen(String routeName, {dynamic arguments}) {
     return navigatorKey.currentState!
         .pushReplacementNamed(routeName, arguments: arguments);
@@ -69,7 +69,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully removeAllAndPushed.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully removeAllAndPushed.
   Future<dynamic> removeAllAndPush(
     String routeName,
     String tillRoute, {


### PR DESCRIPTION
### What kind of change does this PR introduce?

Docs — typo fix.

### Issue Number:

Fixes #3374.

### Did you add tests for your changes?

- [ ] Tests are written for all changes made in this PR. (n/a — dartdoc comment fix)

### Summary

Corrects the four dartdoc comments on `NavigationService` in \`lib/services/navigation_service.dart\` that read \`succesfully\` instead of \`successfully\`, plus the matching four lines in the auto-generated markdown under \`docs/docs/auto-docs/services_navigation_service/NavigationService/\` so the docsite reflects the fix until the next regeneration overwrites those files.

The PR template references \`develop-postgres\` but that branch isn't in the remote (only \`develop\`, \`develop-mongodb-legacy\`, \`develop-postgres-legacy\` and \`main\` show up); targeting \`develop\` since that's where the recent commits land. Happy to retarget if I'm off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling in navigation service documentation comments.
  - No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->