### PR TITLE
fix: correct succesfully to successfully in NavigationService dartdocs

### DIFF
--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/popAndPushScreen.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/popAndPushScreen.md
@@ -24,7 +24,7 @@ navigator.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully
+-   `Future<dynamic>`: resolves if the Screen was successfully
     popAndPushed.
 
 

--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/pushReplacementScreen.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/pushReplacementScreen.md
@@ -24,7 +24,7 @@ This function push the route and replace the screen.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully
+-   `Future<dynamic>`: resolves if the Screen was successfully
     pushedReplacementScreen.
 
 

--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/pushScreen.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/pushScreen.md
@@ -23,7 +23,7 @@ Pushes a Screen.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully pushed.
+-   `Future<dynamic>`: resolves if the Screen was successfully pushed.
 
 
 

--- a/docs/docs/auto-docs/services_navigation_service/NavigationService/removeAllAndPush.md
+++ b/docs/docs/auto-docs/services_navigation_service/NavigationService/removeAllAndPush.md
@@ -27,7 +27,7 @@ new route.
 
 **returns**:
 
--   `Future<dynamic>`: resolves if the Screen was succesfully
+-   `Future<dynamic>`: resolves if the Screen was successfully
     removeAllAndPushed.
 
 

--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -29,7 +29,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully pushed.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully pushed.
   Future<dynamic> pushScreen(String routeName, {dynamic arguments}) {
     return navigatorKey.currentState!
         .pushNamed(routeName, arguments: arguments);
@@ -42,7 +42,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully popAndPushed.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully popAndPushed.
   Future<dynamic> popAndPushScreen(String routeName, {dynamic arguments}) {
     navigatorKey.currentState!.pop();
     return pushScreen(routeName, arguments: arguments);
@@ -55,7 +55,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully pushedReplacementScreen.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully pushedReplacementScreen.
   Future<dynamic> pushReplacementScreen(String routeName, {dynamic arguments}) {
     return navigatorKey.currentState!
         .pushReplacementNamed(routeName, arguments: arguments);
@@ -69,7 +69,7 @@ class NavigationService {
   /// * `arguments`: Set of arguments
   ///
   /// **returns**:
-  /// * `Future<dynamic>`: resolves if the Screen was succesfully removeAllAndPushed.
+  /// * `Future<dynamic>`: resolves if the Screen was successfully removeAllAndPushed.
   Future<dynamic> removeAllAndPush(
     String routeName,
     String tillRoute, {


### PR DESCRIPTION
## Summary
Corrects `succesfully` to `successfully` in NavigationService dartdoc comments and matching auto-generated docs.

## Files changed
- `lib/services/navigation_service.dart` — 4 occurrences fixed (lines 32, 45, 58, 72)
- `docs/docs/auto-docs/services_navigation_service/NavigationService/pushScreen.md`
- `docs/docs/auto-docs/services_navigation_service/NavigationService/pushReplacementScreen.md`
- `docs/docs/auto-docs/services_navigation_service/NavigationService/popAndPushScreen.md`
- `docs/docs/auto-docs/services_navigation_service/NavigationService/removeAllAndPush.md`

## Issue
Fixes PalisadoesFoundation/talawa#3374

---
This is a one-commit typo fix (GH007 compliant: noreply email used for both author and committer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling errors in navigation method documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->